### PR TITLE
ci: add bass dlls to vpinmame artifacts

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -41,7 +41,7 @@ jobs:
            for name in "${WORKFLOWS[@]}"
            do 
               RUN_ID=$(jq -r --arg SHA "${{ needs.version.outputs.sha }}" --arg NAME "${name}" '.workflow_runs[] | select(.head_sha==$SHA and .name==$NAME) | .id' runs.json) 
-              echo "Downloading ${name} artifiact list ${RUN_ID}..."
+              echo "Downloading ${name} artifact list ${RUN_ID}..."
               curl -s "${{ env.ACTIONS_API_URL }}/runs/${RUN_ID}/artifacts" --output artifacts.json
               ARTIFACTS=($(jq -r '.artifacts[] | .archive_download_url' artifacts.json)) 
               for url in ${ARTIFACTS[@]}

--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           name: VPinMAME-win-x64
           path: cmake/instvpm/bin/Setup64.exe
+      - uses: actions/upload-artifact@v2
+        with:
+          name: VPinMAME-win-x64
+          path: ext/bass/x64/Bass64.dll
 
   build-win-x86:
     runs-on: windows-latest
@@ -61,3 +65,7 @@ jobs:
         with:
           name: VPinMAME-win-x86
           path: cmake/instvpm/bin/Setup.exe
+      - uses: actions/upload-artifact@v2
+        with:
+          name: VPinMAME-win-x86
+          path: ext/bass/Bass.dll


### PR DESCRIPTION
This PR allows the vpinmame artifacts to be truly a single download, run installer, and go.