### PR TITLE
Make dmddevice.h BSD-3.

### DIFF
--- a/ext/dmddevice/dmddevice.h
+++ b/ext/dmddevice/dmddevice.h
@@ -1,3 +1,5 @@
+// license:BSD-3-Clause
+
 #ifdef DMDDEVICE_DLL_EXPORTS
 	#define DMDDEV __declspec(dllexport) 
 #else


### PR DESCRIPTION
In order to make the dmddevice.dll API usable by commercial entities, I've added the BSD-3 tag to the header file. 

@toxieainc @lucky1 @russdx I think you guys were the main contributors? Can we have an official okay from your side?

For context, Zen Studio might be adding dmddevice support to Pinball FX, and we need to make sure there are no legal issues with that. As far as I know, copyrighting just an API shouldn't be an issue (see [Google v. Oracle](https://en.wikipedia.org/wiki/Google_LLC_v._Oracle_America,_Inc.)), but they want to be sure anyway.