### PR TITLE
libpinmame: implement mechs using callbacks

### DIFF
--- a/src/libpinmame/test.cpp
+++ b/src/libpinmame/test.cpp
@@ -222,6 +222,26 @@ void CALLBACK OnSolenoidUpdated(int solenoid, int isActive) {
 	printf("OnSolenoidUpdated: solenoid=%d, isActive=%d\n", solenoid, isActive);
 }
 
+void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
+	printf("OnMechAvailable: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
+		mechNo,
+		p_mechInfo->type,
+		p_mechInfo->length,
+		p_mechInfo->steps,
+		p_mechInfo->pos,
+		p_mechInfo->speed);
+}
+
+void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo) {
+	printf("OnMechUpdated: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
+		mechNo,
+		p_mechInfo->type,
+		p_mechInfo->length,
+		p_mechInfo->steps,
+		p_mechInfo->pos,
+		p_mechInfo->speed);
+}
+
 void CALLBACK OnConsoleDataUpdated(void* p_data, int size) {
 	printf("OnConsoleDataUpdated: size=%d\n", size);
 }
@@ -241,6 +261,8 @@ int main(int, char**) {
 		&OnDisplayUpdated,
 		&OnAudioAvailable,
 		&OnAudioUpdated,
+		&OnMechAvailable,
+		&OnMechUpdated,
 		&OnSolenoidUpdated,
 		&OnConsoleDataUpdated,
 		&IsKeyPressed
@@ -255,6 +277,7 @@ int main(int, char**) {
 	PinmameSetConfig(&config);
 
 	PinmameSetHandleKeyboard(1);
+	PinmameSetHandleMechanics(0);
 
 	PinmameGetGames(&Game);
 	PinmameGetGame("fourx4", &Game);
@@ -271,7 +294,7 @@ int main(int, char**) {
 	//PinmameRun("acd_168hc");
 	//PinmameRun("snspares");
 
-	if (PinmameRun("f1gp") == OK) {
+	if (PinmameRun("t2_l8") == OK) {
 		while (1) {
 			std::this_thread::sleep_for(std::chrono::microseconds(100));
 		}

--- a/src/wpc/mech.c
+++ b/src/wpc/mech.c
@@ -8,30 +8,19 @@
 #endif /* M_PI */
 #define MECH_STEP       60
 #define MECH_FASTPULSES  8
-typedef struct {
-  int fast;       /* running fast */
-  int sol1, sol2; /* Controlling solenoids */
-  int solinv;     /* inverted solenoids (active low) */
-  int length;     /* Length to move from one end to the other in VBLANKS 1/60s */
-  int steps;      /* steps returned */
-  int type;       /* type */
-  int acc;        /* acceleration */
-  int ret;
-  mech_tSwData swPos[20]; /* switches activated */
-  int pos;      /* current position */
-  int speed;    /* current speed -acc -> acc */
-  int anglePos;
-  int last;
-} tMechData, *ptMechData;
 
 static struct {
-  tMechData mechData[MECH_MAXMECH];
+  mech_tMechData mechData[MECH_MAXMECH];
   void *mechTimer;
   int mechCounter;
   int emuRunning;
 } locals;
 static void mech_updateAll(int param);
 static void mech_update(int mechNo);
+
+#ifdef LIBPINMAME
+  extern void libpinmame_update_mech(const int mechNo, mech_tMechData* mechData);
+#endif
 
 void mech_init(void) {
   memset(&locals,0,sizeof(locals));
@@ -114,6 +103,8 @@ static void mech_update(int mechNo) {
   int dir = 0;
   int currPos, ii;
 
+
+
   { /*-- check power direction -1, 0, 1 --*/
      if ((md->type & 0x70) == MECH_FOURSTEPSOL)
      {
@@ -192,6 +183,10 @@ static void mech_update(int mechNo) {
         core_setSw(md->swPos[ii].swNo, TRUE);
     }
   }
+
+#ifdef LIBPINMAME
+    libpinmame_update_mech(mechNo, md);
+#endif
 }
 
 void mech_nv(void *file, int write) {

--- a/src/wpc/mech.h
+++ b/src/wpc/mech.h
@@ -52,6 +52,22 @@ typedef struct {
   int initialpos; 
 } mech_tInitData, *mech_ptInitData;
 
+typedef struct {
+  int fast;       /* running fast */
+  int sol1, sol2; /* Controlling solenoids */
+  int solinv;     /* inverted solenoids (active low) */
+  int length;     /* Length to move from one end to the other in VBLANKS 1/60s */
+  int steps;      /* steps returned */
+  int type;       /* type */
+  int acc;        /* acceleration */
+  int ret;
+  mech_tSwData swPos[20]; /* switches activated */
+  int pos;      /* current position */
+  int speed;    /* current speed -acc -> acc */
+  int anglePos;
+  int last;
+} mech_tMechData, *ptMechData;
+
 extern void mech_init(void);
 extern void mech_emuInit(void);
 extern void mech_emuExit(void);

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -547,6 +547,9 @@ static INTERRUPT_GEN(wpc_vblank) {
   /  Update switches every vblank; or on every pass when using P-ROC
   /-------------------------------*/
   if (
+#ifdef LIBPINMAME
+      1 ||
+#endif
 #ifdef PROC_SUPPORT
       coreGlobals.p_rocEn || 
 #endif


### PR DESCRIPTION
While working on the T2 cannon for VPE, I finally had a chance to understand how mechs in pinmame/vpinmame really work.

The `g_fHandleMechanics` flag is somewhat inaccurate. Even with it set to `0`, T2 will still add a mech for the gun motor: 

https://github.com/vpinball/pinmame/blob/12f65c4b85163bc7686bd79828850cb732f4171f/src/wpc/sims/wpc/full/t2.c#L676

`g_fHandleMechanics` only disables calls to `t2_handleMech` which is used for simulation.

The gun mark and gun home switches, are still automatically controlled by `mech_updateAll`:

https://github.com/vpinball/pinmame/blob/12f65c4b85163bc7686bd79828850cb732f4171f/src/wpc/mech.c#L41

This explains why I would see erratic behavior for the Gun Test in VPE --  I was manually setting the switches and this was automatically setting the switches.


This PR properly implements mechs in `libpinmame`. We are now using callbacks, just like for audio, displays, solenoids, etc.

There are two new callbacks:

`PinmameOnMechAvailableCallback` - called once for each mech that is added
`PinmameOnMechUpdatedCallback` - called only when position or speed change values

The following api methods have removed / updated:

`int PinmameGetMech(int mechNo)`:

Removed. Use `PinmameOnMechUpdatedCallback` callback instead


`PINMAME_STATUS PinmameSetMech(int mechNo, PinmameMechConfig* p_mechConfig`:

If you want to disable pinmame's default T2 gun motor:

```
PinmameSetMech(0, nullptr)
```

If you want to use different settings for the T2 gun motor:

```
PinmameMechConfig config;
memset(&config, 0, sizeof(PinmameMechConfig));

config.sol1 = 11;
config.type = LINEAR | ONESOL | REVERSE;
config.length = 240;
config.steps = 240;
config.initialPos = 5;
config.sw[0].swNo = 32;
config.sw[0].startPos = 5;
config.sw[0].endPos = 20;
config.sw[1].swNo = 33;
config.sw[1].startPos = 100;
config.sw[1].endPos = 120;

PinmameSetMech(0, &config)
```

Note, `PinmameSetMech` should only be called after the simulator is running, and preferably in `PinmameOnStateUpdatedCallback`


