### PR TITLE
ci: add support for PinMAME32

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -3,8 +3,20 @@ on:
   push:
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: version
+        run: |
+          VERSION=$(grep -o "[0-9\.]\+" src/version.c | head -1)
+          echo "::set-output name=version::${VERSION}"
+
   build-win-x64:
     runs-on: windows-latest
+    needs: [ version ]
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -13,13 +25,18 @@ jobs:
           copy CMakeLists_win-x64.txt CMakeLists.txt
           cmake -G "Visual Studio 16 2019" -A x64 .
           cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/libpinmame/lib/libpinmame-${{ needs.version.outputs.version }}.dll
+          args: --best --lzma
       - uses: actions/upload-artifact@v2
         with:
-          name: win-x64
-          path: cmake/libpinmame/lib/libpinmame-*.dll
+          name: libpinmame-win-x64
+          path: cmake/libpinmame/lib/libpinmame-${{ needs.version.outputs.version }}.dll
           
   build-win-x86:
     runs-on: windows-latest
+    needs: [ version ]
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -28,13 +45,18 @@ jobs:
           copy CMakeLists_win-x86.txt CMakeLists.txt
           cmake -G "Visual Studio 16 2019" -A Win32 .
           cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/libpinmame/lib/libpinmame-${{ needs.version.outputs.version }}.dll
+          args: --best --lzma
       - uses: actions/upload-artifact@v2
         with:
-          name: win-x86
-          path: cmake/libpinmame/lib/libpinmame-*.dll
+          name: libpinmame-win-x86
+          path: cmake/libpinmame/lib/libpinmame-${{ needs.version.outputs.version }}.dll
         
   build-osx-x64:
     runs-on: macos-latest
+    needs: [ version ]
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -45,11 +67,12 @@ jobs:
           cmake --build . 
       - uses: actions/upload-artifact@v2
         with:
-          name: osx-x64
-          path: cmake/libpinmame/lib/libpinmame.*.dylib
+          name: libpinmame-osx-x64
+          path: cmake/libpinmame/lib/libpinmame.${{ needs.version.outputs.version }}.dylib
 
   build-linux-x64:
     runs-on: ubuntu-latest
+    needs: [ version ]
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -58,10 +81,14 @@ jobs:
           cp CMakeLists_linux-x64.txt CMakeLists.txt
           cmake -DCMAKE_BUILD_TYPE=Release . 
           cmake --build .
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/libpinmame/lib/libpinmame.so.${{ needs.version.outputs.version }}
+          args: --best --lzma
       - uses: actions/upload-artifact@v2
         with:
-          name: linux-x64
-          path: cmake/libpinmame/lib/libpinmame.so.*
+          name: libpinmame-linux-x64
+          path: cmake/libpinmame/lib/libpinmame.so.${{ needs.version.outputs.version }}
 
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/pinmame32.yml
+++ b/.github/workflows/pinmame32.yml
@@ -1,0 +1,43 @@
+name: pinmame32
+on:
+  push:
+
+jobs:
+  build-win-x64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd cmake/pinmame32
+          copy CMakeLists_win-x64.txt CMakeLists.txt
+          cmake -G "Visual Studio 16 2019" -A x64 .
+          cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/pinmame32/bin/PinMAME32.exe
+          args: --best --lzma
+      - uses: actions/upload-artifact@v2
+        with:
+          name: PinMAME32-win-x64
+          path: cmake/pinmame32/bin/PinMAME32.exe
+
+  build-win-x86:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilammy/setup-nasm@v1
+      - name: Build
+        run: |
+          cd cmake/pinmame32
+          copy CMakeLists_win-x86.txt CMakeLists.txt
+          cmake -G "Visual Studio 16 2019" -A Win32 .
+          cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/pinmame32/bin/PinMAME32.exe
+          args: --best --lzma
+      - uses: actions/upload-artifact@v2
+        with:
+          name: PinMAME32-win-x86
+          path: cmake/pinmame32/bin/PinMAME32.exe

--- a/PinMAME32_VC2012.vcxproj
+++ b/PinMAME32_VC2012.vcxproj
@@ -231,7 +231,7 @@
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib\include;ext\htmlhelp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_DX7;__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -248,7 +248,7 @@
       <AdditionalIncludeDirectories>src\ui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibstatmt64.lib;winmm.lib;dxguid.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatmt64.lib;winmm.lib;dxguid.lib;ddraw.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName)_VC2012.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>ext\dinput;ext\zlib\lib_vc9;ext\htmlhelp\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -312,7 +312,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib\include;ext\htmlhelp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_DX7;__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -329,7 +329,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
       <AdditionalIncludeDirectories>src\ui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibstatmtd64.lib;winmm.lib;dxguid.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatmtd64.lib;winmm.lib;dxguid.lib;ddraw.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName)_VC2012vcd.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>ext\dinput;ext\zlib\lib_vc9;ext\htmlhelp\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -391,7 +391,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib\include;ext\htmlhelp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_DX7;__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -408,7 +408,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
       <AdditionalIncludeDirectories>src\ui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibstatmt64.lib;winmm.lib;dxguid.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatmt64.lib;winmm.lib;dxguid.lib;ddraw.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName)_VC2012md.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>ext\dinput;ext\zlib\lib_vc9;ext\htmlhelp\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -472,7 +472,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib\include;ext\htmlhelp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_DX7;__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;ZLIB_WINAPI;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME32NAME="PinMAME32";WINUI=1;SUFFIX=32;_WIN32_IE=0x0500;_WIN32_WINNT=0x0400;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -489,7 +489,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
       <AdditionalIncludeDirectories>src\ui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibstatmtd64.lib;winmm.lib;dxguid.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlibstatmtd64.lib;winmm.lib;dxguid.lib;ddraw.lib;dinput64.lib;dsound.lib;comctl32.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName)_VC2012vcmd.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>ext\dinput;ext\zlib\lib_vc9;ext\htmlhelp\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/cmake/libpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/libpinmame/CMakeLists_linux-x64.txt
@@ -75,15 +75,17 @@ add_compile_definitions(
    HAS_MEA8000=1
    HAS_SAA1099=1
    HAS_QSOUND=1
+
    MAMEVER=7300
-   INLINE=static __inline__
-   LSB_FIRST
-   PI=M_PI
-   UNIX
    PINMAME
    PINMAME_NO_UNUSED
    LIBPINMAME
    NAME="LIBPINMAME"
+
+   LSB_FIRST
+   INLINE=static __inline__
+   PI=M_PI
+   UNIX
 )
 
 add_library(pinmame SHARED
@@ -597,7 +599,7 @@ target_link_libraries(pinmame
    pthread
 )
 
-set_target_properties(pinmame
-   PROPERTIES VERSION ${PROJECT_VERSION}
+set_target_properties(pinmame PROPERTIES
+   VERSION ${PROJECT_VERSION}
    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
 )

--- a/cmake/libpinmame/CMakeLists_win-x64.txt
+++ b/cmake/libpinmame/CMakeLists_win-x64.txt
@@ -75,16 +75,18 @@ add_compile_definitions(
    HAS_MEA8000=1
    HAS_SAA1099=1
    HAS_QSOUND=1
+
    MAMEVER=7300
-   LSB_FIRST
-   _CRT_SECURE_NO_WARNINGS
-   __LP64__
-   WIN32
-   _MBCS
-   ZLIB_WINAPI
    PINMAME
    PINMAME_NO_UNUSED
    LIBPINMAME
+
+   LSB_FIRST
+   _CRT_SECURE_NO_WARNINGS
+   _MBCS
+   __LP64__
+   WIN32
+   ZLIB_WINAPI
 )
 
 add_library(pinmame SHARED
@@ -608,8 +610,8 @@ target_link_libraries(pinmame
    winmm.lib
 )
 
-set_target_properties(pinmame
-   PROPERTIES VERSION ${PROJECT_VERSION}
+set_target_properties(pinmame PROPERTIES 
+   VERSION ${PROJECT_VERSION}
    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/lib"
    RUNTIME_OUTPUT_NAME "libpinmame-${PROJECT_VERSION}"
 )

--- a/cmake/libpinmame/CMakeLists_win-x86.txt
+++ b/cmake/libpinmame/CMakeLists_win-x86.txt
@@ -75,16 +75,18 @@ add_compile_definitions(
    HAS_MEA8000=1
    HAS_SAA1099=1
    HAS_QSOUND=1
+
    MAMEVER=7300
-   LSB_FIRST
-   _CRT_SECURE_NO_WARNINGS
-   __LP64__
-   WIN32
-   _MBCS
-   ZLIB_WINAPI
    PINMAME
    PINMAME_NO_UNUSED
    LIBPINMAME
+
+   LSB_FIRST
+   _CRT_SECURE_NO_WARNINGS
+   _MBCS
+   __LP64__
+   WIN32
+   ZLIB_WINAPI
 )
 
 add_library(pinmame SHARED
@@ -607,8 +609,8 @@ target_link_libraries(pinmame
    zlibstatmt.lib
    winmm.lib)
 
-set_target_properties(pinmame
-   PROPERTIES VERSION ${PROJECT_VERSION}
+set_target_properties(pinmame PROPERTIES 
+   VERSION ${PROJECT_VERSION}
    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/lib"
    RUNTIME_OUTPUT_NAME "libpinmame-${PROJECT_VERSION}"
 )

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -5,7 +5,7 @@ set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 file(READ ${SOURCE_DIR}/src/version.c version)
 string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
 
-project(pinmame VERSION ${PROJECT_VERSION})
+project(pinmame32 VERSION ${PROJECT_VERSION})
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 99)
@@ -79,13 +79,26 @@ add_compile_definitions(
    MAMEVER=7300
    PINMAME
    PINMAME_NO_UNUSED
-   LIBPINMAME
+   MAME32NAME="PinMAME32"
+   WINUI=1
 
    LSB_FIRST
-   INLINE=static __inline
+   DIRECTINPUT_VERSION=0x0700
+   DIRECTDRAW_VERSION=0x0300
+   DECL_SPEC=__cdecl
+   NONAMELESSUNION
+   WIN32
+   _MBCS
+   _CRT_SECURE_NO_WARNINGS
+   __LP64__
+   ZLIB_WINAPI
 )
 
-add_library(pinmame SHARED
+set_source_files_properties(
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc LANGUAGE RC
+)
+
+add_executable(pinmame32 WIN32
    ${SOURCE_DIR}/src/artwork.c 
    ${SOURCE_DIR}/src/artwork.h 
    ${SOURCE_DIR}/src/audit.c 
@@ -557,44 +570,82 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
+   ${SOURCE_DIR}/src/ui/audit32.c
+   ${SOURCE_DIR}/src/ui/bitmask.c
+   ${SOURCE_DIR}/src/ui/columnedit.c
+   ${SOURCE_DIR}/src/ui/datamap.c
+   ${SOURCE_DIR}/src/ui/dialogs.c
+   ${SOURCE_DIR}/src/ui/dijoystick.c
+   ${SOURCE_DIR}/src/ui/directdraw.c
+   ${SOURCE_DIR}/src/ui/directinput.c
+   ${SOURCE_DIR}/src/ui/directories.c
+   ${SOURCE_DIR}/src/ui/dxdecode.c
+   ${SOURCE_DIR}/src/ui/help.c
+   ${SOURCE_DIR}/src/ui/history.c
+   ${SOURCE_DIR}/src/ui/layout.c
+   ${SOURCE_DIR}/src/ui/m32main.c
+   ${SOURCE_DIR}/src/ui/m32util.c
+   ${SOURCE_DIR}/src/ui/options.c
+   ${SOURCE_DIR}/src/ui/properties.c
+   ${SOURCE_DIR}/src/ui/screenshot.c
+   ${SOURCE_DIR}/src/ui/splitters.c
+   ${SOURCE_DIR}/src/ui/treeview.c
+   ${SOURCE_DIR}/src/ui/win32ui.c 
+
    ${SOURCE_DIR}/ext/vgm/vgmwrite.c
    ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 
-   ${SOURCE_DIR}/src/ios/fronthlp.c
-   ${SOURCE_DIR}/src/ios/rc.c
-   ${SOURCE_DIR}/src/ios/rc.h
+   ${SOURCE_DIR}/src/vc/dirent.c
 
-   ${SOURCE_DIR}/src/libpinmame/video.c
-   ${SOURCE_DIR}/src/libpinmame/video.h
-   ${SOURCE_DIR}/src/libpinmame/joystick.c
-   ${SOURCE_DIR}/src/libpinmame/keyboard.c
-   ${SOURCE_DIR}/src/libpinmame/fileio.c
-   ${SOURCE_DIR}/src/libpinmame/sound.c
-   ${SOURCE_DIR}/src/libpinmame/sound.h
-   ${SOURCE_DIR}/src/libpinmame/config.c
-   ${SOURCE_DIR}/src/libpinmame/config.h
-   ${SOURCE_DIR}/src/libpinmame/misc.c
-   ${SOURCE_DIR}/src/libpinmame/misc.h
-   ${SOURCE_DIR}/src/libpinmame/ticker.c
-   ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
-   ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+   ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/fileio.c
+   ${SOURCE_DIR}/src/windows/fronthlp.c
+   ${SOURCE_DIR}/src/windows/input.c
+   ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/sound.c
+   ${SOURCE_DIR}/src/windows/ticker.c
+   ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/window.c
+   ${SOURCE_DIR}/src/windows/winmain.c 
+
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc
 )
 
-target_include_directories(pinmame PUBLIC
+target_include_directories(pinmame32 PUBLIC
    ${SOURCE_DIR}/src
-   ${SOURCE_DIR}/src/wpc
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
-   ${SOURCE_DIR}/src/ios
-   ${SOURCE_DIR}/src/libpinmame
+   ${SOURCE_DIR}/src/wpc
+   ${SOURCE_DIR}/src/windows
+   ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/ui
+   ${SOURCE_DIR}/ext/zlib/include
+   ${SOURCE_DIR}/ext/dinput
 )
 
-find_package(ZLIB)
-
-target_link_libraries(pinmame 
-   ZLIB::ZLIB
+target_link_directories(pinmame32 PUBLIC
+   ${SOURCE_DIR}/ext/zlib/lib_vc9
+   ${SOURCE_DIR}/ext/dinput
 )
 
-set_target_properties(pinmame PROPERTIES 
-   VERSION ${PROJECT_VERSION}
-   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+target_link_libraries(pinmame32 
+   winmm.lib
+   comctl32.lib
+   htmlhelp.lib
+   dxguid.lib
+   dsound.lib
+   ddraw.lib
+   dinput64.lib
+   zlibstatmt64.lib
+)
+
+set_target_properties(pinmame32 PROPERTIES
+   RUNTIME_OUTPUT_NAME "PinMAME32"
+   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
 )

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -5,10 +5,16 @@ set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 file(READ ${SOURCE_DIR}/src/version.c version)
 string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
 
-project(pinmame VERSION ${PROJECT_VERSION})
+project(pinmame32 VERSION ${PROJECT_VERSION})
+
+enable_language(ASM_NASM)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 99)
+
+set(CMAKE_EXE_LINKER_FLAGS
+   "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO"
+)
 
 add_compile_definitions(
    HAS_M6809=1
@@ -79,13 +85,27 @@ add_compile_definitions(
    MAMEVER=7300
    PINMAME
    PINMAME_NO_UNUSED
-   LIBPINMAME
+   MAME32NAME="PinMAME32"
+   WINUI=1
 
    LSB_FIRST
-   INLINE=static __inline
+   DIRECTINPUT_VERSION=0x0700
+   DIRECTDRAW_VERSION=0x0300
+   DECL_SPEC=__cdecl
+   NONAMELESSUNION
+   WIN32
+   _MBCS
+   _CRT_SECURE_NO_WARNINGS
+   ZLIB_WINAPI
 )
 
-add_library(pinmame SHARED
+set_source_files_properties(
+   ${SOURCE_DIR}/src/windows/asmblit.asm LANGUAGE ASM_NASM
+   ${SOURCE_DIR}/src/windows/asmtile.asm LANGUAGE ASM_NASM
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc LANGUAGE RC
+)
+
+add_executable(pinmame32 WIN32
    ${SOURCE_DIR}/src/artwork.c 
    ${SOURCE_DIR}/src/artwork.h 
    ${SOURCE_DIR}/src/audit.c 
@@ -557,44 +577,86 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
+   ${SOURCE_DIR}/src/ui/audit32.c
+   ${SOURCE_DIR}/src/ui/bitmask.c
+   ${SOURCE_DIR}/src/ui/columnedit.c
+   ${SOURCE_DIR}/src/ui/datamap.c
+   ${SOURCE_DIR}/src/ui/dialogs.c
+   ${SOURCE_DIR}/src/ui/dijoystick.c
+   ${SOURCE_DIR}/src/ui/directdraw.c
+   ${SOURCE_DIR}/src/ui/directinput.c
+   ${SOURCE_DIR}/src/ui/directories.c
+   ${SOURCE_DIR}/src/ui/dxdecode.c
+   ${SOURCE_DIR}/src/ui/help.c
+   ${SOURCE_DIR}/src/ui/history.c
+   ${SOURCE_DIR}/src/ui/layout.c
+   ${SOURCE_DIR}/src/ui/m32main.c
+   ${SOURCE_DIR}/src/ui/m32util.c
+   ${SOURCE_DIR}/src/ui/options.c
+   ${SOURCE_DIR}/src/ui/properties.c
+   ${SOURCE_DIR}/src/ui/screenshot.c
+   ${SOURCE_DIR}/src/ui/splitters.c
+   ${SOURCE_DIR}/src/ui/treeview.c
+   ${SOURCE_DIR}/src/ui/win32ui.c 
+
    ${SOURCE_DIR}/ext/vgm/vgmwrite.c
    ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 
-   ${SOURCE_DIR}/src/ios/fronthlp.c
-   ${SOURCE_DIR}/src/ios/rc.c
-   ${SOURCE_DIR}/src/ios/rc.h
+   ${SOURCE_DIR}/src/vc/dirent.c
 
-   ${SOURCE_DIR}/src/libpinmame/video.c
-   ${SOURCE_DIR}/src/libpinmame/video.h
-   ${SOURCE_DIR}/src/libpinmame/joystick.c
-   ${SOURCE_DIR}/src/libpinmame/keyboard.c
-   ${SOURCE_DIR}/src/libpinmame/fileio.c
-   ${SOURCE_DIR}/src/libpinmame/sound.c
-   ${SOURCE_DIR}/src/libpinmame/sound.h
-   ${SOURCE_DIR}/src/libpinmame/config.c
-   ${SOURCE_DIR}/src/libpinmame/config.h
-   ${SOURCE_DIR}/src/libpinmame/misc.c
-   ${SOURCE_DIR}/src/libpinmame/misc.h
-   ${SOURCE_DIR}/src/libpinmame/ticker.c
-   ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
-   ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+   ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/fileio.c
+   ${SOURCE_DIR}/src/windows/fronthlp.c
+   ${SOURCE_DIR}/src/windows/input.c
+   ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/sound.c
+   ${SOURCE_DIR}/src/windows/ticker.c
+   ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/window.c
+   ${SOURCE_DIR}/src/windows/winmain.c 
+
+   ${SOURCE_DIR}/src/windows/asmblit.asm
+   ${SOURCE_DIR}/src/windows/asmtile.asm
+
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc
 )
 
-target_include_directories(pinmame PUBLIC
+target_include_directories(pinmame32 PUBLIC
    ${SOURCE_DIR}/src
-   ${SOURCE_DIR}/src/wpc
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
-   ${SOURCE_DIR}/src/ios
-   ${SOURCE_DIR}/src/libpinmame
+   ${SOURCE_DIR}/src/wpc
+   ${SOURCE_DIR}/src/windows
+   ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/ui
+   ${SOURCE_DIR}/ext/zlib/include
+   ${SOURCE_DIR}/ext/dinput
 )
 
-find_package(ZLIB)
-
-target_link_libraries(pinmame 
-   ZLIB::ZLIB
+target_link_directories(pinmame32 PUBLIC
+   ${SOURCE_DIR}/ext/zlib/lib_vc9
+   ${SOURCE_DIR}/ext/dinput
 )
 
-set_target_properties(pinmame PROPERTIES 
-   VERSION ${PROJECT_VERSION}
-   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+target_link_libraries(pinmame32 
+   winmm.lib
+   comctl32.lib
+   htmlhelp.lib
+   dxguid.lib
+   ddraw.lib
+   dsound.lib
+   dinput.lib
+   zlibstatmt.lib
+)
+
+set_target_properties(pinmame32 PROPERTIES
+   LINKER_LANGUAGE CXX
+   RUNTIME_OUTPUT_NAME "PinMAME32"
+   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
 )

--- a/src/ui/dialogs.c
+++ b/src/ui/dialogs.c
@@ -349,7 +349,16 @@ INT_PTR CALLBACK AboutDialogProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lPar
 									  IMAGE_BITMAP, 0, 0, LR_SHARED);
 			SendMessage(GetDlgItem(hDlg, IDC_ABOUT), STM_SETIMAGE,
 						(WPARAM)IMAGE_BITMAP, (LPARAM)hBmp);
-			Static_SetText(GetDlgItem(hDlg, IDC_VERSION), GetVersionString());
+
+			char tmp[80];
+
+#if defined(__LP64__) || defined(_WIN64)
+			snprintf(tmp,sizeof(tmp), "%s (x64)", GetVersionString());
+#else 
+			snprintf(tmp,sizeof(tmp), "%s", GetVersionString());
+#endif
+
+			Static_SetText(GetDlgItem(hDlg, IDC_VERSION), tmp);
 		}
 		return 1;
 


### PR DESCRIPTION
This PR adds support for compiling win-x86 and win-x64 versions of PinMAME32 using CMake. This PR also compresses all binaries generated by the CI using UPX, except for the osx-x64 version of libpinmame. (UPX does not yet support .dylib)

Many thanks to @toxieainc for fixing errors in x64 version of PinMAME32!