### PR TITLE
ci: dispatch event to pinmame-dotnet repo upon successful libpinmame build

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -62,3 +62,14 @@ jobs:
         with:
           name: linux-x64
           path: cmake/libpinmame/lib/libpinmame.so.*
+
+  dispatch:
+    runs-on: ubuntu-latest
+    needs: [ build-win-x64, build-win-x86, build-osx-x64, build-linux-x64 ]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PAT_PINMAME_DOTNET }}
+          repository: VisualPinball/pinmame-dotnet
+          event-type: build


### PR DESCRIPTION
This PR will trigger a repository dispatch in the pinmame-dotnet repo. 

This can be used to automatically build pinmame-dotnet, when code is pushed to this repository.