### PR TITLE
missed openAL closeDeivce call

### DIFF
--- a/src/ppuc/ppuc.cpp
+++ b/src/ppuc/ppuc.cpp
@@ -704,7 +704,17 @@ int main (int argc, char *argv[]) {
     // Initialize the sound device
     const ALCchar *defaultDeviceName = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
     ALCdevice *device = alcOpenDevice(defaultDeviceName);
+    if (!device) {
+        printf("failed to alcOpenDevice to %s\n", defaultDeviceName);
+        return 1;
+    }
+
     ALCcontext *context = alcCreateContext(device, NULL);
+    if (!context) {
+        printf("failed call to alcCreateContext\n");
+        return 1;
+    }
+
     alcMakeContextCurrent(context);
     alGenSources((ALuint) 1, &_audioSource);
     alGenBuffers(MAX_AUDIO_BUFFERS, _audioBuffers);
@@ -777,6 +787,8 @@ int main (int argc, char *argv[]) {
 
     // Close the serial device
     serial.closeDevice();
+
+	if (device) alcCloseDevice(device);
 
 	return 0;
 }


### PR DESCRIPTION
Greetings, I am new! I tried to run the example from the repository and got a message about a problem related to OpenAL:
```
build/Release/ppuc -c src/ppuc/examples/t2.yml
AL lib: (EE) alc_cleanup: 1 device not closed
```
Correct roms I put on their path. There was no other error messages, just silent launch. My operating system is Linux Ubuntu 22.04.2 LTS. Then I casually familiarized myself with the code and found that call to `alcCloseDevice` is missed. Also I added 2 additional checks for `alcOpenDevice` and `alcCreateContext` calls which shuld help to diagnose the problems related to OpenAL.