### PR TITLE
ci: merge osx libaries with lipo, other misc cleanup

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   VERSION_START_SHA: e87be0e3cfa66411976ca04a72dd29e36c483966
+  UPX_ARTIFACT: 176385880
 
 defaults:
   run:
@@ -19,7 +20,7 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: version
@@ -76,10 +77,10 @@ jobs:
             platform: android-arm64-v8a
             libpinmame: libpinmame.${{ needs.version.outputs.version }}.so
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/176385880/zip -o upx.zip
+            curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
             7z x upx.zip -oupx
             rm upx.zip
           fi
@@ -109,14 +110,34 @@ jobs:
             cp build/Release/${{ matrix.pinmame-test }} tmp
           fi
           cp release/license.txt tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: libpinmame-${{ needs.version.outputs.tag }}-${{ matrix.platform }}
+          path: tmp
+
+  post-build:
+    runs-on: macos-latest
+    needs: [ version, build ]
+    name: Build libpinmame-osx
+    steps:
+      - uses: actions/download-artifact@v3
+      - run: |
+          mkdir tmp
+          cp libpinmame-${{ needs.version.outputs.tag }}-osx-x64/license.txt tmp 
+          lipo -create -output tmp/libpinmame.${{ needs.version.outputs.version }}.dylib \
+             libpinmame-${{ needs.version.outputs.tag }}-osx-x64/libpinmame.${{ needs.version.outputs.version }}.dylib \
+             libpinmame-${{ needs.version.outputs.tag }}-osx-arm64/libpinmame.${{ needs.version.outputs.version }}.dylib 
+          lipo -create -output tmp/pinmame_test \
+             libpinmame-${{ needs.version.outputs.tag }}-osx-x64/pinmame_test \
+             libpinmame-${{ needs.version.outputs.tag }}-osx-arm64/pinmame_test 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libpinmame-${{ needs.version.outputs.tag }}-osx
           path: tmp
           
   dispatch:
     runs-on: ubuntu-latest
-    needs: [ version, build ]
+    needs: [ version, post-build ]
     if: github.repository == 'vpinball/pinmame' && github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/pinmame.yml
+++ b/.github/workflows/pinmame.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   VERSION_START_SHA: e87be0e3cfa66411976ca04a72dd29e36c483966
+  UPX_ARTIFACT: 176385880
 
 defaults:
   run:
@@ -16,7 +17,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: version
@@ -48,10 +49,10 @@ jobs:
             artifact-suffix: -sc
             extra-flags: -D CMAKE_CXX_FLAGS=//DSAM_INCLUDE_COLORED
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
       - run: |
-          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/176385880/zip -o upx.zip
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
           7z x upx.zip -oupx
           rm upx.zip
       - name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
@@ -65,7 +66,7 @@ jobs:
           cp build/Release/PinMAME.exe tmp
           cp release/license.txt tmp
           cp release/whatsnew.txt tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: PinMAME${{ matrix.artifact-suffix }}-${{ needs.version.outputs.tag }}-${{ matrix.platform }}
           path: tmp

--- a/.github/workflows/pinmame32.yml
+++ b/.github/workflows/pinmame32.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   VERSION_START_SHA: e87be0e3cfa66411976ca04a72dd29e36c483966
+  UPX_ARTIFACT: 176385880
 
 defaults:
   run:
@@ -16,7 +17,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: version
@@ -48,10 +49,10 @@ jobs:
             artifact-suffix: -sc
             extra-flags: -D CMAKE_CXX_FLAGS=//DSAM_INCLUDE_COLORED
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
       - run: |
-          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/176385880/zip -o upx.zip
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
           7z x upx.zip -oupx
           rm upx.zip
       - name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
@@ -65,7 +66,7 @@ jobs:
           cp build/Release/PinMAME32.exe tmp
           cp release/license.txt tmp
           cp release/whatsnew.txt tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: PinMAME32${{ matrix.artifact-suffix }}-${{ needs.version.outputs.tag }}-${{ matrix.platform }}
           path: tmp

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,7 +23,7 @@ jobs:
            SHA7="${SHA::7}"
            echo "::set-output name=sha::${SHA}"
            echo "::set-output name=sha7::${SHA7}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ steps.sha.outputs.sha }}
           fetch-depth: 0

--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   VERSION_START_SHA: e87be0e3cfa66411976ca04a72dd29e36c483966
+  UPX_ARTIFACT: 176385880
 
 defaults:
   run:
@@ -16,7 +17,7 @@ jobs:
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: version
@@ -60,10 +61,10 @@ jobs:
             artifact-suffix: -sc
             extra-flags: -D CMAKE_CXX_FLAGS=//DSAM_INCLUDE_COLORED
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ilammy/setup-nasm@v1
       - run: |
-          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/176385880/zip -o upx.zip
+          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
           7z x upx.zip -oupx
           rm upx.zip
       - name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
@@ -83,7 +84,7 @@ jobs:
           cp release/VPMAlias.txt tmp
           cp release/license.txt tmp
           cp release/whatsnewVPM.txt tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: VPinMAME${{ matrix.artifact-suffix }}-${{ needs.version.outputs.tag }}-${{ matrix.platform }}
           path: tmp

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -19,7 +19,7 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: version
@@ -46,7 +46,7 @@ jobs:
             platform: osx-x64
             exe: xpinmame
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - if: matrix.os == 'macos-latest'
         run: |
           brew install xquartz
@@ -59,7 +59,7 @@ jobs:
           mkdir tmp
           cp build/Release/${{ matrix.exe }} tmp
           cp release/license.txt tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: xpinmame-${{ needs.version.outputs.tag }}-${{ matrix.platform }}
           path: tmp

--- a/cmake/libpinmame/CMakeLists_osx-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-arm64.txt
@@ -599,3 +599,8 @@ add_executable(pinmame_test
 target_link_libraries(pinmame_test LINK_PUBLIC
    pinmame
 )
+
+set_target_properties(pinmame_test PROPERTIES
+   SKIP_BUILD_RPATH TRUE
+   LINK_FLAGS "-Wl,-rpath,@executable_path"
+)

--- a/cmake/libpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-x64.txt
@@ -84,8 +84,9 @@ add_compile_definitions(
    SAM_INCLUDE_COLORED
 
    LSB_FIRST
-   INLINE=static __inline
 )
+
+add_definitions( "-DINLINE=static inline __attribute__((always_inline))" )
 
 add_library(pinmame SHARED
    src/artwork.c
@@ -597,4 +598,9 @@ add_executable(pinmame_test
 
 target_link_libraries(pinmame_test LINK_PUBLIC
    pinmame
+)
+
+set_target_properties(pinmame_test PROPERTIES
+   SKIP_BUILD_RPATH TRUE
+   LINK_FLAGS "-Wl,-rpath,@executable_path"
 )


### PR DESCRIPTION
This PR updates the libpinmame workflow to build an additional set of OSX binaries that support both x64 and arm64 architectures. 