### PR TITLE
libpinmame: new SetPath function. Added user data to callbacks.

### DIFF
--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -15,7 +15,7 @@
 #define CALLBACK
 #endif
 
-#define PINMAME_MAX_VPM_PATH 512
+#define PINMAME_MAX_PATH 512
 #define PINMAME_MAX_DISPLAYS 50
 #define PINMAME_MAX_MECHSW 20
 #define PINMAME_ACCUMULATOR_SAMPLES 8192 // from mixer.c
@@ -29,6 +29,14 @@ typedef enum {
 	MECH_HANDLE_MECHANICS = 5,
 	MECH_NO_INVALID = 6
 } PINMAME_STATUS;
+
+typedef enum {
+	ROMS = 0,
+	NVRAM = 1,
+	SAMPLES = 2,
+	CONFIG = 3,
+	HIGHSCORE = 4
+} PINMAME_FILE_TYPE;
 
 typedef enum {
 	BRIGHTNESS = 0,
@@ -360,23 +368,23 @@ typedef struct {
 	unsigned int standardcode;
 } PinmameKeyboardInfo;
 
-typedef void (CALLBACK *PinmameGameCallback)(PinmameGame* p_game);
-typedef void (CALLBACK *PinmameOnStateUpdatedCallback)(int state);
-typedef void (CALLBACK *PinmameOnDisplayAvailableCallback)(int index, int displayCount, PinmameDisplayLayout* p_displayLayout);
-typedef void (CALLBACK *PinmameOnDisplayUpdatedCallback)(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout);
-typedef int (CALLBACK *PinmameOnAudioAvailableCallback)(PinmameAudioInfo* p_audioInfo);
-typedef int (CALLBACK *PinmameOnAudioUpdatedCallback)(void* p_buffer, int samples);
-typedef void (CALLBACK *PinmameOnMechAvailableCallback)(int mechNo, PinmameMechInfo* p_mechInfo);
-typedef void (CALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInfo* p_mechInfo);
-typedef void (CALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState);
-typedef void (CALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size);
-typedef int (CALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode);
-typedef void (CALLBACK *PinmameOnLogMessageCallback)(const char* format, va_list args);
+typedef void (CALLBACK *PinmameGameCallback)(PinmameGame* p_game, void* userData);
+typedef void (CALLBACK *PinmameOnStateUpdatedCallback)(int state, void* userData);
+typedef void (CALLBACK *PinmameOnDisplayAvailableCallback)(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, void* userData);
+typedef void (CALLBACK *PinmameOnDisplayUpdatedCallback)(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, void* userData);
+typedef int (CALLBACK *PinmameOnAudioAvailableCallback)(PinmameAudioInfo* p_audioInfo, void* userData);
+typedef int (CALLBACK *PinmameOnAudioUpdatedCallback)(void* p_buffer, int samples, void* userData);
+typedef void (CALLBACK *PinmameOnMechAvailableCallback)(int mechNo, PinmameMechInfo* p_mechInfo, void* userData);
+typedef void (CALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInfo* p_mechInfo, void* userData);
+typedef void (CALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState, void* userData);
+typedef void (CALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size, void* userData);
+typedef int (CALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode, void* userData);
+typedef void (CALLBACK *PinmameOnLogMessageCallback)(const char* format, va_list args, void* userData);
 
 typedef struct {
 	const PINMAME_AUDIO_FORMAT audioFormat;
 	const int sampleRate;
-	const char vpmPath[PINMAME_MAX_VPM_PATH];
+	const char vpmPath[PINMAME_MAX_PATH];
 	PinmameOnStateUpdatedCallback cb_OnStateUpdated;
 	PinmameOnDisplayAvailableCallback cb_OnDisplayAvailable;
 	PinmameOnDisplayUpdatedCallback cb_OnDisplayUpdated;
@@ -393,6 +401,7 @@ typedef struct {
 LIBPINMAME_API PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback);
 LIBPINMAME_API PINMAME_STATUS PinmameGetGames(PinmameGameCallback callback);
 LIBPINMAME_API void PinmameSetConfig(const PinmameConfig* const p_config);
+LIBPINMAME_API void PinmameSetPath(const PINMAME_FILE_TYPE fileType, const char* const p_path);
 LIBPINMAME_API int PinmameGetHandleKeyboard();
 LIBPINMAME_API void PinmameSetHandleKeyboard(const int handleKeyboard);
 LIBPINMAME_API int PinmameGetHandleMechanics();
@@ -425,4 +434,5 @@ LIBPINMAME_API int PinmameGetMaxMechs();
 LIBPINMAME_API PINMAME_STATUS PinmameSetMech(const int mechNo, const PinmameMechConfig* const p_mechConfig);
 LIBPINMAME_API int PinmameGetDIP(const int dipBank);
 LIBPINMAME_API void PinmameSetDIP(const int dipBank, const int value);
+LIBPINMAME_API void PinmameSetUserData(const void* p_userData);
 #endif

--- a/src/libpinmame/test.cpp
+++ b/src/libpinmame/test.cpp
@@ -129,12 +129,12 @@ void DumpAlphanumeric(int index, UINT16* p_displayData, PinmameDisplayLayout* p_
 	}
 }
 
-void CALLBACK Game(PinmameGame* game) {
+void CALLBACK Game(PinmameGame* game, void* p_userData) {
 	printf("Game(): name=%s, description=%s, manufacturer=%s, year=%s, flags=%lu, found=%d\n",
 		game->name, game->description, game->manufacturer, game->year, (unsigned long)game->flags, game->found);
 }
 
-void CALLBACK OnStateUpdated(int state) {
+void CALLBACK OnStateUpdated(int state, void* p_userData) {
 	printf("OnStateUpdated(): state=%d\n", state);
 
 	if (!state) {
@@ -156,7 +156,7 @@ void CALLBACK OnStateUpdated(int state) {
 	}
 }
 
-void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout) {
+void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, void* p_userData) {
 	printf("OnDisplayAvailable(): index=%d, displayCount=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
 		index,
 		displayCount,
@@ -169,7 +169,7 @@ void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayo
 		p_displayLayout->length);
 }
 
-void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout) {
+void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, void* p_userData) {
 	printf("OnDisplayUpdated(): index=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
 		index,
 		p_displayLayout->type,
@@ -188,7 +188,7 @@ void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLay
 	}
 }
 
-int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo) {
+int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo, void* p_userData) {
 	printf("OnAudioAvailable(): format=%d, channels=%d, sampleRate=%.2f, framesPerSecond=%.2f, samplesPerFrame=%d, bufferSize=%d\n",
 		p_audioInfo->format,
 		p_audioInfo->channels,
@@ -199,15 +199,15 @@ int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo) {
 	return p_audioInfo->samplesPerFrame;
 }
 
-int CALLBACK OnAudioUpdated(void* p_buffer, int samples) {
+int CALLBACK OnAudioUpdated(void* p_buffer, int samples, void* p_userData) {
 	return samples;
 }
 
-void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState) {
+void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState, void* p_userData) {
 	printf("OnSolenoidUpdated: solenoid=%d, state=%d\n", p_solenoidState->solNo,  p_solenoidState->state);
 }
 
-void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
+void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo, void* p_userData) {
 	printf("OnMechAvailable: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
 		mechNo,
 		p_mechInfo->type,
@@ -217,7 +217,7 @@ void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
 		p_mechInfo->speed);
 }
 
-void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo) {
+void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo, void* p_userData) {
 	printf("OnMechUpdated: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
 		mechNo,
 		p_mechInfo->type,
@@ -227,15 +227,15 @@ void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo) {
 		p_mechInfo->speed);
 }
 
-void CALLBACK OnConsoleDataUpdated(void* p_data, int size) {
+void CALLBACK OnConsoleDataUpdated(void* p_data, int size, void* p_userData) {
 	printf("OnConsoleDataUpdated: size=%d\n", size);
 }
 
-int CALLBACK IsKeyPressed(PINMAME_KEYCODE keycode) {
+int CALLBACK IsKeyPressed(PINMAME_KEYCODE keycode, void* p_userData) {
 	return 0;
 }
 
-void CALLBACK OnLogMessage(const char* format, va_list args) {
+void CALLBACK OnLogMessage(const char* format, va_list args, void* p_userData) {
     char buffer[1024];
     vsnprintf(buffer, sizeof(buffer), format, args);
     printf("%s\n", buffer);
@@ -262,9 +262,9 @@ int main(int, char**) {
 	};
 
 	#if defined(_WIN32) || defined(_WIN64)
-		snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
+		snprintf((char*)config.vpmPath, PINMAME_MAX_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
 	#else
-		snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s/.pinmame/", getenv("HOME"));
+		snprintf((char*)config.vpmPath, PINMAME_MAX_PATH, "%s/.pinmame/", getenv("HOME"));
 	#endif
 
 	PinmameSetConfig(&config);

--- a/src/ppuc/ppuc.cpp
+++ b/src/ppuc/ppuc.cpp
@@ -206,7 +206,7 @@ void CALLBACK Game(PinmameGame* game) {
            game->name, game->description, game->manufacturer, game->year, (unsigned long)game->flags, game->found);
 }
 
-void CALLBACK OnStateUpdated(int state) {
+void CALLBACK OnStateUpdated(int state, void* p_userData) {
     if (opt_debug) printf("OnStateUpdated(): state=%d\n", state);
 
     if (!state) {
@@ -230,7 +230,7 @@ void CALLBACK OnStateUpdated(int state) {
     }
 }
 
-void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout) {
+void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, void* p_userData) {
     if (opt_debug) printf("OnDisplayAvailable(): index=%d, displayCount=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
                           index,
                           displayCount,
@@ -243,7 +243,7 @@ void CALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayo
                           p_displayLayout->length);
 }
 
-void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout) {
+void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, void* p_userData) {
     if (opt_debug) printf("OnDisplayUpdated(): index=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
                           index,
                           p_displayLayout->type,
@@ -324,7 +324,7 @@ void CALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLay
     }
 }
 
-int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo) {
+int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo, void* p_userData) {
     if (opt_debug) printf("OnAudioAvailable(): format=%d, channels=%d, sampleRate=%.2f, framesPerSecond=%.2f, samplesPerFrame=%d, bufferSize=%d\n",
                           p_audioInfo->format,
                           p_audioInfo->channels,
@@ -353,7 +353,7 @@ int CALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo) {
     return p_audioInfo->samplesPerFrame;
 }
 
-int CALLBACK OnAudioUpdated(void* p_buffer, int samples) {
+int CALLBACK OnAudioUpdated(void* p_buffer, int samples, void* p_userData) {
     if (_audioQueue.size() >= MAX_AUDIO_QUEUE_SIZE) {
         while (!_audioQueue.empty()) {
             void* p_destBuffer = _audioQueue.front();
@@ -407,12 +407,12 @@ int CALLBACK OnAudioUpdated(void* p_buffer, int samples) {
     return samples;
 }
 
-void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState) {
+void CALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState, void* p_userData) {
     if (opt_debug) printf("OnSolenoidUpdated: solenoid=%d, state=%d\n", p_solenoidState->solNo,  p_solenoidState->state);
     sendEvent(new Event(EVENT_SOURCE_SOLENOID, (UINT16) p_solenoidState->solNo, (UINT8) p_solenoidState->state));
 }
 
-void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
+void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo, void* p_userData) {
     if (opt_debug) printf("OnMechAvailable: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
                           mechNo,
                           p_mechInfo->type,
@@ -422,7 +422,7 @@ void CALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo) {
                           p_mechInfo->speed);
 }
 
-void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo) {
+void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo, void* p_userData) {
     if (opt_debug) printf("OnMechUpdated: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
                           mechNo,
                           p_mechInfo->type,
@@ -432,11 +432,11 @@ void CALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo) {
                           p_mechInfo->speed);
 }
 
-void CALLBACK OnConsoleDataUpdated(void* p_data, int size) {
+void CALLBACK OnConsoleDataUpdated(void* p_data, int size, void* p_userData) {
     if (opt_debug) printf("OnConsoleDataUpdated: size=%d\n", size);
 }
 
-int CALLBACK IsKeyPressed(PINMAME_KEYCODE keycode) {
+int CALLBACK IsKeyPressed(PINMAME_KEYCODE keycode, void* p_userData) {
     return 0;
 }
 
@@ -526,9 +526,9 @@ int main (int argc, char *argv[]) {
     };
 
 #if defined(_WIN32) || defined(_WIN64)
-    snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
+    snprintf((char*)config.vpmPath, PINMAME_MAX_PATH, "%s%s\\pinmame\\", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
 #else
-    snprintf((char*)config.vpmPath, PINMAME_MAX_VPM_PATH, "%s/.pinmame/", getenv("HOME"));
+    snprintf((char*)config.vpmPath, PINMAME_MAX_PATH, "%s/.pinmame/", getenv("HOME"));
 #endif
 
 #if defined(SERUM_SUPPORT)


### PR DESCRIPTION
While using libpinmame in a C++ application, there is no way to get a reference to the parent class in the callbacks without using a global static variable. 

To get around this, I've added a new void pointer `userData` to all callbacks. To not break the existing `PinmameConfig`, `userData` can be set with the new`PinmameSetUserData` function.

This PR also adds a new `SetPath` function which can be used to override `ROMS`, `NVRAM`, `SAMPLES`, `CONFIG`, and `HIGHSCORE` paths after `PinmameSetConfig` has been called.

This will be useful in iOS, where a rom may be located in the application directory, but the NVRAM file should save in the application's documents directory. 