### PR TITLE
ci: update workflows to use matrix, upx devel, sc builds.

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -14,101 +14,81 @@ jobs:
           VERSION=$(grep -Eo "[0-9\.]+" src/version.c | head -1)
           echo "::set-output name=version::${VERSION}"
 
-  build-win-x64:
-    runs-on: windows-latest
+  build:
+    name: Build libpinmame-${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
     needs: [ version ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win-x64
+            platform-name: x64
+            lib: libpinmame-${{ needs.version.outputs.version }}.dll
+          - os: windows-latest
+            platform: win-x86
+            platform-name: Win32
+            lib: libpinmame-${{ needs.version.outputs.version }}.dll
+          - os: windows-latest
+            platform: win-arm64
+            platform-name: ARM64
+            lib: libpinmame-${{ needs.version.outputs.version }}.dll
+          - os: macos-latest
+            platform: osx-x64
+            lib: libpinmame.${{ needs.version.outputs.version }}.dylib
+          - os: ubuntu-latest
+            platform: linux-x64
+            lib: libpinmame.so.${{ needs.version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
-      - name: Build
+      - run: |
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/46946159/zip -o upx.zip
+            7z x upx.zip -oupx
+            rm upx.zip
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/46946156/zip -o upx.zip
+            7z x upx.zip -oupx
+            chmod 755 upx/upx
+            rm upx.zip
+          fi
+        shell: bash
+      - name: Build libpinmame-${{ matrix.platform }}
         run: |
-          copy cmake/libpinmame/CMakeLists_win-x64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A x64 -B build
-          cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/libpinmame-${{ needs.version.outputs.version }}.dll
-          args: --best --lzma
+          cp cmake/libpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            cmake -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build
+            cmake --build build --config Release
+            if [[ "${{ matrix.platform }}" != "win-arm64" ]]; then 
+              ./upx/upx.exe build/Release/${{ matrix.lib }}
+            fi
+          else
+            cmake -DCMAKE_BUILD_TYPE=Release -B build/Release
+            cmake --build build/Release
+            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              ./upx/upx build/Release/${{ matrix.lib }}
+            fi
+          fi
+        shell: bash
+      - run: |
+          mkdir tmp
+          cp build/Release/${{ matrix.lib }} tmp
+          cp release/license.txt tmp
+        shell: bash
       - uses: actions/upload-artifact@v2
         with:
-          name: libpinmame-win-x64
-          path: build/Release/libpinmame-${{ needs.version.outputs.version }}.dll
+          name: libpinmame-${{ matrix.platform }}
+          path: build/Release/${{ matrix.lib }}
           
-  build-win-x86:
-    runs-on: windows-latest
-    needs: [ version ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          copy cmake/libpinmame/CMakeLists_win-x86.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A Win32 -B build
-          cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/libpinmame-${{ needs.version.outputs.version }}.dll
-          args: --best --lzma
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libpinmame-win-x86
-          path: build/Release/libpinmame-${{ needs.version.outputs.version }}.dll
-
-  build-win-arm64:
-    runs-on: windows-latest
-    needs: [ version ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          copy cmake/libpinmame/CMakeLists_win-arm64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A ARM64 -B build
-          cmake --build build --config Release
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libpinmame-win-arm64
-          path: build/Release/libpinmame-${{ needs.version.outputs.version }}.dll
-        
-  build-osx-x64:
-    runs-on: macos-latest
-    needs: [ version ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          cp cmake/libpinmame/CMakeLists_osx-x64.txt CMakeLists.txt
-          cmake -DCMAKE_BUILD_TYPE=Release -B build
-          cmake --build build 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libpinmame-osx-x64
-          path: build/libpinmame.${{ needs.version.outputs.version }}.dylib
-
-  build-linux-x64:
-    runs-on: ubuntu-latest
-    needs: [ version ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          cp cmake/libpinmame/CMakeLists_linux-x64.txt CMakeLists.txt
-          cmake -DCMAKE_BUILD_TYPE=Release -B build
-          cmake --build build 
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/libpinmame.so.${{ needs.version.outputs.version }}
-          args: --best --lzma
-      - uses: actions/upload-artifact@v2
-        with:
-          name: libpinmame-linux-x64
-          path: build/libpinmame.so.${{ needs.version.outputs.version }}
-
   dispatch:
     runs-on: ubuntu-latest
-    needs: [ build-win-x64, build-win-x86, build-win-arm64, build-osx-x64, build-linux-x64 ]
+    needs: [ build ]
     if: github.repository == 'vpinball/pinmame' && github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.PAT_PINMAME_DOTNET }}
+          token: ${{ secrets.GH_PAT }}
           repository: VisualPinball/pinmame-dotnet
           event-type: update-libpinmame
           client-payload: '{"run_id": "${{ github.run_id }}"}'

--- a/.github/workflows/pinmame.yml
+++ b/.github/workflows/pinmame.yml
@@ -3,39 +3,45 @@ on:
   push:
 
 jobs:
-  build-win-x64:
+  build:
+    name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
     runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          copy cmake/pinmame/CMakeLists_win-x64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A x64 -B build
-          cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/PinMAME.exe
-          args: --best --lzma
-      - uses: actions/upload-artifact@v2
-        with:
-          name: PinMAME-win-x64
-          path: build/Release/PinMAME.exe
-
-  build-win-x86:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: win-x64
+            platform-name: x64
+          - platform: win-x86
+            platform-name: Win32
+          - platform: win-x64
+            platform-name: x64
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
+          - platform: win-x86
+            platform-name: Win32
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
     steps:
       - uses: actions/checkout@v2
       - uses: ilammy/setup-nasm@v1
-      - name: Build
+      - run: |
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/46946159/zip -o upx.zip
+          7z x upx.zip -oupx
+          rm upx.zip
+        shell: bash
+      - name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
-          copy cmake/pinmame/CMakeLists_win-x86.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A Win32 -B build
+          copy cmake\pinmame\CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
+          cmake ${{ matrix.extra-flags }} -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build
           cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/PinMAME.exe
-          args: --best --lzma
+          .\upx\upx.exe --best --lzma --best --lzma build\Release\PinMAME.exe
+      - run: |
+          mkdir tmp
+          copy build\Release\PinMAME.exe tmp
+          copy release\license.txt tmp
+          copy release\whatsnew.txt tmp
       - uses: actions/upload-artifact@v2
         with:
-          name: PinMAME-win-x86
-          path: build/Release/PinMAME.exe
+          name: PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
+          path: tmp

--- a/.github/workflows/pinmame32.yml
+++ b/.github/workflows/pinmame32.yml
@@ -3,39 +3,45 @@ on:
   push:
 
 jobs:
-  build-win-x64:
+  build:
+    name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
     runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          copy cmake/pinmame32/CMakeLists_win-x64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A x64 -B build
-          cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/PinMAME32.exe
-          args: --best --lzma
-      - uses: actions/upload-artifact@v2
-        with:
-          name: PinMAME32-win-x64
-          path: build/Release/PinMAME32.exe
-
-  build-win-x86:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: win-x64
+            platform-name: x64
+          - platform: win-x86
+            platform-name: Win32
+          - platform: win-x64
+            platform-name: x64
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
+          - platform: win-x86
+            platform-name: Win32
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
     steps:
       - uses: actions/checkout@v2
       - uses: ilammy/setup-nasm@v1
-      - name: Build
+      - run: |
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/46946159/zip -o upx.zip
+          7z x upx.zip -oupx
+          rm upx.zip
+        shell: bash
+      - name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
-          copy cmake/pinmame32/CMakeLists_win-x86.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A Win32 -B build
+          copy cmake\pinmame32\CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
+          cmake ${{ matrix.extra-flags }} -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build
           cmake --build build --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/Release/PinMAME32.exe
-          args: --best --lzma
+          .\upx\upx.exe --best --lzma --best --lzma build\Release\PinMAME32.exe
+      - run: |
+          mkdir tmp
+          copy build\Release\PinMAME32.exe tmp
+          copy release\license.txt tmp
+          copy release\whatsnew.txt tmp
       - uses: actions/upload-artifact@v2
         with:
-          name: PinMAME32-win-x86
-          path: build/Release/PinMAME32.exe
+          name: PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
+          path: tmp

--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -3,65 +3,63 @@ on:
   push:
 
 jobs:
-  build-win-x64:
+  build:
+    name: Build VPinMAME${{ matrix.artifact-suffix }}-win-${{ matrix.platform }}
     runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: |
-          copy cmake/vpinmame/CMakeLists_win-x64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A x64 -B build/vpinmame
-          cmake --build build/vpinmame --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/vpinmame/Release/VPinMAME64.dll
-          args: --best --lzma
-      - name: Build Installer
-        run: |
-          copy cmake/instvpm/CMakeLists_win-x64.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A x64 -B build/instvpm
-          cmake --build build/instvpm --config Release
-      - uses: actions/upload-artifact@v2
-        with:
-          name: VPinMAME-win-x64
-          path: build/vpinmame/Release/VPinMAME64.dll
-      - uses: actions/upload-artifact@v2
-        with:
-          name: VPinMAME-win-x64
-          path: build/instvpm/Release/Setup64.exe
-      - uses: actions/upload-artifact@v2
-        with:
-          name: VPinMAME-win-x64
-          path: ext/bass/x64/Bass64.dll
-
-  build-win-x86:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: win-x64
+            platform-name: x64
+            dll: VPinMAME64.dll
+            setup: Setup64.exe
+            bass: x64\Bass64.dll
+          - platform: win-x86
+            platform-name: Win32
+            dll: VPinMAME.dll
+            setup: Setup.exe
+            bass: Bass.dll
+          - platform: win-x64
+            platform-name: x64
+            dll: VPinMAME64.dll
+            setup: Setup64.exe
+            bass: x64\Bass64.dll
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
+          - platform: win-x86
+            platform-name: Win32
+            dll: VPinMAME.dll
+            setup: Setup.exe
+            bass: Bass.dll
+            artifact-suffix: -sc
+            extra-flags: -D CMAKE_CXX_FLAGS=/DSAM_INCLUDE_COLORED
     steps:
       - uses: actions/checkout@v2
       - uses: ilammy/setup-nasm@v1
-      - name: Build
+      - run: |
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/46946159/zip -o upx.zip
+          7z x upx.zip -oupx
+          rm upx.zip
+        shell: bash 
+      - name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
-          copy cmake/vpinmame/CMakeLists_win-x86.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A Win32 -B build/vpinmame
-          cmake --build build/vpinmame --config Release
-      - uses: svenstaro/upx-action@v2
-        with:
-          file: build/vpinmame/Release/VPinMAME.dll
-          args: --best --lzma
-      - name: Build Installer
-        run: |
-          copy cmake/instvpm/CMakeLists_win-x86.txt CMakeLists.txt
-          cmake -G "Visual Studio 16 2019" -A Win32 -B build/instvpm
-          cmake --build build/instvpm --config Release
+          copy cmake\vpinmame\CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
+          cmake ${{ matrix.extra-flags }} -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build\vpinmame
+          cmake --build build\vpinmame --config Release
+          .\upx\upx.exe --best --lzma --best --lzma build\vpinmame\Release\${{ matrix.dll }}
+          copy cmake\instvpm\CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
+          cmake -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build\instvpm
+          cmake --build build\instvpm --config Release
+      - run: |
+          mkdir tmp
+          copy build\vpinmame\Release\${{ matrix.dll }} tmp
+          copy build\instvpm\Release\${{ matrix.setup }} tmp
+          copy ext\bass\${{ matrix.bass }} tmp
+          copy release\VPMAlias.txt tmp
+          copy release\license.txt tmp
+          copy release\whatsnewVPM.txt tmp
       - uses: actions/upload-artifact@v2
         with:
-          name: VPinMAME-win-x86
-          path: build/vpinmame/Release/VPinMAME.dll
-      - uses: actions/upload-artifact@v2
-        with:
-          name: VPinMAME-win-x86
-          path: build/instvpm/Release/Setup.exe
-      - uses: actions/upload-artifact@v2
-        with:
-          name: VPinMAME-win-x86
-          path: ext/bass/Bass.dll
+          name: VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
+          path: tmp

--- a/cmake/instvpm/CMakeLists_win-x64.txt
+++ b/cmake/instvpm/CMakeLists_win-x64.txt
@@ -52,8 +52,6 @@ target_include_directories(instvpm PUBLIC
 )
 
 target_link_libraries(instvpm
-   odbc32.lib
-   odbccp32.lib
    version.lib
 )
 

--- a/cmake/instvpm/CMakeLists_win-x86.txt
+++ b/cmake/instvpm/CMakeLists_win-x86.txt
@@ -52,8 +52,6 @@ target_include_directories(instvpm PUBLIC
 )
 
 target_link_libraries(instvpm
-   odbc32.lib
-   odbccp32.lib
    version.lib
 )
 

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -705,8 +705,6 @@ target_link_libraries(vpinmame
    dxguid.lib
    dsound.lib
    dinput64.lib
-   odbc32.lib
-   odbccp32.lib
    version.lib
    zlibstatmt64.lib
    bass.lib

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -96,6 +96,7 @@ add_compile_options(
    $<$<CONFIG:RELEASE>:/Ob2>
    $<$<CONFIG:RELEASE>:/O2>
    $<$<CONFIG:RELEASE>:/Oi>
+   $<$<CONFIG:RELEASE>:/arch:SSE2>
    $<$<CONFIG:RELEASE>:/fp:fast>
    $<$<CONFIG:RELEASE>:/fp:except->
    $<$<CONFIG:RELEASE>:/Ot>
@@ -710,8 +711,6 @@ target_link_libraries(vpinmame
    dxguid.lib
    dsound.lib
    dinput.lib
-   odbc32.lib
-   odbccp32.lib
    version.lib
    zlibstatmt.lib
    bass.lib


### PR DESCRIPTION
This PR includes the following:

- rework all workflows to use `matrix` instead of multiple jobs.  
- compress binaries with `upx devel` which fixes x86 `VPinMAME.dll` failing to load in VBScript.
- adds `SAM_INCLUDE_COLORED` builds for `PinMAME`, `PinMAME32`, and `VPinMAME` 
- adds `license.txt` and `whatsnew.txt` to artifact zips.

