### PR TITLE
ci: fix x86 builds due to cmake 3.26 breaking nasm compile

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -69,11 +69,11 @@ jobs:
           - os: macos-latest
             platform: ios-arm64
             libpinmame: libpinmame.${{ needs.version.outputs.version }}.a
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             platform: linux-x64
             libpinmame: libpinmame.so.${{ needs.version.outputs.version }}
             pinmame-test: pinmame_test
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             platform: android-arm64-v8a
             libpinmame: libpinmame.${{ needs.version.outputs.version }}.so
     steps:

--- a/cmake/instvpm/CMakeLists_win-x64.txt
+++ b/cmake/instvpm/CMakeLists_win-x64.txt
@@ -14,22 +14,6 @@ add_compile_definitions(
    __LP64__
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/instvpm/InstallVPinMAME.rc LANGUAGE RC
 )
@@ -46,6 +30,13 @@ add_executable(instvpm WIN32
 
    src/instvpm/InstallVPinMAME.rc
    src/win32com/VPinMAME.idl
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(instvpm PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(instvpm PUBLIC

--- a/cmake/instvpm/CMakeLists_win-x86.txt
+++ b/cmake/instvpm/CMakeLists_win-x86.txt
@@ -13,23 +13,6 @@ add_compile_definitions(
    _CRT_SECURE_NO_WARNINGS
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/arch:SSE2>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/instvpm/InstallVPinMAME.rc LANGUAGE RC
 )
@@ -46,6 +29,13 @@ add_executable(instvpm WIN32
 
    src/instvpm/InstallVPinMAME.rc
    src/win32com/VPinMAME.idl
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(instvpm PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(instvpm PUBLIC

--- a/cmake/libpinmame/CMakeLists_win-arm64.txt
+++ b/cmake/libpinmame/CMakeLists_win-arm64.txt
@@ -87,22 +87,6 @@ add_compile_definitions(
    WIN32
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 add_library(pinmame SHARED
    src/artwork.c
    src/artwork.h
@@ -616,6 +600,13 @@ add_library(pinmame SHARED
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/libpinmame/CMakeLists_win-x64.txt
+++ b/cmake/libpinmame/CMakeLists_win-x64.txt
@@ -87,22 +87,6 @@ add_compile_definitions(
    WIN32
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 add_library(pinmame SHARED
    src/artwork.c
    src/artwork.h
@@ -616,6 +600,13 @@ add_library(pinmame SHARED
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/libpinmame/CMakeLists_win-x86.txt
+++ b/cmake/libpinmame/CMakeLists_win-x86.txt
@@ -87,23 +87,6 @@ add_compile_definitions(
    WIN32
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/arch:SSE2>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 add_library(pinmame SHARED
    src/artwork.c
    src/artwork.h
@@ -617,6 +600,13 @@ add_library(pinmame SHARED
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -89,22 +89,6 @@ add_compile_definitions(
    __LP64__
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 add_executable(pinmame WIN32
    src/artwork.c
    src/artwork.h
@@ -636,6 +620,13 @@ add_executable(pinmame WIN32
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -90,23 +90,6 @@ add_compile_definitions(
    _CRT_SECURE_NO_WARNINGS
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/arch:SSE2>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/windows/asmblit.asm LANGUAGE ASM_NASM
    src/windows/asmtile.asm LANGUAGE ASM_NASM
@@ -645,6 +628,13 @@ add_executable(pinmame WIN32
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -91,22 +91,6 @@ add_compile_definitions(
    __LP64__
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/ui/PinMAME32.rc LANGUAGE RC
 )
@@ -665,6 +649,13 @@ add_executable(pinmame32 WIN32
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame32 PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame32 PUBLIC

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -92,23 +92,6 @@ add_compile_definitions(
    _CRT_SECURE_NO_WARNINGS
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/arch:SSE2>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/windows/asmblit.asm LANGUAGE ASM_NASM
    src/windows/asmtile.asm LANGUAGE ASM_NASM
@@ -671,6 +654,13 @@ add_executable(pinmame32 WIN32
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame32 PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame32 PUBLIC

--- a/cmake/ppuc/CMakeLists_win-x64.txt
+++ b/cmake/ppuc/CMakeLists_win-x64.txt
@@ -88,22 +88,6 @@ add_compile_definitions(
    WIN32
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 add_library(pinmame SHARED
    src/artwork.c
    src/artwork.h
@@ -617,6 +601,13 @@ add_library(pinmame SHARED
    ext/zlib/trees.c
    ext/zlib/uncompr.c
    ext/zlib/zutil.c
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(pinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(pinmame PUBLIC

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -90,22 +90,6 @@ add_compile_definitions(
    __LP64__
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/win32com/VPinMAME.rc LANGUAGE RC
 )
@@ -694,6 +678,13 @@ add_library(vpinmame SHARED
 
    ext/basicbitmap/BasicBitmap_SSE2.cpp
    ext/basicbitmap/BasicBitmap_C.h
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(vpinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(vpinmame PUBLIC

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -91,23 +91,6 @@ add_compile_definitions(
    _USRDLL
 )
 
-add_compile_options(
-   $<$<CONFIG:RELEASE>:/Ob2>
-   $<$<CONFIG:RELEASE>:/O2>
-   $<$<CONFIG:RELEASE>:/Oi>
-   $<$<CONFIG:RELEASE>:/arch:SSE2>
-   $<$<CONFIG:RELEASE>:/fp:fast>
-   $<$<CONFIG:RELEASE>:/fp:except->
-   $<$<CONFIG:RELEASE>:/Ot>
-   $<$<CONFIG:RELEASE>:/GF>
-   $<$<CONFIG:RELEASE>:/GS->
-   $<$<CONFIG:RELEASE>:/Gy>
-   $<$<CONFIG:RELEASE>:/GR->
-   $<$<CONFIG:RELEASE>:/Oy>
-   $<$<CONFIG:RELEASE>:/GT>
-   $<$<CONFIG:RELEASE>:/GL>
-)
-
 set_source_files_properties(
    src/windows/asmblit.asm LANGUAGE ASM_NASM
    src/windows/asmtile.asm LANGUAGE ASM_NASM
@@ -700,6 +683,13 @@ add_library(vpinmame SHARED
 
    ext/basicbitmap/BasicBitmap_SSE2.cpp
    ext/basicbitmap/BasicBitmap_C.h
+)
+
+set(OPT_COMMON /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)
+
+target_compile_options(vpinmame PUBLIC
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
+   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
 )
 
 target_include_directories(vpinmame PUBLIC


### PR DESCRIPTION
The `windows-2019` images were updated on the [20230326](https://github.com/actions/runner-images/blob/win19/20230326.1/images/win/Windows2019-Readme.md). This includes a new version of CMake (3.26.1) that appears to have a different behavior when compiling assembly files using `nasm`?

The CI was failing with:

`C:\Program Files\CMake\share\cmake-3.26\Templates\MSBuild\nasm.targets(33,5): error MSB3721: The command ""C:/Users/runneradmin/nasm/nasm.exe" -o "pinmame32.dir\Release\asmblit.obj" -fwin32 -I"D:\a\pinmame\pinmame\src\\" -I"D:\a\pinmame\pinmame\src\cpu\m68000\generated_by_m68kmake\\" -I"D:\a\pinmame\pinmame\src\wpc\\" -I"D:\a\pinmame\pinmame\src\vc\\" -I"D:\a\pinmame\pinmame\src\ui\\" -I"D:\a\pinmame\pinmame\src\windows\\" -I"D:\a\pinmame\pinmame\ext\zlib\\" -I"D:\a\pinmame\pinmame\ext\dinput\include\\" -D"WIN32" -D"_WINDOWS" -D"NDEBUG" -D"HAS_M6809=1" -D"HAS_M6808=1" -D"HAS_M6800=1" -D"HAS_M6803=1" -D"HAS_M6802=1" -D"HAS_ADSP2101=1" -D"HAS_ADSP2105=1" -D"HAS_Z80=1" -D"HAS_M6502=1" -D"HAS_M65C02=1" -D"HAS_M68000=1" -D"HAS_M68306=1" -D"HAS_S2650=1" -D"HAS_8080=1" -D"HAS_8085A=1" -D"HAS_I8035=1" -D"HAS_I8039=1" -D"HAS_I86=1" -D"HAS_I88=1" -D"HAS_I186=1" -D"HAS_I188=1" -D"HAS_4004=1" -D"HAS_PPS4=1" -D"HAS_SCAMP=1" -D"HAS_I8051=1" -D"HAS_I8752=1" -D"HAS_TMS7000=1" -D"HAS_AT91=1" -D"HAS_ARM7=1" -D"HAS_CDP1802=1" -D"HAS_TMS9980=1" -D"HAS_TMS9995=1" -D"HAS_COP420=1" -D"HAS_DAC=1" -D"HAS_YM2151_ALT=1" -D"HAS_HC55516=1" -D"HAS_MC3417=1" -D"HAS_SAMPLES=1" -D"HAS_TMS5220=1" -D"HAS_AY8910=1" -D"HAS_MSM5205=1" -D"HAS_CUSTOM=1" -D"HAS_BSMT2000=1" -D"HAS_OKIM6295=1" -D"HAS_ADPCM=1" -D"HAS_VOTRAXSC01=1" -D"HAS_SN76477=1" -D"HAS_SN76496=1" -D"HAS_DISCRETE=1" -D"HAS_SP0250=1" -D"HAS_TMS320AV120=1" -D"HAS_M114S=1" -D"HAS_YM3812=1" -D"HAS_S14001A=1" -D"HAS_YM2203=1" -D"HAS_YM3526=1" -D"HAS_TMS5110=1" -D"HAS_SP0256=1" -D"HAS_Y8950=1" -D"HAS_ASTROCADE=1" -D"HAS_YMF262=1" -D"HAS_MEA8000=1" -D"HAS_SAA1099=1" -D"HAS_QSOUND=1" -D"MAMEVER=7300" -D"PINMAME" -D"PINMAME_NO_UNUSED" -D"MAME32NAME="PinMAME32"" -D"WINUI=1" -D"LSB_FIRST" -D"DIRECTINPUT_VERSION=0x0700" -D"DIRECTDRAW_VERSION=0x0300" -D"DECL_SPEC=__cdecl" -D"NONAMELESSUNION" -D"_MBCS" -D"_CRT_SECURE_NO_WARNINGS" -D"CMAKE_INTDIR="Release"" /Ob2 /O2 /Oi /arch:SSE2 /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL "D:\a\pinmame\pinmame\src\windows\asmblit.asm"" exited with code 1. [D:\a\pinmame\pinmame\build\pinmame32.vcxproj]`

It looks like passing in the compile options was breaking this.

The solution is to only include the release options for C and C++ files:

```
set(OPT_COMMON /Ob2 /O2 /Oi /fp:fast /fp:except- /Ot /GF /GS- /Gy /GR- /Oy /GT /GL)

target_compile_options(pinmame PUBLIC
   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:CXX>:${OPT_COMMON}>>
   $<$<CONFIG:RELEASE>:$<$<COMPILE_LANGUAGE:C>:${OPT_COMMON}>>
)
```

All cmake files that used `add_compile_options` have been migrated to `target_compile_options`

This PR also updates linux and android `libpinmame` builds to use `ubuntu-latest`.