### PR TITLE
Improve Incandescent Bulb model

### DIFF
--- a/LibPinMAME_VC2015.vcxproj
+++ b/LibPinMAME_VC2015.vcxproj
@@ -964,6 +964,7 @@
     <ClCompile Include="src\wpc\boomerang.c" />
     <ClCompile Include="src\wpc\bowarrow.c" />
     <ClCompile Include="src\wpc\bowlgames.c" />
+    <ClCompile Include="src\wpc\bulb.c" />
     <ClCompile Include="src\wpc\by35.c" />
     <ClCompile Include="src\wpc\by35games.c" />
     <ClCompile Include="src\wpc\by35snd.c" />
@@ -1292,6 +1293,7 @@
     <ClInclude Include="src\wpc\alvgdmd.h" />
     <ClInclude Include="src\wpc\alvgs.h" />
     <ClInclude Include="src\wpc\atari.h" />
+    <ClInclude Include="src\wpc\bulb.h" />
     <ClInclude Include="src\wpc\by35.h" />
     <ClInclude Include="src\wpc\by35snd.h" />
     <ClInclude Include="src\wpc\by6803.h" />

--- a/LibPinMAME_VC2015.vcxproj.filters
+++ b/LibPinMAME_VC2015.vcxproj.filters
@@ -654,6 +654,9 @@
     <ClCompile Include="src\wpc\bowlgames.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
+    <ClCompile Include="src\wpc\bulb.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
     <ClCompile Include="src\wpc\by35.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
@@ -1662,6 +1665,9 @@
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\atari.h">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClInclude>
+    <ClInclude Include="src\wpc\bulb.h">
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\by35.h">

--- a/PinMAME32_VC2008.vcproj
+++ b/PinMAME32_VC2008.vcproj
@@ -3556,6 +3556,14 @@
 					>
 				</File>
 				<File
+					RelativePath=".\src\wpc\bulb.c"
+					>
+				</File>
+				<File
+					RelativePath=".\src\wpc\bulb.h"
+					>
+				</File>
+				<File
 					RelativePath=".\src\wpc\by35.c"
 					>
 				</File>

--- a/PinMAME32_VC2012.vcxproj
+++ b/PinMAME32_VC2012.vcxproj
@@ -1295,6 +1295,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile Include="src\wpc\boomerang.c" />
     <ClCompile Include="src\wpc\bowarrow.c" />
     <ClCompile Include="src\wpc\bowlgames.c" />
+    <ClCompile Include="src\wpc\bulb.c" />
     <ClCompile Include="src\wpc\by35.c" />
     <ClCompile Include="src\wpc\by35games.c" />
     <ClCompile Include="src\wpc\by35snd.c" />
@@ -1658,6 +1659,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClInclude Include="src\wpc\alvgdmd.h" />
     <ClInclude Include="src\wpc\alvgs.h" />
     <ClInclude Include="src\wpc\atari.h" />
+    <ClInclude Include="src\wpc\bulb.h" />
     <ClInclude Include="src\wpc\by35.h" />
     <ClInclude Include="src\wpc\by35snd.h" />
     <ClInclude Include="src\wpc\by6803.h" />

--- a/PinMAME32_VC2012.vcxproj.filters
+++ b/PinMAME32_VC2012.vcxproj.filters
@@ -711,6 +711,9 @@
     <ClCompile Include="src\wpc\bowlgames.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
+    <ClCompile Include="src\wpc\bulb.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
     <ClCompile Include="src\wpc\by35.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
@@ -1815,6 +1818,9 @@
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\atari.h">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClInclude>
+    <ClInclude Include="src\wpc\bulb.h">
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\by35.h">

--- a/PinMAME_VC2008.vcproj
+++ b/PinMAME_VC2008.vcproj
@@ -3546,6 +3546,14 @@
 					>
 				</File>
 				<File
+					RelativePath=".\src\wpc\bulb.c"
+					>
+				</File>
+				<File
+					RelativePath=".\src\wpc\bulb.h"
+					>
+				</File>
+				<File
 					RelativePath=".\src\wpc\by35.c"
 					>
 				</File>

--- a/PinMAME_VC2012.vcxproj
+++ b/PinMAME_VC2012.vcxproj
@@ -1273,6 +1273,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile Include="src\wpc\boomerang.c" />
     <ClCompile Include="src\wpc\bowarrow.c" />
     <ClCompile Include="src\wpc\bowlgames.c" />
+    <ClCompile Include="src\wpc\bulb.c" />
     <ClCompile Include="src\wpc\by35.c" />
     <ClCompile Include="src\wpc\by35games.c" />
     <ClCompile Include="src\wpc\by35snd.c" />
@@ -1613,6 +1614,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClInclude Include="src\wpc\alvgdmd.h" />
     <ClInclude Include="src\wpc\alvgs.h" />
     <ClInclude Include="src\wpc\atari.h" />
+    <ClInclude Include="src\wpc\bulb.h" />
     <ClInclude Include="src\wpc\by35.h" />
     <ClInclude Include="src\wpc\by35snd.h" />
     <ClInclude Include="src\wpc\by6803.h" />

--- a/PinMAME_VC2012.vcxproj.filters
+++ b/PinMAME_VC2012.vcxproj.filters
@@ -705,6 +705,9 @@
     <ClCompile Include="src\wpc\bowlgames.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
+    <ClCompile Include="src\wpc\bulb.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
     <ClCompile Include="src\wpc\by35.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
@@ -1740,6 +1743,9 @@
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\atari.h">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClInclude>
+    <ClInclude Include="src\wpc\bulb.h">
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\by35.h">

--- a/VPinMAME_VC2008.vcproj
+++ b/VPinMAME_VC2008.vcproj
@@ -3561,6 +3561,14 @@
 					>
 				</File>
 				<File
+					RelativePath=".\src\wpc\bulb.c"
+					>
+				</File>
+				<File
+					RelativePath=".\src\wpc\bulb.h"
+					>
+				</File>
+				<File
 					RelativePath=".\src\wpc\by35.c"
 					>
 				</File>

--- a/VPinMAME_VC2012.vcxproj
+++ b/VPinMAME_VC2012.vcxproj
@@ -1402,6 +1402,7 @@ echo regsvr32 exec. time &gt; "$(OutDir)regsvr32.trg"
     <ClCompile Include="src\wpc\boomerang.c" />
     <ClCompile Include="src\wpc\bowarrow.c" />
     <ClCompile Include="src\wpc\bowlgames.c" />
+    <ClCompile Include="src\wpc\bulb.c" />
     <ClCompile Include="src\wpc\by35.c" />
     <ClCompile Include="src\wpc\by35games.c" />
     <ClCompile Include="src\wpc\by35snd.c" />
@@ -1767,6 +1768,7 @@ echo regsvr32 exec. time &gt; "$(OutDir)regsvr32.trg"
     <ClInclude Include="src\wpc\alvgdmd.h" />
     <ClInclude Include="src\wpc\alvgs.h" />
     <ClInclude Include="src\wpc\atari.h" />
+    <ClInclude Include="src\wpc\bulb.h" />
     <ClInclude Include="src\wpc\by35.h" />
     <ClInclude Include="src\wpc\by35snd.h" />
     <ClInclude Include="src\wpc\by6803.h" />

--- a/VPinMAME_VC2012.vcxproj.filters
+++ b/VPinMAME_VC2012.vcxproj.filters
@@ -719,6 +719,9 @@
     <ClCompile Include="src\wpc\bowlgames.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
+    <ClCompile Include="src\wpc\bulb.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
     <ClCompile Include="src\wpc\by35.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
@@ -1823,6 +1826,9 @@
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\atari.h">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClInclude>
+    <ClInclude Include="src\wpc\bulb.h">
       <Filter>Source Files\PinMAME</Filter>
     </ClInclude>
     <ClInclude Include="src\wpc\by35.h">

--- a/cmake/libpinmame/CMakeLists_android-arm64-v8a.txt
+++ b/cmake/libpinmame/CMakeLists_android-arm64-v8a.txt
@@ -362,6 +362,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_ios-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_ios-arm64.txt
@@ -373,6 +373,8 @@ add_library(pinmame STATIC
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/libpinmame/CMakeLists_linux-x64.txt
@@ -357,6 +357,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_osx-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-arm64.txt
@@ -356,6 +356,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-x64.txt
@@ -356,6 +356,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_win-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_win-arm64.txt
@@ -371,6 +371,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_win-x64.txt
+++ b/cmake/libpinmame/CMakeLists_win-x64.txt
@@ -371,6 +371,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/libpinmame/CMakeLists_win-x86.txt
+++ b/cmake/libpinmame/CMakeLists_win-x86.txt
@@ -372,6 +372,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -373,6 +373,8 @@ add_executable(pinmame WIN32
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -380,6 +380,8 @@ add_executable(pinmame WIN32
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -379,6 +379,8 @@ add_executable(pinmame32 WIN32
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -383,6 +383,8 @@ add_executable(pinmame32 WIN32
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/ppuc/CMakeLists_linux-arm64.txt
+++ b/cmake/ppuc/CMakeLists_linux-arm64.txt
@@ -358,6 +358,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/ppuc/CMakeLists_linux-x64.txt
+++ b/cmake/ppuc/CMakeLists_linux-x64.txt
@@ -358,6 +358,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/ppuc/CMakeLists_osx-x64.txt
+++ b/cmake/ppuc/CMakeLists_osx-x64.txt
@@ -356,6 +356,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/ppuc/CMakeLists_win-x64.txt
+++ b/cmake/ppuc/CMakeLists_win-x64.txt
@@ -372,6 +372,8 @@ add_library(pinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -378,6 +378,8 @@ add_library(vpinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -382,6 +382,8 @@ add_library(vpinmame SHARED
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -366,6 +366,8 @@ add_executable(xpinmame
    src/wpc/boomerang.c
    src/wpc/bowarrow.c
    src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
    src/wpc/by35.c
    src/wpc/by35.h
    src/wpc/by35games.c

--- a/src/pinmame.mak
+++ b/src/pinmame.mak
@@ -19,7 +19,7 @@ TOOLS=
 #
 DRVLIBS = $(PINOBJ)/sim.o $(PINOBJ)/core.o $(OBJ)/allgames.a
 DRVLIBS += $(PINOBJ)/vpintf.o $(PINOBJ)/snd_cmd.o $(PINOBJ)/wpcsam.o
-DRVLIBS += $(PINOBJ)/sndbrd.o
+DRVLIBS += $(PINOBJ)/sndbrd.o $(PINOBJ)/bulb.o 
 DRVLIBS += $(OBJ)/machine/4094.o
 DRVLIBS += $(OBJ)/sound/wavwrite.o
 

--- a/src/wpc/bulb.c
+++ b/src/wpc/bulb.c
@@ -1,0 +1,182 @@
+// license:GPLv3+
+
+#include <math.h>
+#include "bulb.h"
+
+
+/*-------------------
+/  Bulb characteristics and precomputed LUTs
+/-------------------*/
+typedef struct {
+  double surface; /* filament surface in m² */
+  double mass;	/* filament mass in kg */
+  double r0; /* resistance at 293K */
+  double cool_down[3000]; /* precomputed cool down factor */
+  double heat_factor[3000]; /* precomputed heat factor = 1.0 / (R * Mass * Specific Heat) */
+} bulb_tLampCharacteristics;
+
+/*-------------------
+/  local variables
+/-------------------*/
+static struct {
+  double                      t_to_p[1500];
+  double                      p_to_t[512];
+  double                      specific_heat[3000];
+} locals;
+
+bulb_tLampCharacteristics bulbs[BULB_MAX] = {
+   { 0.000001549619403110030, 0.000000203895434417560, 1.70020865326503000 }, // #44 Bulb characteristics (6.3V, 250mA, 1.26W, 5lm)
+   { 0.000000929872857822516, 0.000000087040748856477, 2.83368108877505000 }, // #47 Bulb characteristics (6.3V, 150mA, 0.95W, 6.3lm)
+   { 0.000001239604749734440, 0.000000140555683560514, 2.12526081658129000 }, // #86 Bulb characteristics (6.3V, 200mA, 1.58W, 11.3lm)
+   { 0.000007413493071564570, 0.000001709095572478890, 1.51222718202281000 }, // #89 Bulb characteristics (13V, 580mA, 7.54W, 75.4lm)
+};
+
+/*-------------------------------
+/  Initialize all pre-computed LUTs
+/-------------------------------*/
+void bulb_init()
+{
+   // Compute filament temperature to visible emission power LUT, normalized by visible emission power at T=2700K, according 
+   // to the formula from "Luminous radiation from a black body and the mechanical equivalentt of light" by W.W.Coblentz and W.B.Emerson
+   for (int i=0; i<1500; i++)
+   {
+      double T = 1500.0 + i;
+      locals.t_to_p[i] = 1.247/pow(1.0+129.05/T, 204.0) + 0.0678/pow(1.0+78.85/T, 404.0) + 0.0489/pow(1.0+23.52/T, 1004.0) + 0.0406/pow(1.0+13.67/T, 2004.0);
+   }
+   double P2700 = locals.t_to_p[2700 - 1500];
+   for (int i=0; i<1500; i++)
+   {
+      locals.t_to_p[i] /= P2700;
+   }
+   // Compute visible emission power to filament temperature LUT, normalized for a relative power of 255 for visible emission power at T=2700K
+   // For the time being we simply search in the previously created LUT
+   int t_pos = 0;
+   for (int i=0; i<512; i++)
+   {
+      double p = i / 255.0;
+      while (locals.t_to_p[t_pos] < p)
+         t_pos++;
+      locals.p_to_t[i] = 1500 + t_pos;
+   }
+   for (int i=0; i<3000; i++)
+   {
+      double T = i;
+      // Compute Tungsten specific heat (energy to temperature transfer, depending on temperature) according to forumla from "Heating-times of tungsten filament incandescent lamps" by Dulli Chandra Agrawal
+      locals.specific_heat[i] = 3.0 * 45.2268 * (1.0 - 310.0 * 310.0 / (20.0 * T*T)) + (2.0 * 0.0045549 * T) + (4 * 0.000000000577874 * T*T*T);
+      // Compute cooldown and heat up factor for the predefined bulbs
+      for (int j=0; j<BULB_MAX; j++)
+      {
+         // pow(T, 5.0796) is pow(T, 4) from Stefan/Boltzmann multiplied by tungsten overall (all wavelengths) emissivity which is 0.0000664*pow(T,1.0796)
+         double delta_energy = -0.00000005670374419 * bulbs[j].surface * 0.0000664 * pow(T, 5.0796);
+         bulbs[j].cool_down[i] = delta_energy / (locals.specific_heat[i] * bulbs[j].mass);
+         bulbs[j].heat_factor[i] = 1.0 / (bulbs[j].r0 * pow(T / 293.0, 1.215) * locals.specific_heat[i] * bulbs[j].mass);
+      }
+   }
+}
+
+/*-------------------------------
+/  Returns relative visible emission power for a given filament temperature. Result is relative to the emission power at 2700K
+/-------------------------------*/
+double bulb_filament_temperature_to_emission(const double T)
+{
+   if (T < 1500.0) return 0;
+   if (T >= 2999.0) return locals.t_to_p[1499];
+   return locals.t_to_p[(int)T - 1500];
+   // Linear interpolation is not worth its cost
+   // int lower_T = (int) T, upper_T = (int) (T + 0.5);
+   // double alpha = T - lower_T;
+   // return (1.0 - alpha) * locals.t_to_p[lower_T - 1500] + alpha * locals.t_to_p[upper_T - 1500];
+}
+
+/*-------------------------------
+/  Returns filament temperature for a given visible emission power normalized for a an emission power of 1.0 at 2700K
+/-------------------------------*/
+double bulb_emission_to_filament_temperature(const double p)
+{
+   int v = (int)p * 255;
+   return v >= 512 ? locals.p_to_t[511] : locals.p_to_t[v];
+}
+
+/*-------------------------------
+/  Compute cool down factor of a filament
+/-------------------------------*/
+double bulb_cool_down_factor(const int bulb, const double T)
+{
+   return bulbs[bulb].cool_down[(int) T];
+}
+
+/*-------------------------------
+/  Compute cool down factor of a filament over a given period
+/-------------------------------*/
+double bulb_cool_down(const int bulb, double T, double duration)
+{
+   while (duration > 0.0)
+   {
+      double dt = duration > 0.001 ? 0.001 : duration;
+      T += dt * bulbs[bulb].cool_down[(int) T];
+      if (T <= 294.0)
+      {
+         return 293.0;
+      }
+      duration -= dt;
+   }
+   return T;
+}
+
+/*-------------------------------
+/  Compute heat up factor of a filament under a given voltage (sum of heating and cooldown)
+/-------------------------------*/
+double bulb_heat_up_factor(const int bulb, const double T, const double U, const double serial_R)
+{
+   if (serial_R)
+   {
+      double R = bulbs[bulb].r0 * pow(T / 293.0, 1.215);
+      double U1 = U * R / (R + serial_R);
+      return U1 * U1 * bulbs[bulb].heat_factor[(int) T] + bulbs[bulb].cool_down[(int) T];
+   }
+   else
+   {
+      return U * U * bulbs[bulb].heat_factor[(int) T] + bulbs[bulb].cool_down[(int) T];
+   }
+}
+
+/*-------------------------------
+/  Compute temperature of a filament under a given voltage over a given period (sum of heating and cooldown)
+/-------------------------------*/
+double bulb_heat_up(const int bulb, double T, double duration, const double U, const double serial_R)
+{
+   while (duration > 0.0)
+   {
+      T = T < 293.0 ? 293.0 : T > 2999.0 ? 2999.0 : T; // Keeps T within the range of the LUT (between room temperature and melt down point)
+      double energy;
+      if (serial_R)
+      {
+         const double R = bulbs[bulb].r0 * pow(T / 293.0, 1.215);
+         const double U1 = U * R / (R + serial_R);
+         energy = U1 * U1 * bulbs[bulb].heat_factor[(int) T] + bulbs[bulb].cool_down[(int)T];
+      }
+      else
+      {
+         energy = U * U * bulbs[bulb].heat_factor[(int) T] + bulbs[bulb].cool_down[(int)T];
+      }
+      if (-10 < energy && energy < 10)
+      {
+         // Stable state reached since electric heat (roughly) equals radiation cool down
+         return T;
+      }
+      double dt;
+      if (energy > 1000e3)
+      {
+         // Initial current surge, 0.5ms integration period in order to account for the fast resistor rise that will quickly lower the current
+         dt = duration > 0.0005 ? 0.0005 : duration;
+      }
+      else
+      {
+         // Ramping up, 1ms integration period
+         dt = duration > 0.001 ? 0.001 : duration;
+      }
+      T += dt * energy;
+      duration -= dt;
+   }
+   return T;
+}

--- a/src/wpc/bulb.h
+++ b/src/wpc/bulb.h
@@ -1,0 +1,22 @@
+// license:GPLv3+
+#ifndef INC_BULB
+#define INC_BULB
+#if !defined(__GNUC__) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || (__GNUC__ >= 4)	// GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+#define BULB_44   0
+#define BULB_47   1
+#define BULB_86   2
+#define BULB_89   3
+#define BULB_MAX  4
+
+extern void bulb_init();
+extern double bulb_filament_temperature_to_emission(const double T);
+extern double bulb_emission_to_filament_temperature(const double p);
+extern double bulb_cool_down_factor(const int bulb, const double T);
+extern double bulb_cool_down(const int bulb, double T, double duration);
+extern double bulb_heat_up_factor(const int bulb, const double T, const double U, const double serial_R);
+extern double bulb_heat_up(const int bulb, double T, const double dt, const double U, const double serial_R);
+
+#endif /* INC_BULB */


### PR DESCRIPTION
While implementing the companion feature for VPX, I identified a few precision issue that lead me to refactor the incandescent model for a cleaner version, namely:
- fix precision issues (due to emission polynomial regressions being 3rd order),
- improve performance by precomputing most of the maths
- cleanup implementation so that it can be shared accross PinMame / VPX / VPE / whoever wants it :)
- adjust bulbs characteristics so that they all stabilize at 2700K
- add an implementation of the model for efficient steady state (mainly for VPX)

I don't know what is the right license for that (since the bulb.c/bulb.h files are meant to be shared across projects), so I put the same comment that what is done in VPX for the part that is shared with VPE. Feel free to change to whatever suits PinMame licensing.