### PR TITLE
libpinmame: add support for android-arm64-v8a. Tweak INLINE define

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -72,6 +72,9 @@ jobs:
             platform: linux-x64
             libpinmame: libpinmame.so.${{ needs.version.outputs.version }}
             pinmame-test: pinmame_test
+          - os: ubuntu-18.04
+            platform: android-arm64-v8a
+            libpinmame: libpinmame.${{ needs.version.outputs.version }}.so
     steps:
       - uses: actions/checkout@v2
       - run: |
@@ -92,7 +95,7 @@ jobs:
           else
             cmake -DCMAKE_BUILD_TYPE=Release -B build/Release
             cmake --build build/Release
-            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
               upx --best --lzma build/Release/${{ matrix.libpinmame }}
             fi
           fi

--- a/cmake/libpinmame/CMakeLists_android-arm64-v8a.txt
+++ b/cmake/libpinmame/CMakeLists_android-arm64-v8a.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
-set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_SYSTEM_NAME Android)
+set(CMAKE_SYSTEM_VERSION 30)
+set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
 
 file(READ src/version.c version)
 string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
@@ -9,12 +11,8 @@ project(pinmame VERSION ${PROJECT_VERSION})
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_CXX_FLAGS -fembed-bitcode)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_C_FLAGS -fembed-bitcode)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
-set(CMAKE_OSX_ARCHITECTURES arm64)
 
 add_compile_definitions(
    HAS_M6809=1
@@ -87,8 +85,11 @@ add_compile_definitions(
    PINMAME_NO_UNUSED
    LIBPINMAME
    SAM_INCLUDE_COLORED
+   NAME="LIBPINMAME"
 
    LSB_FIRST
+   PI=M_PI
+   UNIX
 )
 
 add_definitions( "-DINLINE=static inline __attribute__((always_inline))" )
@@ -583,7 +584,8 @@ target_include_directories(pinmame PUBLIC
    src
    src/wpc
    src/cpu/m68000/generated_by_m68kmake
-   src/ios
+   src/unix
+   src/unix/sysdep
    src/libpinmame
 )
 
@@ -595,4 +597,6 @@ target_link_libraries(pinmame
 
 set_target_properties(pinmame PROPERTIES
    VERSION ${PROJECT_VERSION}
+   SUFFIX ".${PROJECT_VERSION}.so"
+   LINK_FLAGS_RELEASE -s
 )

--- a/cmake/libpinmame/CMakeLists_osx-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-arm64.txt
@@ -84,8 +84,9 @@ add_compile_definitions(
    SAM_INCLUDE_COLORED
 
    LSB_FIRST
-   INLINE=static __inline
 )
+
+add_definitions( "-DINLINE=static inline __attribute__((always_inline))" )
 
 add_library(pinmame SHARED
    src/artwork.c


### PR DESCRIPTION
This PR adds support for `android-arm64-v8a`.

In addition, this PR also tweaks the compiler definition for `INLINE`.

iOS, MacOS, and Android are being compiled using clang which supports `__attribute__((always_inline))`.