### PR TITLE
Add PWM with user selected output device PWM integrator

### DIFF
--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -951,7 +951,7 @@ STDMETHODIMP CController::get_ChangedSolenoidsState(int **buf, int *pVal)
 	if (uCount == 0)
 	{ *pVal = 0; return S_OK; }
 
-	/*-- add changed lamps to array --*/
+	/*-- add changed solenoids to array --*/
 	int *dst = reinterpret_cast<int*>(buf);
 	for (int i = 0; i < uCount; i++)
 	{
@@ -1514,7 +1514,7 @@ STDMETHODIMP CController::get_ChangedGIStrings(VARIANT *pVal) {
 /****************************************************************************
  * IController.ChangedSolenoids property (read-only): gets the state of all 
  * solenoids
- * (also gets the information, if at leats one solenoid has changed after 
+ * (also gets the information, if at least one solenoid has changed after 
  * last call; element 0 state if TRUE if at least one solenoid has changed 
  * state sice last call)
  ****************************************************************************/
@@ -1685,10 +1685,35 @@ STDMETHODIMP CController::get_SolMask(int nLow, long *pVal)
 
 STDMETHODIMP CController::put_SolMask(int nLow, long newVal)
 {
-	if ( (nLow<0) || (nLow>2) ) //TODO B2S hack, see vp_setSolMask()
+	// TODO B2S hack, see vp_setSolMask()
+	if (!((0 <= nLow && nLow <= 2) || (1000 <= nLow && nLow < 1999)))
 		return S_FALSE;
 
 	vp_setSolMask(nLow, newVal);
+
+	return S_OK;
+}
+
+/****************************************************************************
+ * IController.ModOutputType property: gets/sets modulated output type, i.e.
+ * how the output behaves when it is modulated
+ ****************************************************************************/
+STDMETHODIMP CController::get_ModOutputType(int output, int no, int* pVal)
+{
+	if (output != VP_OUT_SOLENOID)
+		return S_FALSE;
+
+	*pVal = vp_getModOutputType(output, no);
+
+	return S_OK;
+}
+
+STDMETHODIMP CController::put_ModOutputType(int output, int no, int newVal)
+{
+	if (output != VP_OUT_SOLENOID)
+		return S_FALSE;
+
+	vp_setModOutputType(output, no, newVal);
 
 	return S_OK;
 }

--- a/src/win32com/Controller.h
+++ b/src/win32com/Controller.h
@@ -200,6 +200,9 @@ public:
 	STDMETHOD(put_SoundMode)(/*[in]*/ int newVal);
 
 	STDMETHOD(get_ROMName)(/*[out, retval]*/ BSTR* pVal);
+
+	STDMETHOD(get_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[out, retval]*/ int* pVal);
+	STDMETHOD(put_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[in]*/ int newVal);
 };
 
 #endif // !defined(AFX_Controller_H__D2811491_40D6_4656_9AA7_8FF85FD63543__INCLUDED_)

--- a/src/win32com/VPinMAME.idl
+++ b/src/win32com/VPinMAME.idl
@@ -256,6 +256,8 @@ import "ocidl.idl";
 		[propget, id(86), helpstring("property SoundMode")] HRESULT SoundMode([out, retval] int *pVal);
 		[propput, id(86), helpstring("property SoundMode")] HRESULT SoundMode([in] int newVal);
 		[propget, id(87), helpstring("property ROMName")] HRESULT ROMName([out, retval] BSTR *pVal);
+		[propget, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [out, retval] int *pVal);
+		[propput, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [in] int newVal);
 	};
 
 	// WSHDlg and related interfaces

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -357,9 +357,26 @@ extern void video_update_core_dmd(struct mame_bitmap *bitmap, const struct recta
 #define LPURPLE     (COL_LAMP+7)
 
 /* Modulated solenoid array */
-#define CORE_MODSOL_CUR		0
-#define CORE_MODSOL_PREV	1
-#define CORE_MODSOL_MAX		68
+#define CORE_MODSOL_CUR		    0
+#define CORE_MODSOL_PREV	    1
+#define CORE_MODSOL_MAX		    68
+
+#define CORE_MODOUT_DEFAULT                0 /* Uses default driver modulated solenoid implementation */
+#define CORE_MODOUT_PWM_RATIO              1 /* pulse ratio over the last integration period, allow (approximated) device emulation by the calling app */
+#define CORE_MODOUT_BULB_44_6_3V_AC      100 /* Incandescent #44/555 Bulb connected to 6.3V, commonly used for GI */
+#define CORE_MODOUT_BULB_47_6_3V_AC      101 /* Incandescent #47 Bulb connected to 6.3V, commonly used for (darker) GI with less heat */
+#define CORE_MODOUT_BULB_86_6_3V_AC      102 /* Incandescent #86 Bulb connected to 6.3V, seldom use: TZ, CFTBL,... */
+#define CORE_MODOUT_BULB_44_18V_DC_WPC   201 /* Incandescent #44/555 Bulb connected to 18V, commonly used for lamp matrix with short strobing */
+#define CORE_MODOUT_BULB_44_18V_DC_GTS3  202 /* Incandescent #44/555 Bulb connected to 18V, commonly used for lamp matrix with short strobing */
+#define CORE_MODOUT_BULB_44_18V_DC_S11   203 /* Incandescent #44/555 Bulb connected to 18V, commonly used for lamp matrix with short strobing */
+#define CORE_MODOUT_BULB_89_20V_DC_WPC   301 /* Incandescent #89/906 Bulb connected to 12V, commonly used for flashers */
+#define CORE_MODOUT_BULB_89_20V_DC_GTS3  302 /* Incandescent #89/906 Bulb connected to 12V, commonly used for flashers */
+#define CORE_MODOUT_BULB_89_32V_DC_S11   303 /* Incandescent #89/906 Bulb connected to 32V, used for flashers on S11 with output strobing */
+#define CORE_MODOUT_LED                  400 /* LED PWM (in fact mostly human eye reaction, since LED are nearly instantaneous) */
+#define CORE_MODOUT_MOTOR_LINEAR         500 /* Linear integration for motor (like Twilight Zone clock). Note: evaluate PWM implementation for mech for this type of devices. */
+
+#define CORE_MODOUT_SAMPLE_MAX  256 /* Size of sampling history for PWM integration. Must be a power of 2 */
+
 
 /*-------------------------------------------
 /  Draw data. draw lamps,switches,solenoids
@@ -380,6 +397,20 @@ typedef struct {
   core_tLampData lamps[CORE_MAXLAMPCOL*8];      /*Can support up to 160 lamps!*/
 } core_tLampDisplay;
 
+typedef struct {
+   int type; /* Type of modulation from CORE_MODOUT_ definitions */
+   UINT8 value; /* Last computed output value */
+   union { /* Internal state of the output device, depending of its type */
+      struct
+      {
+         double filament_temperature;
+         double emission_history[16];
+         int emission_history_pos;
+      };
+      int motor_position;
+   } state;
+} core_tModulatedOutput;
+
 #define CORE_SEGCOUNT 128
 #ifdef LSB_FIRST
 typedef union { struct { UINT8 lo, hi; } b; UINT16 w; } core_tSeg[CORE_SEGCOUNT];
@@ -399,8 +430,17 @@ typedef struct {
   volatile UINT32 solenoids2;      /* flipper solenoids */
   volatile UINT8  modulatedSolenoids[2][CORE_MODSOL_MAX];
   volatile UINT32 pulsedSolState;  /* current pulse value of solenoids on driver board */
+  volatile UINT8 pulsedGIState;  /* current pulse value of WPC GI strings */
   UINT64 lastSol;         /* last state of all solenoids */
   UINT8 lastModSol[CORE_MODSOL_MAX];
+  double lastACZeroCross; /* Machine time of zero crossing (AC frequency is fixed at 60Hz) */
+  double pulsedOutStateSampleFreq; /* Frequency of output sampling */
+  int pulsedOutStateSamplePos; /* Current position of output sampling in the circular buffers */
+  UINT32 pulsedSolStateSamples[CORE_MODOUT_SAMPLE_MAX];  /* sample pulse value of all solenoids */
+  UINT8 pulsedGIStateSamples[CORE_MODOUT_SAMPLE_MAX];  /* sample pulse value of WPC gi strings */
+  int nModulatedOutputs;
+  int lastModulatedOutputIntegrationPos; /* Last sample index where modulated output integration was performed */
+  core_tModulatedOutput modulatedOutputs[CORE_MAXSOL + CORE_MAXGI + CORE_MAXLAMPCOL*8];
   volatile int    gi[CORE_MAXGI];  /* WPC gi strings */
   int    simAvail;        /* simulator (keys) available */
   int    soundEn;         /* Sound enabled ? */
@@ -437,7 +477,7 @@ typedef struct {
   } hw;
   const void *simData;
   struct { /* WPC specific stuff */
-    char serialNo[21];  /* Securty chip serial number */
+    char serialNo[21];  /* Security chip serial number */
     UINT8 invSw[CORE_MAXSWCOL]; /* inverted switches (e.g. optos) */
     /* common switches */
     struct { int start, tilt, sTilt, coinDoor, shooter; } comSw;
@@ -483,6 +523,18 @@ extern int core_getSol(int solNo);
 extern int core_getPulsedSol(int solNo);
 extern UINT64 core_getAllSol(void);
 
+/*-- PWM sampling, AC sync and integration --*/
+extern void core_perform_pwm_integration();
+INLINE void core_zero_cross() {
+   coreGlobals.lastACZeroCross = timer_get_time();
+}
+INLINE void core_store_pulsed_samples(double freq) {
+   coreGlobals.pulsedOutStateSampleFreq = freq;
+   coreGlobals.pulsedOutStateSamplePos++;
+   coreGlobals.pulsedSolStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedSolState;
+   coreGlobals.pulsedGIStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedGIState;
+}
+
 INLINE void core_update_modulated_light(UINT32 *light, int bit){
 	(*light) = (*light) << 1;
 	if (bit)
@@ -490,6 +542,8 @@ INLINE void core_update_modulated_light(UINT32 *light, int bit){
 }
 
 extern UINT8 core_calc_modulated_light(UINT32 bits, UINT32 bit_count, volatile UINT8 *prev_level);
+extern void core_perform_pwm_integration();
+
 extern void core_sound_throttle_adj(int sIn, int *sOut, int buffersize, double samplerate);
 
 /*-- nvram handling --*/

--- a/src/wpc/gts3.c
+++ b/src/wpc/gts3.c
@@ -385,6 +385,8 @@ static void GTS3_irq(int state) {
 	static int irq = 0;
 	cpu_set_irq_line(GTS3_CPUNO, 0, irq?ASSERT_LINE:CLEAR_LINE);
 	irq = !irq;
+	if (coreGlobals.nModulatedOutputs > 0)
+		core_store_pulsed_samples(GTS3_IRQFREQ);
 }
 
 /*

--- a/src/wpc/s11.c
+++ b/src/wpc/s11.c
@@ -100,6 +100,8 @@ static struct {
 
 static void s11_irqline(int state) {
   if (state) {
+    if (coreGlobals.nModulatedOutputs > 0)
+      core_store_pulsed_samples((int) S11_IRQFREQ);
     cpu_set_irq_line(0, M6808_IRQ_LINE, ASSERT_LINE);
     /*Set coin door inputs, differs between S11 & DE*/
     if (locals.deGame) {

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -196,14 +196,14 @@ int vp_getDIP(int dipBank) {
 void vp_setSolMask(int no, int mask) {
 	// TODO This is a bit of a B2S compatibility hack - B2S precludes us from adding a proper new setting,
 	// Therefore we use this setting for modulated and PWM settings, also see VPinMame Controller.put_SolMask()
-	if (1000 <= no && no < 1200)
-		// Map to solenoid output PWM settings
+	if (1001 <= no && no <= 1200)
+		// Map to solenoid output PWM settings (first solenoid is #1 to ...)
 		vp_setModOutputType(VP_OUT_SOLENOID, no - 1000, mask);
-	else if (1200 <= no && no < 1300)
-		// Map to GI output PWM settings
+	else if (1201 <= no && no <= 1300)
+		// Map to GI output PWM settings (first GI is #1 to #5)
 		vp_setModOutputType(VP_OUT_GI, no - 1200, mask);
-	else if (1300 <= no && no < 2000)
-		// Map to lamp output PWM settings
+	else if (1301 <= no && no <= 2000)
+		// Map to lamp output PWM settings (first lamp is #1 to ...)
 		vp_setModOutputType(VP_OUT_LAMP, no - 1300, mask);
 	else if (no == 2)
 		// Use index 2 to turn on/off modulated solenoids
@@ -224,7 +224,7 @@ UINT64 vp_getSolMask64(void) {
 }
 
 /*-----------
-/  set Output Modulation Type
+/  set Output Modulation Type ('no' starts at 1 upward, for example 1-5 for GI)
 /-----------*/
 void vp_setModOutputType(int output, int no, int type) {
 	// For the time being, the only supported output type is solenoid, but the API is designed to be 
@@ -232,11 +232,11 @@ void vp_setModOutputType(int output, int no, int type) {
 	if (coreGlobals.modulatedOutputs[no].type != type)
 	{
 		if (output == VP_OUT_SOLENOID)
-			coreGlobals.modulatedOutputs[no].type = type;
+			coreGlobals.modulatedOutputs[no - 1].type = type;
 		else if (output == VP_OUT_GI)
-			coreGlobals.modulatedOutputs[CORE_MAXSOL + no].type = type;
+			coreGlobals.modulatedOutputs[CORE_MAXSOL + no - 1].type = type;
 		else if (output == VP_OUT_LAMP)
-			coreGlobals.modulatedOutputs[CORE_MAXSOL + CORE_MAXGI + no].type = type;
+			coreGlobals.modulatedOutputs[CORE_MAXSOL + CORE_MAXGI + no - 1].type = type;
 		if (type == CORE_MODOUT_DEFAULT)
 			coreGlobals.nModulatedOutputs--;
 		else

--- a/src/wpc/vpintf.h
+++ b/src/wpc/vpintf.h
@@ -19,6 +19,11 @@ typedef struct { int ledNo, chgSeg, currStat; } vp_tChgLED[CORE_SEGCOUNT];
 typedef struct { int sndNo; } vp_tChgSound[MAX_CMD_LOG];
 typedef struct { int nvramNo, oldStat, currStat; } vp_tChgNVRAMs[CORE_MAXNVRAM];
 
+#define VP_OUT_SOLENOID          0 /* Solenoid output type */
+#define VP_OUT_LAMP              1 /* Lamp output type */
+#define VP_OUT_GI                2 /* Global Illumination output type */
+#define VP_OUT_LED               3 /* LED segment output type */
+
 #define VP_MAXDIPBANKS 10
 /*----------------------------------------------------
 / Switches/Lamps are numbered differently in WPCgames
@@ -100,6 +105,16 @@ void vp_setSolMask(int low, int mask);
 /  get Solenoid Mask
 /-----------*/
 int vp_getSolMask(int low);
+
+/*-----------
+/  set Output Modulation Type
+/-----------*/
+void vp_setModOutputType(int output, int no, int type);
+
+/*-----------
+/  get Output Modulation Type
+/-----------*/
+int vp_getModOutputType(int output, int no);
 
 /*-----------
 / Mechanics


### PR DESCRIPTION
Warning, this is a very lengthy PR comment since this PR contains a fairly complicated new feature that took me quite some time to (i hope) understand.

### Context

When I played with Twilight Zone, I stumbled upon 2 problems:
- GI simulation was (partly) broken and needed hacks
- Flashers were nice but dit not look true to the real table.

When I experimented with XMen, I had the same problem with (LED) flashers that I solved by pushing their power to unrealistic values but giving visually ok results. Lately, I played with CFTBL and the GI seemed broken needing hacks, and the flashers were not true to the real thing either. This added up with Guns'n Roses were flashers bulbs are directly visible to the player, and did not look about right.

After investigation, GI implementation in pinmame WPC only worked when a single light was dimmed. If more than one is dimmed at the same time, it woud break. So it was a controller emulation bug which is now (mostly) solved.

For the flashers, it is far more difficult and hence all the maths and tests made here. My understanding of the problem is the following:

### Pulse Width Modulation used in Pinball hardware as I understand it

PWM is used with Triac/Thyristor/Darlington Transistor driven outputs for :
- GI dimming (for example, WPC has 5 PWM outputs with modulation from 0 to 8 of a 8ms period)
- Flasher modulation (for example, WPC performs output switching at IRQ frequency ~1ms)
- Single coil solenoid to modulate between fire and hold strength or for progressive strength (Twilight zone shooter diverter for example)
- Shaker motor speed

The effect on a device of PWM is entirely different depending on the connected device and its physical characteristic.

For example, an incandescent bulb is a varying resistor with resistance depending on filament temperature. It has a non linear heating/cooling curve. We measured a specific 44 bulb to ramp up from <10% visible emission to >90% in around 37ms. Its behavior (light flow & color) depends on the filament temperature.

On the other hand, LEDs have more or less instantaneous switching time (below 1µs). Online ressources state that most humans will not perceive flashing on/off LED above 50 cycles per second (100Hz) as flicker/flashing but only its strobscopic effect (lik wheel not moving in a movie), below this it depends on each human, finally, around and under 10 cycles per second (20Hz) most people will see the LED as flashing.

So the frequency limits between flashing and dimming for these 2 type of lights will be different as well as their visible emission outputs.

Another example are solenoids or shaker motors where the time constant are fairly larger than for LED & incandescent bulbs.

One point to note is that the connected devices can vary for a given table (for example, some tables have been shipped with 44 incandescent bulbs, but may be ran with 47 in a custom version).

### Pinmame WPC PWM implementation

Pinmame WPC driver samples every 2 IRQ, then smooths lineary other the 28 samples. Therefore, the smoothing is performed over 56 IRQ, meaning every 56*8192/8000000 = 57,344ms (17 times per second).

This seems to work well for inductive outputs like solenoids but has a few drawbacks for others since it is not tied to the effective connected output device:
- Smoothing time constant is fixed (57ms), causing some fast effects targeted at fast devices (lights) to be visibly smoothed out (for example, Twilight Zone flashers),
- Smoothing is linear, causing an inaccurate response if the connected device does not have a linear behavior (incandescent bulbs for example),
- Update frequency is fixed (17 times per second) not corresponding to the connected device nor the simulation output (screen FPS, or DOF light), therefore causing synchronization artefacts.
- Update frequency can be too high for some fast effect to be correctly sampled (for example Creature From The Black Lagoon lights each ramp chase light in turn during 48 to 52 IRQ, causing miss or half lit lights to happen)

Each other driver implements a custom and different behavior.

### Proposed fix

To account for these, the overall implementation needs to be aware of the connected device and simulates its dedicated response on the effective output device. Therefore it needs to take in acount :
- The characteristics of the simulated device (incandescent bulb vs solenoid vs LED vs motor,… as well as intermediate electronics like voltage regulation,...)
- The characteristics of the user output device (like FPS & brightness for a screen output, or for physical bulb, shaker motor, solenoid, fan, etc. the characteristic of this hardware and its associated electronic driver).

3 ways for implementing it were investigated:
- Modify PinMame hardware driver to natively include the outputs and performs PWM integration.
- Allow client application (VPE, VPX, DOF,…) to access high frequency sampling of outputs and let them manage PWM,
- Allow client application to setup PWM integration inside PinMame

The first solution would need a large change of the code, with some challenge regarding backward compatibility, and would not solve the problem of taking in account the effective user output device, so it was not pursued. The second was initially attempted but was not satisfying for client application that access PinMame through low throughput communication (PPUC), it was not pursued either but the intent was (somewhat) kept for the proposed fix which is based on the third solution.

The proposed PR has the following features:
- Add the possibility to configure each output independently through a dedicated function vp_setModOutputType (also available through VPinMame SetSolMask to account for B2S support), setting it to one of the predefined output type. The default behavior being backward compatible.
- Add a (lightweight) method to store high frequency samples of outputs (limited to first 32 solenoids, 8 GI strings) that drivers must call from a suitable timer (like IRQ timer)
- Add predefined PWM integrators for a set of common use cases (see below)
- Trigger PSM integration when requested for changed outputs, and return the computed values as the state of the outputs

The PR rely on the following set of integrators:
- Default: just returns the same as before for backward compatibility
- Linear PWM: returns the duty cycle ratio (since last integration request) to allow a client application to implement its own custom integrator
- LED bulb:
  - Compute dimming by averageing the samples of the last 1/100s (so 10ms)
  - Returns the maximum of the (dimmed) intensities reached since last integration [not yet implemented]
- Incandescent bulbs:
  - Add an electrical & thermodynamic simplified model of a bulb to be able to dynamically compute the filament temperature
  - Add a set of predefined bulb common characteristics
  - Add a set of predefined electronic drivers (voltage level, AC/DC, serial resistor, switching electronic,…)
  - Compute dynamic filament temperature, derived instantaneous light emission power, then compute dimmed emission by averageing it other the last 16 computed values (for simplicity, would be better to use a fixed length likely around 10ms to stick to the 100Hz retina response)
  - Returns the maximum of the (dimmed) intensities reached since last integration

Regarding light integrators :
- Beside the bulb behavior (none for LEDs, filament & grey body for incandescent), a very simple empirical model of the eye is applied to account for the perceived dimming (averageing over 10ms) and retina persistance (maximum intensity over the integration period). This design supposes that the calls to get the changed values are aligned with the frequency at which they are presented to the user.
- The returned value is the visible emission power at the expected color (2700K for incandescent bulbs and pure white for LED). Two points are to be noted on that choice:
  - LED dimming is supposed to be linear, that is to say that the visible emission power is linear with PWM. This is slightly inexact and should be improved in the future.
  - Incandescent bulb emission power takes in account the color temperature variation when heating/cooling (i.e. 1500K results in a lower visible emission power than 2700K and this is already taken in account). This requires that if the client application performs light tinting depending on emission power, it must account for the color intensity ratio between 2700K black body color and the applied tint to avoid incorrect light intensity.

### How to use
The PR adds ModOutputType property to VPinMame Controller, but since it is usely accessed through B2S, it also extends SolMask property which is already used to setup modulated outputs:
- `Controller.SolMask(1000) = 301` will setup Solenoid 0 to use a 89 bulb wired like a flasher in a WPC system,
- `Controller.SolMask(1200) = 100` will setup GI 0 to use a 44 bulb wired to 6.3V AC.

### Bulbs characteristics and wiring
Here are some findings on bulbs characteristics and wiring that were used to design this fix. These are just observation and will vary from boards to boards but give some hints on how the different values were chosen.

| System/Table | Category | Bulb | Voltage | Comments |
|---|---|---|---|---|
| WPC/TZ, CFTBL, TOTAN | GI | 44/555 | 6.8V AC | Through SC141 Triac with Vtm=1.83V max voltage drop (likely around 0.5V drop to reach 6.3V bulb rating) |
| WPC/TZ, CFTBL, TOTAN | Lamps | 44/555 | 18V DC | switched through a TIP102 and a TIP107 (voltage drop supposed of 0.7V per semiconductor switch, datasheet states Vcesat=2V for I=3A) |
| WPC/TZ, CFTBL, TOTAN | Flashers | 89/906 | 20V DC | switched through a TIP102 (voltage drop supposed of 0.7V per semiconductor switch, datasheet states Vcesat=2V for I=3A) |
| S11/GNR | GI | 44/555 | 6.3V AC |  |
| S11/GNR | Lamps | 44/555 | 18V DC | 4.3 Ohms serial resistor |
| S11/GNR | Flashers | 89 | 32V DC | Connected through TIP122 (max 2 to 4V Vcesat), an optional serial diode (when output is switched with a coil), a 3 Ohms resistor (and a relay to switch from coils) |
| GTS3/CueBW | GI |  | 6V AC | Switched through relays |
| GTS3/CueBW | Lamps | 44/LEDs | 20V DC | Switched through MOSFETs (12P06 & 12N10L), serial 3,5 Ohms, then serie with 1N4004 voltage drop (1,1V) for bulbs / 120 Ohms with 1N4004 for LEDs | 
| GTS3/CueBW | Flasher | 67 | 20V DC | Serie with 0.33 Ohms resistor, switched by 12N10L (Mosfet, no voltage drop) | 
| Whitestar/Austin-LOTR | GI | 44 | 5.7 AC | Not investigated yet | 
| Whitestar/Austin-LOTR | Lamps |  | 18V DC | Not investigated yet. PWM needed for LOTR | 
| Whitestar/Austin-LOTR | Flasher |  | 20V DC | Not investigated yet. Connected through TIP122 (max 2 to 4V Vcesat) | 

### Example outputs
The graphics below are a plot of the PWM integration at 1ms (so not the one that would be rendered at 60FPS, therefore 16ms period). White lines are the output digital state, blue line is the PWM integration (44 & 89 bulbs).

Twilight zone has one of the most complex PWM diming light show I found so far. For example (during Clock Millions) with full power flasher pulse but also short low power ones (Sol 28), sequences of flashes of different power (Sol 19) or GI dimming waves:

![image](https://user-images.githubusercontent.com/2796036/213320244-a555dd59-043b-4282-817c-8aa41d2a4293.png)

Tales of the Arabian Night  also exhibits some complex dimming, like the genie flasher which is constantly slowly pulsed at mid power (Sol 25) or waves of GI fading when skillshot is succeeded like below:

![image](https://user-images.githubusercontent.com/2796036/213320177-eee21e73-5c29-4cbf-b78c-b1656e9ce585.png)
