### PR TITLE
Fix WPC GI Dimming

### DIFF
--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -16,6 +16,7 @@
 
 #define PRINT_GI_DATA      0 /* printf the GI Data for debugging purposes   */
 #define DEBUG_GI           0 /* debug GI code - more printf stuff basically */
+#define DEBUG_GI_W         0 /* debug GI write - even more printf stuff */
 #define WPC_FAST_FLIP      1
 #define WPC_VBLANKDIV      32/* This steers how precise the DMD FIRQ interrupt is (as it depends on the DMD_FIRQLINE) */
                              /* Best should be 64, but this leads to instability for some machines DMD (e.g. T2)      */
@@ -129,8 +130,9 @@ static struct {
   int firqSrc;            /* source of last firq */
   int diagnostic;
   int zc;                 /* zero cross flag */
-  int gi_irqcnt;          /* Count IRQ occurrences for GI Dimming */
-  int gi_active[CORE_MAXGI]; /* Used to check if GI string is accessed at all */
+  int gi_zc_state;        /* GI Triac state to be applied on next zero cross */
+  double last_zc_time;    /* Global time when last zero cross for GI Dimming was processed */
+  double gi_on_time[CORE_MAXGI]; /* Global time when when GI Triac was turned on */
   UINT32 solenoidbits[64];
   UINT32 modsol_seen_pulses;
   UINT8 modsol_seen_flip_pulses;
@@ -667,18 +669,47 @@ READ_HANDLER(wpc_r) {
 		//Zero cross detection flag is read from Bit 8.
 		wpc_data[offset] = (wpclocals.zc<<7) | (wpc_data[offset] & 0x7f);
 
-		//Track when Zero Cross occurred and reset gi irq counting
 		if(wpclocals.zc)
 		{
-			wpclocals.gi_irqcnt = 0;
+         // When ASIC receive a watchdog read with Zero Cross flag, it will reset the GI triac latch to the last value written to WPC_GILAMPS
+         // So we update the GI outputs with what we have seen so far, and prepare for next cycle
+         double zc_time = timer_get_time();
+         if (zc_time > wpclocals.last_zc_time)
+         {
+            for (int ii = 0,tmp= wpclocals.gi_zc_state; ii < CORE_MAXGI; ii++, tmp >>= 1) {
+               // On all known ROMs so far, GI Dimming is processed by the CPU during IRQ handling with IRQ being every ~1ms
+               // Zero cross detect on both +5V and -5V of AC. It leads to 120Hz in US (100Hz in Europa), therefore ~8.3ms period (would be ~10ms in Europa).
+               // Since zero cross and IRQ are not perfectly aligned, there can be either 8 or 9 irq per zero cross period in 60Hz countries (~1ms / ~8.3ms, this would be 9 or 10 in 50Hz countries ~1ms / ~10ms).
+               // The ratio of on/off pulse is computed using MAME global time instead of counting the IRQ since it appears easier
+               if (wpclocals.gi_on_time[ii] >= zc_time)
+                  coreGlobals.gi[ii] = 0;
+               else
+                  // The initial implementation would return values between 0 and 8, so we keep this scaling for backward compatibility
+                  // If there are 8 IRQ in a zerocross period, this results in 0 1 2 3 4 5 6 7 8 levels depending on when (which IRQ) the GI Triac was turned on
+                  // If there are 9 IRQ in a zerocross period, this results in 0 1 2 3 4 4 5 6 7 8 levels depending on when (which IRQ) the GI Triac was turned on
+                  coreGlobals.gi[ii] = (int)(0.5 + 8.0 * (1.0 - (wpclocals.gi_on_time[ii] - wpclocals.last_zc_time) / (zc_time - wpclocals.last_zc_time)));
+               // If Bit is set, Triac is turned on directly (for the complete AC period), otherwise we set it's turn on time far after the next zero cross.
+               if (tmp & 0x01)
+                  wpclocals.gi_on_time[ii] = zc_time;
+               else
+                  wpclocals.gi_on_time[ii] = zc_time + 100.0;
+            }
+         }
+         wpclocals.last_zc_time = zc_time;
 
 			#if DEBUG_GI
-			printf("Zero Cross!\n");
+			printf("[%8f] Zero Cross processed: ", timer_get_time());
+         {
+            int i;
+            for (i = 0; i < CORE_MAXGI; i++)
+               printf("GI[%d]=%d ", i, coreGlobals.gi[i]);
+            printf("\n");
+         }
 			#endif
-		}
-
-		//Reset flag now that it's been read.
-		wpclocals.zc = 0;
+         
+         //Reset flag now that it's been read.
+         wpclocals.zc = 0;
+      }
       break;
     case WPC_SOUNDIF:
       return sndbrd_0_data_r(0);
@@ -793,37 +824,34 @@ WRITE_HANDLER(wpc_w) {
         wpc_pic_w(data);
       break;
     case WPC_GILAMPS: {
-      int ii, tmp, gi_bit;
-
-	  #if DEBUG_GI
-	  printf("%8x: GI_W: %x\n",activecpu_get_pc(),data);
-	  #endif
+      int ii, tmp;
 
 	  //WPC95 only controls 3 of the 5 Triacs, the other 2 are ALWAYS ON (power wired directly)
 	  //  We simulate this here by forcing the bits on
 	  if (core_gameData->gen & GEN_WPC95)
-		  data = (data & 0xe7) | 0x18;
+		  data = data | 0x18;
+
+     // Save state for next zero cross GI output reset
+     wpclocals.gi_zc_state = data;
 
      //Loop over each GI Triac Bit
-      for (ii = 0,tmp=data; ii < CORE_MAXGI; ii++, tmp >>= 1) {
-        //If Bit is set, Triac is turned on.
-        gi_bit = tmp & 0x01;
-        if (gi_bit) {
-          if (wpclocals.gi_active[ii] == 2 + core_gameData->hw.gameSpecific1) { // if the bit was set last time as well, it's driven continuously.
-            coreGlobals.gi[ii] = 8; // seemingly no way to discern levels 7 & 8???
-          } else {
-            coreGlobals.gi[ii] = wpclocals.gi_irqcnt > 7 ? 0 : 7 - wpclocals.gi_irqcnt;
-          }
-          wpclocals.gi_active[ii] = 2 + core_gameData->hw.gameSpecific1;
-        } else {
-          if (wpclocals.gi_active[ii]) {
-            wpclocals.gi_active[ii]--;
-          } else { // wait two cycles before turning off for smoothing
-            coreGlobals.gi[ii] = 0;
-          }
-        }
-      }
-      break;
+     double write_time = timer_get_time();
+     for (ii = 0,tmp=data; ii < CORE_MAXGI; ii++, tmp >>= 1) {
+        // If Bit is set, Triac is turned on if it was not already on.
+        // We save irq number to compute dimming on next zero cross.
+        if ((tmp & 0x01) && write_time < wpclocals.gi_on_time[ii])
+           wpclocals.gi_on_time[ii] = write_time;
+     }
+
+     #if DEBUG_GI_W
+     printf("[%8f] GI_W PC=%4x, data=%2x > GI State/On time ", write_time, activecpu_get_pc(), data);
+     for (ii = 0, tmp = data; ii < CORE_MAXGI; ii++, tmp >>= 1) {
+        printf(" || GI[%d]=%d => %8f", ii, tmp & 0x01, wpclocals.gi_on_time[ii]);
+     }
+     printf("\n");
+     #endif
+
+     break;
     }
     case WPC_EXTBOARD1: /* WPC_ALPHAPOS */
       if (wpc_modsol_aux_board == 1)
@@ -896,7 +924,6 @@ WRITE_HANDLER(wpc_w) {
 	    //Only do this if bit 8 is set, as WW_L5 sometimes writes 0x06 here during the interrupt code.
 		if(data & 0x80)
 		{
-			wpclocals.gi_irqcnt++;
 			//Clear the IRQ now
 		  cpu_set_irq_line(WPC_CPUNO, M6809_IRQ_LINE, CLEAR_LINE);
 		}
@@ -1157,6 +1184,8 @@ static MACHINE_INIT(wpc) {
   cpu_setbank(6, memory_region(WPC_CPUREGION) + 0x3400);
   cpu_setbank(7, memory_region(WPC_CPUREGION) + 0x3600);
 
+  wpclocals.gi_zc_state = 0x00;
+
   switch (core_gameData->gen) {
     case GEN_WPCALPHA_1:
       sndbrd_0_init(SNDBRD_S11CS, 1, memory_region(S11CS_ROMREGION),NULL,NULL);
@@ -1173,11 +1202,18 @@ static MACHINE_INIT(wpc) {
     case GEN_WPC95:
 	  //WPC95 only controls 3 of the 5 Triacs, the other 2 are ALWAYS ON (power wired directly)
 	  //  We simulate this here by setting the bits to simulate full intensity immediately at power up.
+       wpclocals.gi_zc_state = 0x18;
 	  coreGlobals.gi[CORE_MAXGI-2] = 8;
 	  coreGlobals.gi[CORE_MAXGI-1] = 8;
     case GEN_WPC95DCS:
 	  //Sound board initialization
       sndbrd_0_init(core_gameData->gen == GEN_WPC95DCS ? SNDBRD_DCS : SNDBRD_DCS95, 1, memory_region(DCS_ROMREGION),NULL,NULL);
+  }
+  
+  // Reset GI dimming timers
+  wpclocals.last_zc_time = timer_get_time();
+  for (int ii = 0,tmp= wpclocals.gi_zc_state; ii < CORE_MAXGI; ii++, tmp >>= 1) {
+     wpclocals.gi_on_time[ii] = wpclocals.last_zc_time + (tmp & 0x01 ? 0 : 100);
   }
 
   wpclocals.pageMask = romLengthMask[((romLength>>17)-1)&0x07];


### PR DESCRIPTION
When working on Twilight Zone and Creature From The Black Lagoon, I had problem with getting correct GI dimming. I noted that other existing VPX versions of these tables (and lots of WPC others) have some hacks around the GI dimming.

After some investigation, it appears that there were 3 problems with the existing implementation:
- it would use the data written to the ASIC register, filtering some of it, this hack would work as long as only one GI line would be faded but fails when there are more than one.
- it was not able to evaluate between 7 and 8 out of the 8 PWM levels (full cycle or first IRQ write)
- it was very slightly incorrect regarding fading since it takes for granted that there are 8 IRQ per Zero Cross cycle, which is wrong: it's most of the time 8 but sometimes 9 (no noticeable effect, just to be exact).

After searching some more (mainly stepping through CFTBL and also reading FreeWPC implementation), I think that the implemented behavior was wrong. My understanding of the ASIC behavior is the following (and implemented in this PR):
- The ASIC has a Zero Cross latch which is turned on when the zero cross signal is received (120Hz in US, so a bit more than 8ms)
- When the ASIC receive a read command from the CPU on the WATCHDOG register and the Zero Cross latch is high, it will reset the GI triac outputs to a stored value (and also reset the Zero Cross latch)
- When the ASIC receive a write command from the CPU on the GI LAMP register, it will store the data for the next zero cross reset, but it will also raise up any output triac line for which the bit is set

This behavior is used by the CPU for dimming by  having a GI reset value at 0 (Read WATCHDOG with ZC), then rise up the GI line after a few IRQ (Write GI LAMP at 1), then prepare the ASIC for the next cycle by immediatly writing the GI line at 0 (Write GI LAMP at 0) which is not outputed until the next zero cross watchdog read.

The existing hack would skip the second write, which works when there is only 2 write in a zero cross cycle but would fail if there is more (for example 2 GI lines fading).

I made the PR to be backward compatible (outputs 0 to 8 level). I have tested it on CFTBL, TZ, T2 and MM. All looks fine but it is difficult to be absolutely sure.