### PR TITLE
PWM integration: fix multithreading issue

### DIFF
--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -436,7 +436,7 @@ typedef struct {
   volatile UINT8 pulsedGIState;  /* current pulse value of WPC GI strings */
   UINT64 lastSol;         /* last state of all solenoids */
   UINT8 lastModSol[CORE_MODSOL_MAX];
-  double lastACZeroCross; /* Machine time of zero crossing (AC frequency is fixed at 60Hz) */
+  int lastACZeroCross; /* Position of output sampling when last zero crossing happened (AC frequency is fixed at 60Hz) */
   double pulsedOutStateSampleFreq; /* Frequency of output sampling */
   int pulsedOutStateSamplePos; /* Current position of output sampling in the circular buffers */
   UINT32 pulsedSolStateSamples[CORE_MODOUT_SAMPLE_MAX];  /* sample pulse value of all solenoids */
@@ -530,7 +530,7 @@ extern UINT64 core_getAllSol(void);
 extern void core_perform_pwm_integration();
 INLINE void core_zero_cross() {
    if (coreGlobals.nModulatedOutputs > 0)
-      coreGlobals.lastACZeroCross = timer_get_time();
+   coreGlobals.lastACZeroCross = coreGlobals.pulsedOutStateSamplePos;
 }
 INLINE void core_store_pulsed_samples(double freq) {
    if (coreGlobals.nModulatedOutputs > 0)


### PR DESCRIPTION
The initial implementation was not thread safe and could have issue (no crash, just output computation error and an error.log being generated) since:
- the emulation thread would continuously fill the sampling arrays and update sampling/zerocross pos
- the client app thread would trigger the PWM integration accessing these data without any synchronization, and requesting machine time which should only be accessed from the emulation thread while emulating a CPU.

This PR adds a simple fix by:
- specifying who is allowed to access what (emulation thread => sampling data, client thread => PWM outputs)
- do not use machine time for PWM integration any more (instead use sampling/zerocross position to compute AC wave)
- have PWM integration read the common data once, avoiding computation errors (no real synchronization since this would be overkill) and rely on the fact that the sampling buffer is large enough to avoid overlapping and computation errors.

The PR also contains a little fix for bulbs where integration was offseted by 1 sample