### PR TITLE
ci: update workflows to fix deprecation warnings

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -30,10 +30,10 @@ jobs:
           SHA="${GITHUB_SHA}"
           SHA7="${SHA::7}"
           TAG="${VERSION}-${REVISION}-${SHA7}"
-          echo "::set-output name=version::${VERSION}"
-          echo "::set-output name=revision::${REVISION}"
-          echo "::set-output name=sha::${SHA}"
-          echo "::set-output name=tag::${TAG}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "revision=${REVISION}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Build libpinmame-${{ matrix.platform }}

--- a/.github/workflows/pinmame.yml
+++ b/.github/workflows/pinmame.yml
@@ -26,7 +26,7 @@ jobs:
           REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..HEAD --count)
           SHA7="${GITHUB_SHA::7}"
           TAG="${VERSION}-${REVISION}-${SHA7}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}

--- a/.github/workflows/pinmame32.yml
+++ b/.github/workflows/pinmame32.yml
@@ -26,7 +26,7 @@ jobs:
           REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..HEAD --count)
           SHA7="${GITHUB_SHA::7}"
           TAG="${VERSION}-${REVISION}-${SHA7}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
            SHA=$(if [[ "${{ github.event.inputs.sha }}" ]]; then echo "${{ github.event.inputs.sha }}"; else echo "${GITHUB_SHA}"; fi)
            SHA7="${SHA::7}"
-           echo "::set-output name=sha::${SHA}"
-           echo "::set-output name=sha7::${SHA7}"
+           echo "sha=${SHA}" >> $GITHUB_OUTPUT
+           echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           ref: ${{ steps.sha.outputs.sha }}
@@ -31,7 +31,7 @@ jobs:
         run: |
           VERSION=$(grep -Eo "[0-9\.]+" src/version.c | head -1)
           REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..${{ steps.sha.outputs.sha }} --count)
-          echo "::set-output name=tag::${VERSION}-${REVISION}-${{ steps.sha.outputs.sha7 }}"
+          echo "tag=${VERSION}-${REVISION}-${{ steps.sha.outputs.sha7 }}" >> $GITHUB_OUTPUT
 
   prerelease:
     runs-on: ubuntu-latest
@@ -55,18 +55,11 @@ jobs:
            done
            rm *.json
       - id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: "v${{ needs.version.outputs.tag }}"
-          release_name: "v${{ needs.version.outputs.tag }}"
           prerelease: true
-          commitish: ${{ needs.version.outputs.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - id: upload_release_assets
-        uses: dwenegar/upload-release-assets@v1
-        with:
-          release_id: ${{ steps.create_release.outputs.id }}
-          assets_path: .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: "v${{ needs.version.outputs.tag }}"
+          tag: "v${{ needs.version.outputs.tag }}" 
+          commit: ${{ needs.version.outputs.sha }}
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "*"

--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -26,7 +26,7 @@ jobs:
           REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..HEAD --count)
           SHA7="${GITHUB_SHA::7}"
           TAG="${VERSION}-${REVISION}-${SHA7}"
-          echo "::set-output name=tag::${TAG}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -29,10 +29,10 @@ jobs:
           SHA="${GITHUB_SHA}"
           SHA7="${SHA::7}"
           TAG="${VERSION}-${REVISION}-${SHA7}"
-          echo "::set-output name=version::${VERSION}"
-          echo "::set-output name=revision::${REVISION}"
-          echo "::set-output name=sha::${SHA}"
-          echo "::set-output name=tag::${TAG}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "revision=${REVISION}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
   build:
     name: Build xpinmame-${{ matrix.platform }}

--- a/.github/workflows/xpinmame_lisy.yml
+++ b/.github/workflows/xpinmame_lisy.yml
@@ -21,10 +21,10 @@ jobs:
             base_image: raspios_lite_arm64:latest
     steps:
       - name: Checkout pinmame
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout WiringPi
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             repository: WiringPi/WiringPi
             ref: master

--- a/cmake/libpinmame/CMakeLists_ios-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_ios-arm64.txt
@@ -19,7 +19,7 @@ set(CMAKE_C_FLAGS -fembed-bitcode)
 include(ExternalProject)
 
 ExternalProject_Add(zlib
-  URL https://zlib.net/zlib-1.2.12.tar.gz
+  URL https://zlib.net/zlib-1.2.13.tar.gz
   CMAKE_ARGS -DCMAKE_SYSTEM_NAME=iOS
   CMAKE_ARGS -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
   CMAKE_ARGS -DCMAKE_OSX_ARCHITECTURES=arm64


### PR DESCRIPTION
This PR is to fix the deprecation warnings that are output during CI builds.

Also, the prerelease workflow has been modified as create-release is no longer maintained by GitHub. We now use a recommended alternative ncipollo/release-action@v1.

It also bumps fixes the failure in `libpinmame-ios-arm64` since `zlib 1.2.12` is no longer available.