### PR TITLE
ci: perform apt-get update for ppuc linux builds

### DIFF
--- a/.github/workflows/ppuc.yml
+++ b/.github/workflows/ppuc.yml
@@ -74,8 +74,9 @@ jobs:
             type: raspi
     steps:
       - uses: actions/checkout@v3
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-latest' && matrix.type != 'raspi' 
         run: |
+          sudo apt-get update
           sudo apt-get install cmake zlib1g-dev libopenal-dev libyaml-cpp-dev libusb-1.0-0-dev
       - if: matrix.os == 'macos-latest'
         run: |


### PR DESCRIPTION
This PR will fix PPUC linux builds in the CI as `libpulse0_15.99.1` was no longer available.

Still need to figure out why NASM is failing for x86 win builds.