### PR TITLE
libpinmame: use structs for change states, add support for SolMask, LEDs, and moduled solenoids

### DIFF
--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -14,11 +14,10 @@
 #define CALLBACK
 #endif
 
-#define MAX_PATH 512
-#define MAX_DISPLAYS 50
-#define MAX_MECHSW 20
-
-#define ACCUMULATOR_SAMPLES 8192 // from mixer.c
+#define PINMAME_MAX_VPM_PATH 512
+#define PINMAME_MAX_DISPLAYS 50
+#define PINMAME_MAX_MECHSW 20
+#define PINMAME_ACCUMULATOR_SAMPLES 8192 // from mixer.c
 
 typedef enum {
 	OK = 0,
@@ -30,7 +29,7 @@ typedef enum {
 	MECH_NO_INVALID = 6
 } PINMAME_STATUS;
 
-typedef enum : int {
+typedef enum {
 	AUDIO_FORMAT_INT16 = 0,
 	AUDIO_FORMAT_FLOAT = 1
 } PINMAME_AUDIO_FORMAT;
@@ -298,6 +297,32 @@ typedef struct {
 
 typedef struct {
 	int swNo;
+	int state;
+} PinmameSwitchState;
+
+typedef struct {
+	int solNo;
+	int state;
+} PinmameSolenoidState;
+
+typedef struct {
+	int lampNo;
+	int state;
+} PinmameLampState;
+
+typedef struct {
+	int giNo;
+	int state;
+} PinmameGIState;
+
+typedef struct {
+	int ledNo;
+	int chgSeg;
+	int state;
+} PinmameLEDState;
+
+typedef struct {
+	int swNo;
 	int startPos;
 	int endPos;
 	int pulse;
@@ -312,7 +337,7 @@ typedef struct {
 	int initialPos;
 	int acc;
 	int ret;
-	PinmameMechSwitchConfig sw[MAX_MECHSW];
+	PinmameMechSwitchConfig sw[PINMAME_MAX_MECHSW];
 } PinmameMechConfig;
 
 typedef struct {
@@ -337,14 +362,14 @@ typedef int (CALLBACK *PinmameOnAudioAvailableCallback)(PinmameAudioInfo* p_audi
 typedef int (CALLBACK *PinmameOnAudioUpdatedCallback)(void* p_buffer, int samples);
 typedef void (CALLBACK *PinmameOnMechAvailableCallback)(int mechNo, PinmameMechInfo* p_mechInfo);
 typedef void (CALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInfo* p_mechInfo);
-typedef void (CALLBACK *PinmameOnSolenoidUpdatedCallback)(int solenoid, int isActive);
+typedef void (CALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState);
 typedef void (CALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size);
 typedef int (CALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode);
 
 typedef struct {
 	const PINMAME_AUDIO_FORMAT audioFormat;
 	const int sampleRate;
-	const char vpmPath[MAX_PATH];
+	const char vpmPath[PINMAME_MAX_VPM_PATH];
 	PinmameOnStateUpdatedCallback cb_OnStateUpdated;
 	PinmameOnDisplayAvailableCallback cb_OnDisplayAvailable;
 	PinmameOnDisplayUpdatedCallback cb_OnDisplayUpdated;
@@ -364,19 +389,27 @@ LIBPINMAME_API int PinmameGetHandleKeyboard();
 LIBPINMAME_API void PinmameSetHandleKeyboard(const int handleKeyboard);
 LIBPINMAME_API int PinmameGetHandleMechanics();
 LIBPINMAME_API void PinmameSetHandleMechanics(const int handleMechanics);
+LIBPINMAME_API int PinmameGetUseModulatedSolenoids();
+LIBPINMAME_API void PinmameSetUseModulatedSolenoids(const int useModSol);
 LIBPINMAME_API PINMAME_STATUS PinmameRun(const char* const p_name);
 LIBPINMAME_API int PinmameIsRunning();
 LIBPINMAME_API PINMAME_STATUS PinmamePause(const int pause);
 LIBPINMAME_API PINMAME_STATUS PinmameReset();
 LIBPINMAME_API void PinmameStop();
 LIBPINMAME_API PINMAME_HARDWARE_GEN PinmameGetHardwareGen();
+LIBPINMAME_API uint64_t PinmameGetSolenoidMask();
+LIBPINMAME_API void PinmameSetSolenoidMask(const uint64_t mask);
 LIBPINMAME_API int PinmameGetSwitch(const int swNo);
 LIBPINMAME_API void PinmameSetSwitch(const int swNo, const int state);
-LIBPINMAME_API void PinmameSetSwitches(const int* const p_states, const int numSwitches);
+LIBPINMAME_API void PinmameSetSwitches(const PinmameSwitchState* const p_states, const int numSwitches);
+LIBPINMAME_API int PinmameGetMaxSolenoids();
+LIBPINMAME_API int PinmameGetChangedSolenoids(PinmameSolenoidState* const p_changedStates);
 LIBPINMAME_API int PinmameGetMaxLamps();
-LIBPINMAME_API int PinmameGetChangedLamps(int* const p_changedStates);
+LIBPINMAME_API int PinmameGetChangedLamps(PinmameLampState* const p_changedStates);
 LIBPINMAME_API int PinmameGetMaxGIs();
-LIBPINMAME_API int PinmameGetChangedGIs(int* const p_changedStates);
+LIBPINMAME_API int PinmameGetChangedGIs(PinmameGIState* constp_changedStates);
+LIBPINMAME_API int PinmameGetMaxLEDs();
+LIBPINMAME_API int PinmameGetChangedLEDs(const uint64_t mask, const uint64_t, PinmameLEDState* const p_changedStates);
 LIBPINMAME_API int PinmameGetMaxMechs();
 LIBPINMAME_API PINMAME_STATUS PinmameSetMech(const int mechNo, const PinmameMechConfig* const p_mechConfig);
 

--- a/src/libpinmame/test.cpp
+++ b/src/libpinmame/test.cpp
@@ -233,8 +233,8 @@ int CALLBACK OnAudioUpdated(void* p_buffer, int samples) {
 	return samples;
 }
 
-void CALLBACK OnSolenoidUpdated(int solenoid, int isActive) {
-	printf("OnSolenoidUpdated: solenoid=%d, isActive=%d\n", solenoid, isActive);
+void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState) {
+	printf("OnSolenoidUpdated: solenoid=%d, state=%d\n", p_solenoidState->solNo,  p_solenoidState->state);
 }
 
 void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
@@ -285,9 +285,9 @@ int main(int, char**) {
 	};
 
 	#if defined(_WIN32) || defined(_WIN64)
-		snprintf((char*)config.vpmPath, MAX_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
+		snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
 	#else
-		snprintf((char*)config.vpmPath, MAX_PATH, "%s/.pinmame/", getenv("HOME"));
+		snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s/.pinmame/", getenv("HOME"));
 	#endif
 
 	PinmameSetConfig(&config);

--- a/src/ppuc/ppuc.cpp
+++ b/src/ppuc/ppuc.cpp
@@ -407,9 +407,9 @@ int CALLBACK OnAudioUpdated(void* p_buffer, int samples) {
     return samples;
 }
 
-void CALLBACK OnSolenoidUpdated(int solenoid, int isActive) {
-    if (opt_debug) printf("OnSolenoidUpdated: solenoid=%d, isActive=%d\n", solenoid, isActive);
-    sendEvent(new Event(EVENT_SOURCE_SOLENOID, (UINT16) solenoid, (UINT8) isActive));
+void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState) {
+    if (opt_debug) printf("OnSolenoidUpdated: solenoid=%d, state=%d\n", p_solenoidState->solNo,  p_solenoidState->state);
+    sendEvent(new Event(EVENT_SOURCE_SOLENOID, (UINT16) p_solenoidState->solNo, (UINT8) p_solenoidState->state));
 }
 
 void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
@@ -526,9 +526,9 @@ int main (int argc, char *argv[]) {
     };
 
 #if defined(_WIN32) || defined(_WIN64)
-    snprintf((char*)config.vpmPath, MAX_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
+    snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
 #else
-    snprintf((char*)config.vpmPath, MAX_PATH, "%s/.pinmame/", getenv("HOME"));
+    snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s/.pinmame/", getenv("HOME"));
 #endif
 
 #if defined(SERUM_SUPPORT)
@@ -716,9 +716,9 @@ int main (int argc, char *argv[]) {
 
 #if defined(_WIN32) || defined(_WIN64)
     // Avoid compile error C2131. Use a larger constant value instead.
-    int changedLampStates[256];
+    PinmameLampState changedLampStates[256];
 #else
-    int changedLampStates[PinmameGetMaxLamps() * 2];
+    PinmameLampState changedLampStates[PinmameGetMaxLamps()];
 #endif
 
 	if (PinmameRun(opt_rom) == OK) {
@@ -763,8 +763,8 @@ int main (int argc, char *argv[]) {
 
             int count = PinmameGetChangedLamps(changedLampStates);
             for (int c = 0; c < count;) {
-                UINT16 lampNo = changedLampStates[c++];
-                UINT8 lampState = changedLampStates[c++] == 0 ? 0 : 1;
+                UINT16 lampNo = changedLampStates[c].lampNo;
+                UINT8 lampState = changedLampStates[c].state == 0 ? 0 : 1;
 
                 if (opt_debug) printf("Lamp updated: lampNo=%d, lampState=%d\n",
                        lampNo,

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -266,9 +266,7 @@ extern void video_update_core_dmd(struct mame_bitmap *bitmap, const struct recta
 #define CORE_FIRSTCUSTSOL  51
 #define CORE_FIRSTLFLIPSOL 45
 #define CORE_FIRSTSIMSOL   49
-#if defined(PROC_SUPPORT) || defined(LIBPINMAME)
 #define CORE_MAXSOL        64
-#endif
 
 #define CORE_SSFLIPENSOL  23
 #define CORE_FIRSTSSSOL   17
@@ -402,6 +400,7 @@ typedef struct {
   volatile UINT8  modulatedSolenoids[2][CORE_MODSOL_MAX];
   volatile UINT32 pulsedSolState;  /* current pulse value of solenoids on driver board */
   UINT64 lastSol;         /* last state of all solenoids */
+  UINT8 lastModSol[CORE_MODSOL_MAX];
   volatile int    gi[CORE_MAXGI];  /* WPC gi strings */
   int    simAvail;        /* simulator (keys) available */
   int    soundEn;         /* Sound enabled ? */

--- a/src/wpc/vpintf.h
+++ b/src/wpc/vpintf.h
@@ -13,9 +13,9 @@
 #endif
 
 typedef struct { int lampNo, currStat; } vp_tChgLamps[CORE_MAXLAMPCOL*8];
-typedef struct { int solNo,  currStat; } vp_tChgSols[64];
+typedef struct { int solNo,  currStat; } vp_tChgSols[CORE_MAXSOL + CORE_MODSOL_MAX];
 typedef struct { int giNo,   currStat; } vp_tChgGIs[CORE_MAXGI];
-typedef struct { int ledNo, chgSeg, currStat; } vp_tChgLED[128];
+typedef struct { int ledNo, chgSeg, currStat; } vp_tChgLED[CORE_SEGCOUNT];
 typedef struct { int sndNo; } vp_tChgSound[MAX_CMD_LOG];
 typedef struct { int nvramNo, oldStat, currStat; } vp_tChgNVRAMs[CORE_MAXNVRAM];
 


### PR DESCRIPTION
This PR makes the following updates to `libpinmame`:

- Adds support for `PinmameGetChangedLEDs`  (Some tables in VPinball use this to render alpha numeric displays)
- Adds support for `PinmameGetChangedSolenoids` (Useful if callback version is not wanted)
- Reworked some constants such as `PINMAME_MAX_VPM_PATH`  (Avoided cross platform collisions with `MAX_PATH`)
- Adds new state structs: `PinmameSolenoidState`, `PinmameLampState`, `PinmameGIState`, `PinmameLEDState`, and `PinmameSwitchState` (So we are not passing around arrays of `int`s and then magically indexing them)
- Adds support for getting and setting `SolMask` via `PinmameGetSolenoidMask` and `PinmameSetSolenoidMask`
- Adds support for returning modulated solenoids to `OnSolenoidUpdated` using `PinmameGetUseModulatedSolenoids` and `PinmameSetUseModulatedSolenoids`
- Updated `OnSolenoidUpdated` to receive a `PinmameSolenoidState` struct
- Updated `PinmameSetSwitches` to use new `PinmameSwitchState` struct