### PR TITLE
libpinmame: revert adding vector_updates for iOS static build

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -21,7 +21,6 @@ int g_fHandleKeyboard = 0;
 int g_fHandleMechanics = 0;
 int g_fDumpFrames = 0;
 int g_fPause = 0;
-int vector_updates = 0;
 
 #ifdef VPINMAME_ALTSOUND
 char g_szGameName[256] = { 0 }; // String containing requested game name (may be different from ROM if aliased)


### PR DESCRIPTION
This PR removes the `vector_updates` variable in `libpinmame.cpp` that was required for iOS static library builds.

- not including `vector_updates` no longer causes an issue on iOS build
- fixes ci errors that are appearing for `libpinmame-android-arm64-v8a`
- fixes issue https://github.com/vpinball/pinmame/issues/58 