### PR TITLE
libpinmame: add support for linux

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1231,6 +1231,7 @@ static int display_rom_load_results(struct rom_load_data *romdata)
 		/* display the result */
 		printf("%s", romdata->errorbuf);
 
+#ifndef LIBPINMAME
 		/* if we're not getting out of here, wait for a keypress */
 		if (!options.gui_host && !bailing)
 		{
@@ -1248,6 +1249,7 @@ static int display_rom_load_results(struct rom_load_data *romdata)
 			if (keyboard_pressed(KEYCODE_LCONTROL) && keyboard_pressed(KEYCODE_C))
 				return 1;
 		}
+#endif
 	}
 
 	/* clean up any regions */

--- a/src/cpu/cop400/cop420.c
+++ b/src/cpu/cop400/cop420.c
@@ -40,7 +40,7 @@ typedef struct {
 	void (*function) (void);
 }	s_opcode;
 
-static COP420_Regs R;
+COP420_Regs R;
 int    cop420_ICount;
 
 static int InstLen[256];

--- a/src/dll/fileio.c
+++ b/src/dll/fileio.c
@@ -34,6 +34,11 @@
 
 #include "fileio.h"
 
+#ifdef UNIX
+FILE *stdout_file;
+FILE *stderr_file;
+#endif
+
 #ifdef MESS
 #include "image.h"
 #endif
@@ -224,7 +229,7 @@ static void create_path(TCHAR *path, int has_filename)
 		return;
 
 #ifdef VERBOSE
-	printf("create_path(): creating path - path=%s, has_filename=%d", path, has_filename);
+	printf("create_path(): creating path - path=%s, has_filename=%d\n", path, has_filename);
 #endif
 
 	/* create the path */
@@ -581,7 +586,7 @@ osd_file *osd_fopen(int pathtype, int pathindex, const char *filename, const cha
 	/* compose the full path */
 	compose_path(fullpath, pathtype, pathindex, filename);
 #ifdef VERBOSE
-	printf("osd_fopen(): access=%08X, fullpath=%s", access, fullpath);
+	printf("osd_fopen(): access=%08X, fullpath=%s\n", access, fullpath);
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -601,7 +606,7 @@ osd_file *osd_fopen(int pathtype, int pathindex, const char *filename, const cha
 
 	if (file->handle == INVALID_HANDLE_VALUE) {
 		if (!(access & O_WRONLY) || errno != ENOENT) {
-			printf("osd_fopen(): unable to open");
+			printf("osd_fopen(): unable to open\n");
 			return NULL;
 		}
 #endif
@@ -617,7 +622,7 @@ osd_file *osd_fopen(int pathtype, int pathindex, const char *filename, const cha
 		/* if that doesn't work, we give up */
 		if (file->handle == INVALID_HANDLE_VALUE) {
 #ifdef VERBOSE
-			printf("osd_fopen(): unable to open");
+			printf("osd_fopen(): unable to open\n");
 #endif
 			return NULL;
 		}
@@ -841,9 +846,9 @@ void osd_fclose(osd_file *file)
 int osd_display_loading_rom_message(const char *name,struct rom_load_data *romdata)
 {
 	if (name)
-		fprintf(stdout, "osd_display_loading_rom_message(): loading %-12s...", name);
+		fprintf(stdout, "osd_display_loading_rom_message(): loading %-12s...\n", name);
 	else
-		fprintf(stdout, "osd_display_loading_rom_message():");
+		fprintf(stdout, "osd_display_loading_rom_message():\n");
 	fflush(stdout);
 
 	return 0;

--- a/src/dll/misc.c
+++ b/src/dll/misc.c
@@ -77,12 +77,12 @@ uclock_t uclock(void)
 
 #endif
 
-void print_colums(const char *text1, const char *text2)
+void print_columns(const char *text1, const char *text2)
 {
-   fprint_colums(stdout, text1, text2);
+   fprint_columns(stdout, text1, text2);
 }
 
-void fprint_colums(FILE *f, const char *text1, const char *text2)
+void fprint_columns(FILE *f, const char *text1, const char *text2)
 {
    const char *text[2];
    int i, cols, width[2], done = 0;

--- a/src/dll/misc.h
+++ b/src/dll/misc.h
@@ -31,7 +31,7 @@ uclock_t uclock(void);
 #define UCLOCKS_PER_SEC 1000000
 
 /* print colum stuff */
-void print_colums(const char *text1, const char *text2);
-void fprint_colums(FILE *f, const char *text1, const char *text2);
+void print_columns(const char *text1, const char *text2);
+void fprint_columns(FILE *f, const char *text1, const char *text2);
 
 #endif /* ifndef __MISC_H */

--- a/src/ios/rc.c
+++ b/src/ios/rc.c
@@ -591,7 +591,7 @@ static void rc_real_print_help(struct rc_option *option, FILE *f)
                (option[i].shortname && (option[i].type == rc_bool))? "[no]":"",
                (option[i].shortname)? option[i].shortname:"",
                type_name[option[i].type]);
-            fprint_colums(f, buf,
+            fprint_columns(f, buf,
                (option[i].help)? option[i].help:"no help available");
       }
    }

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -137,7 +137,7 @@ static struct rc_option opts[] = {
 	{ "debug", "d", rc_bool, &options.mame_debug, NULL, 0, 0, NULL, "Enable/disable debugger" },
 	{ "debug-size", "ds", rc_use_function, NULL, "640x480", 0, 0, config_handle_debug_size, "Specify the resolution/window size to use for the debugger (window) in the form of XRESxYRES (minimum size = 640x480)" },
 #endif
-	{ NULL, NULL, rc_link, frontend_list_opts, NULL, 0, 0, NULL, NULL },
+	{ NULL, NULL, rc_link, frontend_opts, NULL, 0, 0, NULL, NULL },
 	{ NULL, NULL, rc_link, frontend_ident_opts, NULL, 0, 0, NULL, NULL },
 	{ "General Options", NULL, rc_seperator, NULL, NULL, 0, 0, NULL, NULL },
 	{ "loadconfig", "lcf", rc_bool, &loadconfig, "1", 0, 0, NULL, "Load (don't load) configfiles" },

--- a/src/unix/fronthlp.c
+++ b/src/unix/fronthlp.c
@@ -34,7 +34,7 @@ enum {
 /* Mame frontend interface & commandline */
 /* parsing rountines by Maurizio Zanello */
 
-struct rc_option frontend_list_opts[] = {
+struct rc_option frontend_opts[] = {
 	/* name, shortname, type, dest, deflt, min, max, func, help */
 	{ "Frontend Related", NULL, rc_seperator, NULL, NULL, 0, 0, NULL, NULL },
 	{ "list", "l", rc_set_int, &list, NULL, LIST_LIST, 0, NULL, "List supported games matching gamename, or all, gamename may contain * and ? wildcards" },
@@ -142,7 +142,7 @@ int strwildcmp(const char *sp1, const char *sp2)
 		if (s2[i] == '?' && s1[i] != '?') s2[i] = s1[i];
 	}
 
-	return stricmp(s1, s2);
+	return strcasecmp(s1, s2);
 }
 
 static int myprintf(char *fmt, ...)
@@ -158,6 +158,11 @@ static int myprintf(char *fmt, ...)
 		fflush(stdout_file);
 	}
 	return i;
+}
+
+int frontend_help (const char *gamename)
+{
+	return 0;
 }
 
 static void frontend_verify(int driver, int rom)

--- a/src/unix/xmame.h
+++ b/src/unix/xmame.h
@@ -192,7 +192,7 @@ extern struct rc_option sound_opts[];
 extern struct rc_option input_opts[];
 extern struct rc_option network_opts[];
 extern struct rc_option fileio_opts[];
-extern struct rc_option frontend_list_opts[];
+extern struct rc_option frontend_opts[];
 extern struct rc_option frontend_ident_opts[];
 
 #undef EXTERN

--- a/src/windows/misc.c
+++ b/src/windows/misc.c
@@ -76,12 +76,12 @@ uclock_t uclock(void)
 
 #endif
 
-void print_colums(const char *text1, const char *text2)
+void print_columns(const char *text1, const char *text2)
 {
-   fprint_colums(stdout, text1, text2);
+   fprint_columns(stdout, text1, text2);
 }
 
-void fprint_colums(FILE *f, const char *text1, const char *text2)
+void fprint_columns(FILE *f, const char *text1, const char *text2)
 {
    const char *text[2];
    int i, cols, width[2], done = 0;

--- a/src/windows/misc.h
+++ b/src/windows/misc.h
@@ -31,8 +31,8 @@ uclock_t uclock(void);
 #define UCLOCKS_PER_SEC 1000000
 
 /* print colum stuff */
-void print_colums(const char *text1, const char *text2);
-void fprint_colums(FILE *f, const char *text1, const char *text2);
+void print_columns(const char *text1, const char *text2);
+void fprint_columns(FILE *f, const char *text1, const char *text2);
 
 
 

--- a/src/windows/rc.c
+++ b/src/windows/rc.c
@@ -589,7 +589,7 @@ static void rc_real_print_help(struct rc_option *option, FILE *f)
                (option[i].shortname && (option[i].type == rc_bool))? "[no]":"",
                (option[i].shortname)? option[i].shortname:"",
                type_name[option[i].type]);
-            fprint_colums(f, buf,
+            fprint_columns(f, buf,
                (option[i].help)? option[i].help:"no help available");
       }
    }


### PR DESCRIPTION
This PR adds linux support for libpinmame. 

After building the Linux libpinmame, there were a few undefined symbols that I was only able to track down when trying to link it against an executable. 

There was a reference to `R` which is used in cop400. 

I added some carriage returns when displaying loading information, and I removed the `Press Any Key To Continue` wait when `LIBPINMAME` is defined. 

```
VPM path: /Users/jmillard/.pinmame/
GameIndex: 2457
osd_init
osd_display_loading_rom_message(): loading mm_1_09c.bin...
osd_fopen(): access=00000000, fullpath=/Users/jmillard/.pinmame/roms/mm_109c.zip
osd_display_loading_rom_message(): loading mm_s2.1_0   ...
osd_display_loading_rom_message(): loading mm_sav3.rom ...
osd_display_loading_rom_message(): loading mm_sav4.rom ...
osd_display_loading_rom_message(): loading mm_sav5.rom ...
osd_display_loading_rom_message(): loading mm_sav6.rom ...
osd_display_loading_rom_message():
mm_s2.1_0    NOT FOUND
mm_sav3.rom  NOT FOUND
mm_sav4.rom  NOT FOUND
mm_sav5.rom  NOT FOUND
mm_sav6.rom  NOT FOUND
SOUND WAS DISABLED DUE TO PROBLEMS WITH SOUND ROMS
```

Finally, I consolidated all `fprint_colums, print_colums, fprint_columns, print_columns` to `fprint_columns, print_columns`

I am noticing the Linux version is a little slower, so I need to research the timing functions.

https://user-images.githubusercontent.com/1197137/106389278-80216c00-63b0-11eb-884b-54404e93715c.mp4

