### PR TITLE
Improve new PWM integration

### DIFF
--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -2324,7 +2324,7 @@ void core_perform_output_pwm_integration(core_tModulatedOutput* output, int nSam
 void core_perform_pwm_integration()
 {
    int nSamples = coreGlobals.pulsedOutStateSamplePos - coreGlobals.lastModulatedOutputIntegrationPos;
-   if (coreGlobals.nModulatedOutputs > 0 && coreGlobals.pulsedOutStateSampleFreq > 0 && nSamples > 0)
+   if (coreGlobals.pulsedOutStateSampleFreq > 0 && nSamples > 0)
    {
       for (int ii = 0; ii < CORE_MODOUT_SOL_MAX; ii++)
       {

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -2159,7 +2159,7 @@ void core_perform_output_pwm_integration(core_tModulatedOutput* output, int nSam
          serial_R = 0.22; // From schematics (TZ, TOTAN, CFTBL, WPC95 general)
          break;
       case CORE_MODOUT_BULB_44_18V_DC_GTS3:
-         U = 18 - 1.1; // 18V switched through a Mosfets 12P06 & 12N10L, 1N4004 serial (1.1V voltage drop from datasheet)
+         U = 18 - 1.1; // Switched through MOSFETs (12P06 & 12N10L), serial 3,5 Ohms, then serie with 1N4004 voltage drop (1,1V) for bulbs / 120 Ohms with 1N4004 for LEDs
          serial_R = 3.5; // From schematics (Cue Ball Wizard)
          break;
       case CORE_MODOUT_BULB_44_18V_DC_S11:
@@ -2288,8 +2288,31 @@ void core_perform_output_pwm_integration(core_tModulatedOutput* output, int nSam
    break;
    case CORE_MODOUT_DEFAULT:
    default:
-      // Default is the modulated solenoid values as computed by each hardware drivers (nothing to do here since the integration is already performed)
-      break;
+   {
+      // Default is the modulated solenoid values as computed by each hardware drivers if implemented or the non modulated value
+      int index = ((UINT8*)output - (UINT8*)&coreGlobals.modulatedOutputs) / sizeof(core_tModulatedOutput);
+      if (index < CORE_MODOUT_SOL_MAX)
+      {
+         // For the time being, only GTS3 and WPC have modulated solenoids direclty implemented in the driver
+         if ((core_gameData->gen & (GEN_ALLWPC | GEN_GTS3)) && options.usemodsol)
+            output->value = coreGlobals.modulatedSolenoids[CORE_MODSOL_CUR][index];
+         else
+            output->value = core_getSol(index + 1);
+      }
+      else if (index < CORE_MODOUT_SOL_MAX + CORE_MODOUT_GI_MAX)
+      {
+         // WPC & Data East drivers write the GI state in this array, others will be at 0 (no dedicated GI output)
+         output->value = coreGlobals.gi[index - CORE_MODOUT_SOL_MAX];
+      }
+      else if (index < CORE_MODOUT_SOL_MAX + CORE_MODOUT_GI_MAX + CORE_MODOUT_LAMP_MAX)
+      {
+         // TODO preliminary implementation, untested since Lamps are not yet supported
+         int row = (index - CORE_MODOUT_SOL_MAX + CORE_MODOUT_GI_MAX) >> 8;
+         int col = (index - CORE_MODOUT_SOL_MAX + CORE_MODOUT_GI_MAX) & 0x7;
+         output->value = coreGlobals.lampMatrix[row] & (1 << col);
+      }
+   }
+   break;
    }
 }
 
@@ -2301,14 +2324,15 @@ void core_perform_output_pwm_integration(core_tModulatedOutput* output, int nSam
 void core_perform_pwm_integration()
 {
    int nSamples = coreGlobals.pulsedOutStateSamplePos - coreGlobals.lastModulatedOutputIntegrationPos;
+   if (coreGlobals.nModulatedOutputs > 0 && coreGlobals.pulsedOutStateSampleFreq > 0 && nSamples > 0)
    {
-      for (int ii = 0; ii < 32 /*CORE_MAXSOL*/; ii++) // We only store the state of the first 32 solenoids
+      for (int ii = 0; ii < CORE_MODOUT_SOL_MAX; ii++)
       {
          core_perform_output_pwm_integration(&coreGlobals.modulatedOutputs[ii], nSamples, ((UINT8*)coreGlobals.pulsedSolStateSamples) + (ii >> 3), ii & 7, 4);
       }
-      for (int ii = 0; ii < CORE_MAXGI; ii++)
+      for (int ii = 0; ii < CORE_MODOUT_GI_MAX; ii++)
       {
-         core_perform_output_pwm_integration(&coreGlobals.modulatedOutputs[CORE_MAXSOL + ii], nSamples, (UINT8*)coreGlobals.pulsedGIStateSamples, ii, 1);
+         core_perform_output_pwm_integration(&coreGlobals.modulatedOutputs[CORE_MODOUT_SOL_MAX + ii], nSamples, (UINT8*)coreGlobals.pulsedGIStateSamples, ii, 1);
       }
    }
    coreGlobals.lastModulatedOutputIntegrationPos = coreGlobals.pulsedOutStateSamplePos;

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -529,13 +529,17 @@ extern UINT64 core_getAllSol(void);
 /*-- PWM sampling, AC sync and integration --*/
 extern void core_perform_pwm_integration();
 INLINE void core_zero_cross() {
-   coreGlobals.lastACZeroCross = timer_get_time();
+   if (coreGlobals.nModulatedOutputs > 0)
+      coreGlobals.lastACZeroCross = timer_get_time();
 }
 INLINE void core_store_pulsed_samples(double freq) {
-   coreGlobals.pulsedOutStateSampleFreq = freq;
-   coreGlobals.pulsedOutStateSamplePos++;
-   coreGlobals.pulsedSolStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedSolState;
-   coreGlobals.pulsedGIStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedGIState;
+   if (coreGlobals.nModulatedOutputs > 0)
+   {
+      coreGlobals.pulsedOutStateSampleFreq = freq;
+      coreGlobals.pulsedOutStateSamplePos++;
+      coreGlobals.pulsedSolStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedSolState;
+      coreGlobals.pulsedGIStateSamples[coreGlobals.pulsedOutStateSamplePos & (CORE_MODOUT_SAMPLE_MAX - 1)] = coreGlobals.pulsedGIState;
+   }
 }
 
 INLINE void core_update_modulated_light(UINT32 *light, int bit){

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -375,6 +375,9 @@ extern void video_update_core_dmd(struct mame_bitmap *bitmap, const struct recta
 #define CORE_MODOUT_LED                  400 /* LED PWM (in fact mostly human eye reaction, since LED are nearly instantaneous) */
 #define CORE_MODOUT_MOTOR_LINEAR         500 /* Linear integration for motor (like Twilight Zone clock). Note: evaluate PWM implementation for mech for this type of devices. */
 
+#define CORE_MODOUT_SOL_MAX      32 /* Maximum number of modulated outputs for solenoids */
+#define CORE_MODOUT_GI_MAX        5 /* Maximum number of modulated outputs for GI */
+#define CORE_MODOUT_LAMP_MAX      0 /* Maximum number of modulated outputs for lamps (not yet implemented, so 0 for now) */
 #define CORE_MODOUT_SAMPLE_MAX  256 /* Size of sampling history for PWM integration. Must be a power of 2 */
 
 
@@ -440,7 +443,7 @@ typedef struct {
   UINT8 pulsedGIStateSamples[CORE_MODOUT_SAMPLE_MAX];  /* sample pulse value of WPC gi strings */
   int nModulatedOutputs;
   int lastModulatedOutputIntegrationPos; /* Last sample index where modulated output integration was performed */
-  core_tModulatedOutput modulatedOutputs[CORE_MAXSOL + CORE_MAXGI + CORE_MAXLAMPCOL*8];
+  core_tModulatedOutput modulatedOutputs[CORE_MODOUT_SOL_MAX + CORE_MODOUT_GI_MAX + CORE_MODOUT_LAMP_MAX];
   volatile int    gi[CORE_MAXGI];  /* WPC gi strings */
   int    simAvail;        /* simulator (keys) available */
   int    soundEn;         /* Sound enabled ? */

--- a/src/wpc/gts3.c
+++ b/src/wpc/gts3.c
@@ -382,11 +382,10 @@ static WRITE_HANDLER( xvia_1_cb2_w ) {
 //IRQ:  IRQ to Main CPU
 static void GTS3_irq(int state) {
 	// logerror("IN VIA_IRQ - STATE = %x\n",state);
+	core_store_pulsed_samples(GTS3_IRQFREQ);
 	static int irq = 0;
 	cpu_set_irq_line(GTS3_CPUNO, 0, irq?ASSERT_LINE:CLEAR_LINE);
 	irq = !irq;
-	if (coreGlobals.nModulatedOutputs > 0)
-		core_store_pulsed_samples(GTS3_IRQFREQ);
 }
 
 /*

--- a/src/wpc/s11.c
+++ b/src/wpc/s11.c
@@ -100,8 +100,7 @@ static struct {
 
 static void s11_irqline(int state) {
   if (state) {
-    if (coreGlobals.nModulatedOutputs > 0)
-      core_store_pulsed_samples((int) S11_IRQFREQ);
+    core_store_pulsed_samples((int) S11_IRQFREQ);
     cpu_set_irq_line(0, M6808_IRQ_LINE, ASSERT_LINE);
     /*Set coin door inputs, differs between S11 & DE*/
     if (locals.deGame) {

--- a/src/wpc/sam.c
+++ b/src/wpc/sam.c
@@ -1572,10 +1572,12 @@ static NVRAM_HANDLER(sam) {
 static void sam_timer(int data)
 {
 	samlocals.zc = !samlocals.zc;
+	core_zero_cross();
 }
 
 static INTERRUPT_GEN(sam_irq)
 {
+	core_store_pulsed_samples(SAM_IRQFREQ);
 	at91_fire_irq(AT91_FIQ_IRQ);
 }
 

--- a/src/wpc/se.c
+++ b/src/wpc/se.c
@@ -91,6 +91,15 @@ struct {
 #ifdef PROC_SUPPORT
 static int switches_retrieved=0;
 #endif
+
+/*-------------------------
+/  Generate IRQ interrupt
+/--------------------------*/
+static INTERRUPT_GEN(se_irq) {
+   core_store_pulsed_samples(SE_FIRQFREQ);
+   irq1_line_pulse();
+}
+
 static INTERRUPT_GEN(se_vblank) {
   /*-------------------------------
   /  copy local data to interface
@@ -840,7 +849,7 @@ static MACHINE_DRIVER_START(se)
   MDRV_CORE_INIT_RESET_STOP(se,NULL,se)
   MDRV_CPU_MEMORY(se_readmem, se_writemem)
   MDRV_CPU_VBLANK_INT(se_vblank, VBLANK)
-  MDRV_CPU_PERIODIC_INT(irq1_line_pulse, SE_FIRQFREQ)
+  MDRV_CPU_PERIODIC_INT(se_irq, SE_FIRQFREQ)
   MDRV_NVRAM_HANDLER(se)
   MDRV_DIPS(8)
   MDRV_SWITCH_UPDATE(se)
@@ -878,7 +887,7 @@ MACHINE_DRIVER_START(se3aS)
   MDRV_CORE_INIT_RESET_STOP(se3,NULL,se)
   MDRV_CPU_MEMORY(se_readmem, se_writemem)
   MDRV_CPU_VBLANK_INT(se_vblank, VBLANK)
-  MDRV_CPU_PERIODIC_INT(irq1_line_pulse, SE_FIRQFREQ)
+  MDRV_CPU_PERIODIC_INT(se_irq, SE_FIRQFREQ)
   MDRV_NVRAM_HANDLER(se)
   MDRV_DIPS(8)
   MDRV_SWITCH_UPDATE(se)

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -1044,8 +1044,7 @@ static void wpc_pic_w(int data) {
 /  Generate IRQ interrupt
 /--------------------------*/
 static INTERRUPT_GEN(wpc_irq) {
-   if (coreGlobals.nModulatedOutputs > 0)
-      core_store_pulsed_samples(WPC_IRQFREQ);
+   core_store_pulsed_samples(WPC_IRQFREQ);
 #ifdef WPC_MODSOLSAMPLE
 	if (options.usemodsol)
 	{


### PR DESCRIPTION
This PR:
- fix when PWM integration is used with a system that does not have modulated solenoids implemented,
- add support for WhiteStar and SAM
- performs a few cleanups

S11 is tested and fully working (with a full table configured with these new PWM outputs). Whitestar was tested with the graphic analyzer and seems good. SAM was also tested with the graphic analyzer and looks good but, perhaps, more testing for SAM (with a full table) could be interesting since the integration frequency is fairly different (4kHz instead of 1kHz for other systems)