### PR TITLE
libpinmame: add support for setting dmd mode (RAW/BRIGHTNESS)

### DIFF
--- a/cmake/libpinmame/CMakeLists_osx-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-arm64.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.16)
 
+option(BUILD_SHARED "Build shared library" ON)
+option(BUILD_STATIC "Build static library" ON)
+
 file(READ src/version.c version)
 string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
 
 project(pinmame VERSION ${PROJECT_VERSION})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
@@ -88,7 +91,7 @@ add_compile_definitions(
 
 add_definitions( "-DINLINE=static inline __attribute__((always_inline))" )
 
-add_library(pinmame SHARED
+set(PINMAME_SOURCES
    src/artwork.c
    src/artwork.h
    src/audit.c
@@ -576,7 +579,7 @@ add_library(pinmame SHARED
    ext/vgm/vgmwrite.h
 )
 
-target_include_directories(pinmame PUBLIC
+set(PINMAME_INCLUDE_DIRS
    src
    src/wpc
    src/cpu/m68000/generated_by_m68kmake
@@ -586,23 +589,38 @@ target_include_directories(pinmame PUBLIC
 
 find_package(ZLIB)
 
-target_link_libraries(pinmame
+set(PINMAME_LINK_LIBS
    ZLIB::ZLIB
 )
 
-set_target_properties(pinmame PROPERTIES
-   VERSION ${PROJECT_VERSION}
-)
+if(BUILD_SHARED)
+   add_library(pinmame_shared SHARED ${PINMAME_SOURCES})
+   target_include_directories(pinmame_shared PUBLIC ${PINMAME_INCLUDE_DIRS})
+   set_target_properties(pinmame_shared PROPERTIES
+      OUTPUT_NAME "pinmame"
+      VERSION ${PROJECT_VERSION}
+   )
+   target_link_libraries(pinmame_shared ${PINMAME_LINK_LIBS})
+endif()
 
-add_executable(pinmame_test
-   src/libpinmame/test.cpp
-)
+if(BUILD_STATIC)
+   add_library(pinmame_static STATIC ${PINMAME_SOURCES})
+   target_include_directories(pinmame_static PUBLIC ${PINMAME_INCLUDE_DIRS})
+   set_target_properties(pinmame_static PROPERTIES
+      OUTPUT_NAME "pinmame"
+   )
+   target_link_libraries(pinmame_static ${PINMAME_LINK_LIBS})
 
-target_link_libraries(pinmame_test LINK_PUBLIC
-   pinmame
-)
+   add_executable(pinmame_test
+      src/libpinmame/test.cpp
+   )
 
-set_target_properties(pinmame_test PROPERTIES
-   SKIP_BUILD_RPATH TRUE
-   LINK_FLAGS "-Wl,-rpath,@executable_path"
-)
+   target_link_libraries(pinmame_test LINK_PUBLIC
+      pinmame_static
+   )
+
+   set_target_properties(pinmame_test PROPERTIES
+      SKIP_BUILD_RPATH TRUE
+      LINK_FLAGS "-Wl,-rpath,@executable_path"
+   )
+endif()

--- a/cmake/libpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/libpinmame/CMakeLists_osx-x64.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.16)
 
+option(BUILD_SHARED "Build shared library" ON)
+option(BUILD_STATIC "Build static library" ON)
+
 file(READ src/version.c version)
 string(REGEX MATCH "[0-9\\.]+" PROJECT_VERSION ${version})
 
 project(pinmame VERSION ${PROJECT_VERSION})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
@@ -88,7 +91,7 @@ add_compile_definitions(
 
 add_definitions( "-DINLINE=static inline __attribute__((always_inline))" )
 
-add_library(pinmame SHARED
+set(PINMAME_SOURCES
    src/artwork.c
    src/artwork.h
    src/audit.c
@@ -576,7 +579,7 @@ add_library(pinmame SHARED
    ext/vgm/vgmwrite.h
 )
 
-target_include_directories(pinmame PUBLIC
+set(PINMAME_INCLUDE_DIRS
    src
    src/wpc
    src/cpu/m68000/generated_by_m68kmake
@@ -586,23 +589,38 @@ target_include_directories(pinmame PUBLIC
 
 find_package(ZLIB)
 
-target_link_libraries(pinmame
+set(PINMAME_LINK_LIBS
    ZLIB::ZLIB
 )
 
-set_target_properties(pinmame PROPERTIES
-   VERSION ${PROJECT_VERSION}
-)
+if(BUILD_SHARED)
+   add_library(pinmame_shared SHARED ${PINMAME_SOURCES})
+   target_include_directories(pinmame_shared PUBLIC ${PINMAME_INCLUDE_DIRS})
+   set_target_properties(pinmame_shared PROPERTIES
+      OUTPUT_NAME "pinmame"
+      VERSION ${PROJECT_VERSION}
+   )
+   target_link_libraries(pinmame_shared ${PINMAME_LINK_LIBS})
+endif()
 
-add_executable(pinmame_test
-   src/libpinmame/test.cpp
-)
+if(BUILD_STATIC)
+   add_library(pinmame_static STATIC ${PINMAME_SOURCES})
+   target_include_directories(pinmame_static PUBLIC ${PINMAME_INCLUDE_DIRS})
+   set_target_properties(pinmame_static PROPERTIES
+      OUTPUT_NAME "pinmame"
+   )
+   target_link_libraries(pinmame_static ${PINMAME_LINK_LIBS})
 
-target_link_libraries(pinmame_test LINK_PUBLIC
-   pinmame
-)
+   add_executable(pinmame_test
+      src/libpinmame/test.cpp
+   )
 
-set_target_properties(pinmame_test PROPERTIES
-   SKIP_BUILD_RPATH TRUE
-   LINK_FLAGS "-Wl,-rpath,@executable_path"
-)
+   target_link_libraries(pinmame_test LINK_PUBLIC
+      pinmame_static
+   )
+
+   set_target_properties(pinmame_test PROPERTIES
+      SKIP_BUILD_RPATH TRUE
+      LINK_FLAGS "-Wl,-rpath,@executable_path"
+   )
+endif()

--- a/src/libpinmame/fileio.c
+++ b/src/libpinmame/fileio.c
@@ -39,6 +39,8 @@ FILE *stdout_file;
 FILE *stderr_file;
 #endif
 
+extern void libpinmame_log_message(const char* format, ...);
+
 #ifdef MESS
 #include "image.h"
 #endif
@@ -836,10 +838,9 @@ void osd_fclose(osd_file *file)
 int osd_display_loading_rom_message(const char *name,struct rom_load_data *romdata)
 {
 	if (name)
-		fprintf(stdout, "osd_display_loading_rom_message(): loading %-12s...\n", name);
+		libpinmame_log_message("osd_display_loading_rom_message(): loading %-12s...", name);
 	else
-		fprintf(stdout, "osd_display_loading_rom_message():\n");
-	fflush(stdout);
+		libpinmame_log_message("osd_display_loading_rom_message():");
 
 	return 0;
 }

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -21,6 +21,7 @@ int g_fHandleKeyboard = 0;
 int g_fHandleMechanics = 0;
 int g_fDumpFrames = 0;
 int g_fPause = 0;
+PINMAME_DMD_MODE g_fDmdMode = PINMAME_DMD_MODE::RAW;
 
 #ifdef VPINMAME_ALTSOUND
 char g_szGameName[256] = { 0 }; // String containing requested game name (may be different from ROM if aliased)
@@ -414,6 +415,19 @@ extern "C" void OnSolenoid(const int solenoid, const int state) {
 }
 
 /******************************************************
+ * libpinmame_log_message
+ ******************************************************/
+
+extern "C" void libpinmame_log_message(const char* format, ...) {
+	if (_p_Config->cb_OnLogMessage) {
+		va_list args;
+		va_start(args, format);
+		(*(_p_Config->cb_OnLogMessage))(format, args);
+		va_end(args);
+	}
+}
+
+/******************************************************
  * libpinmame_update_mech
  ******************************************************/
 
@@ -544,7 +558,7 @@ LIBPINMAME_API void PinmameSetConfig(const PinmameConfig* const p_config) {
 
 	memcpy(_p_Config, p_config, sizeof(PinmameConfig));
 
-	fprintf(stdout, "PinmameSetConfig(): sampleRate=%d, vpmPath=%s\n", _p_Config->sampleRate, _p_Config->vpmPath);
+	libpinmame_log_message("PinmameSetConfig(): sampleRate=%d, vpmPath=%s\n", _p_Config->sampleRate, _p_Config->vpmPath);
 
 	memset(&options, 0, sizeof(options));
 
@@ -596,6 +610,22 @@ LIBPINMAME_API int PinmameGetHandleMechanics() {
 
 LIBPINMAME_API void PinmameSetHandleMechanics(const int handleMechanics) {
 	g_fHandleMechanics = handleMechanics;
+}
+
+/******************************************************
+ * PinmameSetDmdMode
+ ******************************************************/
+
+LIBPINMAME_API void PinmameSetDmdMode(const PINMAME_DMD_MODE dmdMode) {
+	g_fDmdMode = dmdMode;
+}
+
+/******************************************************
+ * PinmameGetDmdMode
+ ******************************************************/
+
+LIBPINMAME_API PINMAME_DMD_MODE PinmameGetDmdMode() {
+	return g_fDmdMode;
 }
 
 /******************************************************

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -4,6 +4,7 @@
 #define LIBPINMAME_H
 
 #include <stdint.h>
+#include <stdarg.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #define LIBPINMAME_API extern "C" __declspec(dllexport)
@@ -28,6 +29,11 @@ typedef enum {
 	MECH_HANDLE_MECHANICS = 5,
 	MECH_NO_INVALID = 6
 } PINMAME_STATUS;
+
+typedef enum {
+	RAW = 0,
+	BRIGHTNESS = 1
+} PINMAME_DMD_MODE;
 
 typedef enum {
 	AUDIO_FORMAT_INT16 = 0,
@@ -365,6 +371,7 @@ typedef void (CALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInf
 typedef void (CALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState);
 typedef void (CALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size);
 typedef int (CALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode);
+typedef void (CALLBACK *PinmameOnLogMessageCallback)(const char* format, va_list args);
 
 typedef struct {
 	const PINMAME_AUDIO_FORMAT audioFormat;
@@ -380,6 +387,7 @@ typedef struct {
 	PinmameOnSolenoidUpdatedCallback cb_OnSolenoidUpdated;
 	PinmameOnConsoleDataUpdatedCallback cb_OnConsoleDataUpdated;
 	PinmameIsKeyPressedFunction fn_IsKeyPressed;
+	PinmameOnLogMessageCallback cb_OnLogMessage;
 } PinmameConfig;
 
 LIBPINMAME_API PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback);
@@ -389,6 +397,8 @@ LIBPINMAME_API int PinmameGetHandleKeyboard();
 LIBPINMAME_API void PinmameSetHandleKeyboard(const int handleKeyboard);
 LIBPINMAME_API int PinmameGetHandleMechanics();
 LIBPINMAME_API void PinmameSetHandleMechanics(const int handleMechanics);
+LIBPINMAME_API void PinmameSetDmdMode(const PINMAME_DMD_MODE dmdMode);
+LIBPINMAME_API PINMAME_DMD_MODE PinmameGetDmdMode();
 LIBPINMAME_API int PinmameGetUseModulatedSolenoids();
 LIBPINMAME_API void PinmameSetUseModulatedSolenoids(const int useModSol);
 LIBPINMAME_API PINMAME_STATUS PinmameRun(const char* const p_name);

--- a/src/libpinmame/test.cpp
+++ b/src/libpinmame/test.cpp
@@ -265,6 +265,12 @@ int CALLBACK IsKeyPressed(PINMAME_KEYCODE keycode) {
 	return 0;
 }
 
+void CALLBACK OnLogMessage(const char* format, va_list args) {
+    char buffer[1024];
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    printf("%s\n", buffer);
+}
+
 int main(int, char**) {
 	system(CLEAR_SCREEN);
 
@@ -281,7 +287,8 @@ int main(int, char**) {
 		&OnMechUpdated,
 		&OnSolenoidUpdated,
 		&OnConsoleDataUpdated,
-		&IsKeyPressed
+		&IsKeyPressed,
+		&OnLogMessage,
 	};
 
 	#if defined(_WIN32) || defined(_WIN64)

--- a/src/png.c
+++ b/src/png.c
@@ -344,7 +344,7 @@ int png_read_file(mame_file *fp, struct png_info *p)
 	return 1;
 }
 
-int png_read_info(mame_file *fp, struct png_info *p)
+static int png_read_info(mame_file *fp, struct png_info *p)
 {
 	UINT32 chunk_type=0;
 	UINT8 *chunk_data;
@@ -615,7 +615,7 @@ static int write_chunk(mame_file *fp, UINT32 chunk_type, UINT8 *chunk_data, UINT
 	return 1;
 }
 
-int png_write_sig(mame_file *fp)
+static int png_write_sig(mame_file *fp)
 {
 	/* PNG Signature */
 	if (mame_fwrite(fp, PNG_Signature, 8) != 8)

--- a/src/png.h
+++ b/src/png.h
@@ -73,14 +73,14 @@ struct png_info {
 int png_verify_signature (mame_file *fp);
 int png_inflate_image (struct png_info *p);
 int png_read_file(mame_file *fp, struct png_info *p);
-int png_read_info(mame_file *fp, struct png_info *p);
+static int png_read_info(mame_file *fp, struct png_info *p);
 int png_expand_buffer_8bit (struct png_info *p);
 void png_delete_unused_colors (struct png_info *p);
 int png_add_text (const char *keyword, const char *text);
 int png_unfilter(struct png_info *p);
 int png_filter(struct png_info *p);
 int png_deflate_image(struct png_info *p);
-int png_write_sig(mame_file *fp);
+static int png_write_sig(mame_file *fp);
 int png_write_datastream(mame_file *fp, struct png_info *p);
 int png_write_bitmap(mame_file *fp, struct mame_bitmap *bitmap);
 int mng_capture_start(mame_file *fp, struct mame_bitmap *bitmap);

--- a/src/wpc/bulb.c
+++ b/src/wpc/bulb.c
@@ -24,7 +24,7 @@ static struct {
   double                      specific_heat[3000];
 } locals;
 
-bulb_tLampCharacteristics bulbs[BULB_MAX] = {
+static bulb_tLampCharacteristics bulbs[BULB_MAX] = {
    { 0.000001549619403110030, 0.000000203895434417560, 1.70020865326503000 }, // #44 Bulb characteristics (6.3V, 250mA, 1.26W, 5lm)
    { 0.000000929872857822516, 0.000000087040748856477, 2.83368108877505000 }, // #47 Bulb characteristics (6.3V, 150mA, 0.95W, 6.3lm)
    { 0.000001239604749734440, 0.000000140555683560514, 2.12526081658129000 }, // #86 Bulb characteristics (6.3V, 200mA, 1.58W, 11.3lm)

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -27,6 +27,8 @@
  UINT32 g_raw_dmdy = ~0u;
 
 #ifdef LIBPINMAME
+ extern int g_fDmdMode;
+
  int g_display_index = 0;
 #endif
 
@@ -905,7 +907,7 @@ void video_update_core_dmd(struct mame_bitmap *bitmap, const struct rectangle *c
         const int offs = (ii-1)*layout->length + jj;
         currbuffer[offs] = col;
 #ifdef LIBPINMAME
-        g_raw_dmdbuffer[offs] = shade_16_enabled ? raw_16[col] : raw_4[col];
+        g_raw_dmdbuffer[offs] = g_fDmdMode ? col : shade_16_enabled ? raw_16[col] : raw_4[col];
 #else
         if(layout->length >= 128) { // Capcom hack
           g_raw_dmdbuffer[offs + raw_dmdoffs] = shade_16_enabled ? raw_16[col] : raw_4[col];


### PR DESCRIPTION
This PR allows libpinmame to receive dmd data as brightness levels in addition to percentage values.

To use brightness levels:

```
PinmameSetDmdMode(PINMAME_DMD_MODE::BRIGHTNESS);
```

This PR also adds static builds of `libpinmame.a` for osx builds and it fixes a few duplicate symbol issues so it can be used in VPX standalone.