### PR TITLE
ci: add support for InstallVPinMAME. Misc cmake cleanup.

### DIFF
--- a/.github/workflows/instvpm.yml
+++ b/.github/workflows/instvpm.yml
@@ -1,0 +1,43 @@
+name: instvpm
+on:
+  push:
+
+jobs:
+  build-win-x64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd cmake/instvpm
+          copy CMakeLists_win-x64.txt CMakeLists.txt
+          cmake -G "Visual Studio 16 2019" -A x64 .
+          cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/instvpm/bin/Setup64.exe
+          args: --best --lzma
+      - uses: actions/upload-artifact@v2
+        with:
+          name: InstallVPinMAME-win-x64
+          path: cmake/instvpm/bin/Setup64.exe
+
+  build-win-x86:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilammy/setup-nasm@v1
+      - name: Build
+        run: |
+          cd cmake/instvpm
+          copy CMakeLists_win-x86.txt CMakeLists.txt
+          cmake -G "Visual Studio 16 2019" -A Win32 .
+          cmake --build . --config Release
+      - uses: svenstaro/upx-action@v2
+        with:
+          file: cmake/instvpm/bin/Setup.exe
+          args: --best --lzma
+      - uses: actions/upload-artifact@v2
+        with:
+          name: InstallVPinMAME-win-x86
+          path: cmake/instvpm/bin/Setup.exe

--- a/cmake/instvpm/CMakeLists_win-x64.txt
+++ b/cmake/instvpm/CMakeLists_win-x64.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.14)
+
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+file(READ ${SOURCE_DIR}/src/version.c version)
+string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
+
+project(instvpm VERSION ${PROJECT_VERSION})
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
+
+add_compile_definitions(
+   WIN32
+   _CRT_SECURE_NO_WARNINGS
+   __LP64__
+)
+
+set_source_files_properties(
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.rc LANGUAGE RC
+)
+
+add_executable(instvpm WIN32
+   ${SOURCE_DIR}/src/instvpm/Globals.cpp
+   ${SOURCE_DIR}/src/instvpm/Globals.h
+   ${SOURCE_DIR}/src/instvpm/resource.h
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.cpp
+   ${SOURCE_DIR}/src/instvpm/TestVPinMAME.cpp
+   ${SOURCE_DIR}/src/instvpm/TestVPinMAME.h
+   ${SOURCE_DIR}/src/instvpm/Utils.cpp
+   ${SOURCE_DIR}/src/instvpm/Utils.h
+
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.rc
+   ${SOURCE_DIR}/src/win32com/VPinMAME.idl
+)
+
+target_include_directories(instvpm PUBLIC
+   ${CMAKE_CURRENT_BINARY_DIR}/$(IntDir)
+)
+
+target_link_libraries(instvpm 
+   odbc32.lib
+   odbccp32.lib
+   version.lib
+)
+
+set_target_properties(instvpm PROPERTIES
+   LINK_FLAGS "/MANIFESTUAC:\"level='highestAvailable' uiAccess='false'\""
+   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
+   RUNTIME_OUTPUT_NAME "Setup64"
+)

--- a/cmake/instvpm/CMakeLists_win-x86.txt
+++ b/cmake/instvpm/CMakeLists_win-x86.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.14)
+
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+file(READ ${SOURCE_DIR}/src/version.c version)
+string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
+
+project(instvpm VERSION ${PROJECT_VERSION})
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
+
+add_compile_definitions(
+   WIN32
+   _CRT_SECURE_NO_WARNINGS
+)
+
+set_source_files_properties(
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.rc LANGUAGE RC
+)
+
+add_executable(instvpm WIN32
+   ${SOURCE_DIR}/src/instvpm/Globals.cpp
+   ${SOURCE_DIR}/src/instvpm/Globals.h
+   ${SOURCE_DIR}/src/instvpm/resource.h
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.cpp
+   ${SOURCE_DIR}/src/instvpm/TestVPinMAME.cpp
+   ${SOURCE_DIR}/src/instvpm/TestVPinMAME.h
+   ${SOURCE_DIR}/src/instvpm/Utils.cpp
+   ${SOURCE_DIR}/src/instvpm/Utils.h
+
+   ${SOURCE_DIR}/src/instvpm/InstallVPinMAME.rc
+   ${SOURCE_DIR}/src/win32com/VPinMAME.idl
+)
+
+target_include_directories(instvpm PUBLIC
+   ${CMAKE_CURRENT_BINARY_DIR}/$(IntDir)
+)
+
+target_link_libraries(instvpm 
+   odbc32.lib
+   odbccp32.lib
+   version.lib
+)
+
+set_target_properties(instvpm PROPERTIES
+   LINK_FLAGS "/MANIFESTUAC:\"level='highestAvailable' uiAccess='false'\""
+   RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin"
+   RUNTIME_OUTPUT_NAME "Setup"
+)

--- a/cmake/libpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/libpinmame/CMakeLists_linux-x64.txt
@@ -560,9 +560,6 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/unix/fronthlp.c
    ${SOURCE_DIR}/src/unix/sysdep/rc.c
    ${SOURCE_DIR}/src/unix/sysdep/rc.h
@@ -581,6 +578,9 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/libpinmame/ticker.c
    ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
    ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/libpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-x64.txt
@@ -557,9 +557,6 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/ios/fronthlp.c
    ${SOURCE_DIR}/src/ios/rc.c
    ${SOURCE_DIR}/src/ios/rc.h
@@ -578,6 +575,9 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/libpinmame/ticker.c
    ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
    ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/libpinmame/CMakeLists_win-x64.txt
+++ b/cmake/libpinmame/CMakeLists_win-x64.txt
@@ -561,12 +561,9 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/vc/dirent.c
-
-   ${SOURCE_DIR}/src/win32com/Alias.cpp
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/jit.c
@@ -576,6 +573,8 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/windows/rc.c
    ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/ticker.c
+
+   ${SOURCE_DIR}/src/win32com/Alias.cpp
 
    ${SOURCE_DIR}/src/libpinmame/video.c
    ${SOURCE_DIR}/src/libpinmame/video.h
@@ -590,13 +589,16 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/libpinmame/misc.h
    ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
    ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 )
 
 target_include_directories(pinmame PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/ext/zlib/include
 )

--- a/cmake/libpinmame/CMakeLists_win-x86.txt
+++ b/cmake/libpinmame/CMakeLists_win-x86.txt
@@ -561,12 +561,9 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/vc/dirent.c
-
-   ${SOURCE_DIR}/src/win32com/Alias.cpp
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/jit.c
@@ -576,6 +573,8 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/windows/rc.c
    ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/ticker.c
+
+   ${SOURCE_DIR}/src/win32com/Alias.cpp
 
    ${SOURCE_DIR}/src/libpinmame/video.c
    ${SOURCE_DIR}/src/libpinmame/video.h
@@ -590,13 +589,16 @@ add_library(pinmame SHARED
    ${SOURCE_DIR}/src/libpinmame/misc.h
    ${SOURCE_DIR}/src/libpinmame/libpinmame.cpp
    ${SOURCE_DIR}/src/libpinmame/libpinmame.h
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
 )
 
 target_include_directories(pinmame PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/ext/zlib/include
 )

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -564,36 +564,58 @@ add_executable(pinmame WIN32
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/vc/dirent.c
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/blit.h
    ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/d3d_extra.h
+   ${SOURCE_DIR}/src/windows/dirty.h
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
    ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jit.h
    ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/jitemit.h
    ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/misc.h
+   ${SOURCE_DIR}/src/windows/msc.h
+   ${SOURCE_DIR}/src/windows/osd_cpu.h
+   ${SOURCE_DIR}/src/windows/osinline.h
+   ${SOURCE_DIR}/src/windows/pattern.h
    ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/sound.c
    ${SOURCE_DIR}/src/windows/ticker.c
    ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/video.h
    ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3d.h
    ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.h
    ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/winddraw.h
    ${SOURCE_DIR}/src/windows/window.c
+   ${SOURCE_DIR}/src/windows/window.h
    ${SOURCE_DIR}/src/windows/winmain.c 
+   ${SOURCE_DIR}/src/windows/winprefix.h
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+
+   ${SOURCE_DIR}/ext/zlib/include/zconf.h
+   ${SOURCE_DIR}/ext/zlib/include/zlib.h
 )
 
 target_include_directories(pinmame PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/ext/zlib/include
    ${SOURCE_DIR}/ext/dinput
 )
@@ -605,9 +627,9 @@ target_link_directories(pinmame PUBLIC
 
 target_link_libraries(pinmame 
    winmm.lib
+   ddraw.lib 
    dxguid.lib
    dsound.lib
-   ddraw.lib
    dinput64.lib
    zlibstatmt64.lib
 )

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -574,39 +574,60 @@ add_executable(pinmame WIN32
    ${SOURCE_DIR}/src/wpc/zacsnd.c
    ${SOURCE_DIR}/src/wpc/zacsnd.h
 
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
-
    ${SOURCE_DIR}/src/vc/dirent.c
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/blit.h
    ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/d3d_extra.h
+   ${SOURCE_DIR}/src/windows/dirty.h
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
    ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jit.h
    ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/jitemit.h
    ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/misc.h
+   ${SOURCE_DIR}/src/windows/msc.h
+   ${SOURCE_DIR}/src/windows/osd_cpu.h
+   ${SOURCE_DIR}/src/windows/osinline.h
+   ${SOURCE_DIR}/src/windows/pattern.h
    ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/sound.c
    ${SOURCE_DIR}/src/windows/ticker.c
    ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/video.h
    ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3d.h
    ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.h
    ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/winddraw.h
    ${SOURCE_DIR}/src/windows/window.c
-   ${SOURCE_DIR}/src/windows/winmain.c 
-
+   ${SOURCE_DIR}/src/windows/window.h
+   ${SOURCE_DIR}/src/windows/winmain.c
+   ${SOURCE_DIR}/src/windows/winprefix.h
    ${SOURCE_DIR}/src/windows/asmblit.asm
    ${SOURCE_DIR}/src/windows/asmtile.asm
+
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+
+   ${SOURCE_DIR}/ext/zlib/include/zconf.h
+   ${SOURCE_DIR}/ext/zlib/include/zlib.h
 )
 
 target_include_directories(pinmame PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/ext/zlib/include
    ${SOURCE_DIR}/ext/dinput
 )
@@ -618,8 +639,8 @@ target_link_directories(pinmame PUBLIC
 
 target_link_libraries(pinmame 
    winmm.lib
-   dxguid.lib
    ddraw.lib
+   dxguid.lib
    dsound.lib
    dinput.lib
    zlibstatmt.lib

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -591,40 +591,61 @@ add_executable(pinmame32 WIN32
    ${SOURCE_DIR}/src/ui/splitters.c
    ${SOURCE_DIR}/src/ui/treeview.c
    ${SOURCE_DIR}/src/ui/win32ui.c 
-
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc
 
    ${SOURCE_DIR}/src/vc/dirent.c
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/blit.h
    ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/d3d_extra.h
+   ${SOURCE_DIR}/src/windows/dirty.h
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
    ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jit.h
    ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/jitemit.h
    ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/misc.h
+   ${SOURCE_DIR}/src/windows/msc.h
+   ${SOURCE_DIR}/src/windows/osd_cpu.h
+   ${SOURCE_DIR}/src/windows/osinline.h
+   ${SOURCE_DIR}/src/windows/pattern.h
    ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/sound.c
    ${SOURCE_DIR}/src/windows/ticker.c
    ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/video.h
    ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3d.h
    ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.h
    ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/winddraw.h
    ${SOURCE_DIR}/src/windows/window.c
+   ${SOURCE_DIR}/src/windows/window.h
    ${SOURCE_DIR}/src/windows/winmain.c 
+   ${SOURCE_DIR}/src/windows/winprefix.h 
 
-   ${SOURCE_DIR}/src/ui/PinMAME32.rc
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+
+   ${SOURCE_DIR}/ext/zlib/include/zconf.h
+   ${SOURCE_DIR}/ext/zlib/include/zlib.h
 )
 
 target_include_directories(pinmame32 PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
    ${SOURCE_DIR}/src/ui
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/ext/zlib/include
    ${SOURCE_DIR}/ext/dinput
 )

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -598,43 +598,63 @@ add_executable(pinmame32 WIN32
    ${SOURCE_DIR}/src/ui/splitters.c
    ${SOURCE_DIR}/src/ui/treeview.c
    ${SOURCE_DIR}/src/ui/win32ui.c 
-
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
-   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+   ${SOURCE_DIR}/src/ui/PinMAME32.rc
 
    ${SOURCE_DIR}/src/vc/dirent.c
+   ${SOURCE_DIR}/src/vc/dirent.h
+   ${SOURCE_DIR}/src/vc/unistd.h
 
    ${SOURCE_DIR}/src/windows/blit.c
+   ${SOURCE_DIR}/src/windows/blit.h
    ${SOURCE_DIR}/src/windows/config.c
+   ${SOURCE_DIR}/src/windows/d3d_extra.h
+   ${SOURCE_DIR}/src/windows/dirty.h
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
    ${SOURCE_DIR}/src/windows/jit.c
+   ${SOURCE_DIR}/src/windows/jit.h
    ${SOURCE_DIR}/src/windows/jitemit.c
+   ${SOURCE_DIR}/src/windows/jitemit.h
    ${SOURCE_DIR}/src/windows/misc.c
+   ${SOURCE_DIR}/src/windows/misc.h
+   ${SOURCE_DIR}/src/windows/msc.h
+   ${SOURCE_DIR}/src/windows/osd_cpu.h
+   ${SOURCE_DIR}/src/windows/osinline.h
+   ${SOURCE_DIR}/src/windows/pattern.h
    ${SOURCE_DIR}/src/windows/rc.c
+   ${SOURCE_DIR}/src/windows/rc.h
    ${SOURCE_DIR}/src/windows/sound.c
    ${SOURCE_DIR}/src/windows/ticker.c
    ${SOURCE_DIR}/src/windows/video.c
+   ${SOURCE_DIR}/src/windows/video.h
    ${SOURCE_DIR}/src/windows/wind3d.c
+   ${SOURCE_DIR}/src/windows/wind3d.h
    ${SOURCE_DIR}/src/windows/wind3dfx.c
+   ${SOURCE_DIR}/src/windows/wind3dfx.h
    ${SOURCE_DIR}/src/windows/winddraw.c
+   ${SOURCE_DIR}/src/windows/winddraw.h
    ${SOURCE_DIR}/src/windows/window.c
-   ${SOURCE_DIR}/src/windows/winmain.c 
-
+   ${SOURCE_DIR}/src/windows/window.h
+   ${SOURCE_DIR}/src/windows/winmain.c
+   ${SOURCE_DIR}/src/windows/winprefix.h
    ${SOURCE_DIR}/src/windows/asmblit.asm
    ${SOURCE_DIR}/src/windows/asmtile.asm
 
-   ${SOURCE_DIR}/src/ui/PinMAME32.rc
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.c
+   ${SOURCE_DIR}/ext/vgm/vgmwrite.h
+
+   ${SOURCE_DIR}/ext/zlib/include/zconf.h
+   ${SOURCE_DIR}/ext/zlib/include/zlib.h
 )
 
 target_include_directories(pinmame32 PUBLIC
    ${SOURCE_DIR}/src
    ${SOURCE_DIR}/src/cpu/m68000/generated_by_m68kmake
    ${SOURCE_DIR}/src/wpc
-   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/src/vc
    ${SOURCE_DIR}/src/ui
+   ${SOURCE_DIR}/src/windows
    ${SOURCE_DIR}/ext/zlib/include
    ${SOURCE_DIR}/ext/dinput
 )

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -577,9 +577,9 @@ add_library(vpinmame SHARED
 
    ${SOURCE_DIR}/src/windows/blit.c
    ${SOURCE_DIR}/src/windows/blit.h
+   ${SOURCE_DIR}/src/windows/config.c
    ${SOURCE_DIR}/src/windows/d3d_extra.h
    ${SOURCE_DIR}/src/windows/dirty.h
-   ${SOURCE_DIR}/src/windows/config.c
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
@@ -649,7 +649,6 @@ add_library(vpinmame SHARED
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrl.h
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrls.cpp
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrls.h
-
    ${SOURCE_DIR}/src/win32com/VPinMAME.rc
    ${SOURCE_DIR}/src/win32com/VPinMAME.idl
    ${SOURCE_DIR}/src/win32com/VPinMAME64.def
@@ -687,13 +686,13 @@ target_link_directories(vpinmame PUBLIC
 
 target_link_libraries(vpinmame 
    winmm.lib
+   ddraw.lib
+   dxguid.lib
+   dsound.lib
+   dinput64.lib
    odbc32.lib
    odbccp32.lib
    version.lib
-   dxguid.lib
-   dsound.lib
-   ddraw.lib
-   dinput64.lib
    zlibstatmt64.lib
    bass.lib
 )

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -580,9 +580,9 @@ add_library(vpinmame SHARED
 
    ${SOURCE_DIR}/src/windows/blit.c
    ${SOURCE_DIR}/src/windows/blit.h
+   ${SOURCE_DIR}/src/windows/config.c
    ${SOURCE_DIR}/src/windows/d3d_extra.h
    ${SOURCE_DIR}/src/windows/dirty.h
-   ${SOURCE_DIR}/src/windows/config.c
    ${SOURCE_DIR}/src/windows/fileio.c
    ${SOURCE_DIR}/src/windows/fronthlp.c
    ${SOURCE_DIR}/src/windows/input.c
@@ -610,7 +610,6 @@ add_library(vpinmame SHARED
    ${SOURCE_DIR}/src/windows/window.c
    ${SOURCE_DIR}/src/windows/window.h
    ${SOURCE_DIR}/src/windows/winprefix.h
-
    ${SOURCE_DIR}/src/windows/asmblit.asm
    ${SOURCE_DIR}/src/windows/asmtile.asm
 
@@ -655,7 +654,6 @@ add_library(vpinmame SHARED
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrl.h
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrls.cpp
    ${SOURCE_DIR}/src/win32com/WSHDlgCtrls.h
-
    ${SOURCE_DIR}/src/win32com/VPinMAME.rc
    ${SOURCE_DIR}/src/win32com/VPinMAME.idl
    ${SOURCE_DIR}/src/win32com/VPinMAME.def
@@ -691,21 +689,21 @@ target_link_directories(vpinmame PUBLIC
    ${SOURCE_DIR}/ext/bass
 )
 
-target_link_options(vpinmame PUBLIC
-   /SAFESEH:NO
-)
-
 target_link_libraries(vpinmame 
    winmm.lib
+   ddraw.lib
+   dxguid.lib
+   dsound.lib
+   dinput.lib
    odbc32.lib
    odbccp32.lib
    version.lib
-   dxguid.lib
-   dsound.lib
-   ddraw.lib
-   dinput.lib
    zlibstatmt.lib
    bass.lib
+)
+
+target_link_options(vpinmame PUBLIC
+   /SAFESEH:NO
 )
 
 set_target_properties(vpinmame PROPERTIES

--- a/src/windows/wind3dfx.c
+++ b/src/windows/wind3dfx.c
@@ -93,7 +93,7 @@ static char *d3d_rc_effect;
 static char *d3d_rc_custom;
 static char *d3d_rc_expert;
 static int d3d_rc_scan;
-static int d3d_rc_prescale;
+static char *d3d_rc_prescale;
 static int d3d_rc_feedback;
 static int d3d_rc_rotate;
 
@@ -190,7 +190,6 @@ struct rc_option win_d3d_opts[] =
 	{ "d3deffect", NULL, rc_string, &d3d_rc_effect, "none", 0, 0, win_d3d_decode_effect, "specify the blitting effects" },
 	{ "d3dcustom", NULL, rc_string, &d3d_rc_custom, NULL, 0, 0, win_d3d_decode_custom, "customised blitting effects preset" },
 	{ "d3dexpert", NULL, rc_string, &d3d_rc_expert, NULL, 0, 0, win_d3d_decode_expert, "additional customised settings (undocumented)" },
-
 
 	{ NULL,	NULL, rc_end, NULL, NULL, 0, 0,	NULL, NULL }
 };


### PR DESCRIPTION
This PR adds support to the CI for building the VPinMAME installers. 

It also fixes a crash in the x64 version of VPinMAME where `d3d_rc_prescale` was incorrectly set as an `int` instead of a `char*`. [This code](https://github.com/vpinball/pinmame/blob/master/src/windows/rc.c#L109) was trying to free an `int`. 