### PR TITLE
Roscoe build fixes 20230503

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .project
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .project
 build/
+/CMakeLists.txt

--- a/cmake/libpinmame/CMakeLists_win-x64.txt
+++ b/cmake/libpinmame/CMakeLists_win-x64.txt
@@ -623,7 +623,7 @@ target_link_libraries(pinmame
 )
 
 target_link_options(pinmame PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/libpinmame/CMakeLists_win-x86.txt
+++ b/cmake/libpinmame/CMakeLists_win-x86.txt
@@ -623,7 +623,7 @@ target_link_libraries(pinmame
 )
 
 target_link_options(pinmame PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -653,7 +653,7 @@ target_link_libraries(pinmame
 
 target_link_options(pinmame PUBLIC
    /SUBSYSTEM:CONSOLE
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -661,7 +661,7 @@ target_link_libraries(pinmame
 
 target_link_options(pinmame PUBLIC
    /SUBSYSTEM:CONSOLE
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -684,7 +684,7 @@ target_link_libraries(pinmame32
 )
 
 target_link_options(pinmame32 PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -689,7 +689,7 @@ target_link_libraries(pinmame32
 )
 
 target_link_options(pinmame32 PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/ppuc/CMakeLists_win-x64.txt
+++ b/cmake/ppuc/CMakeLists_win-x64.txt
@@ -624,7 +624,7 @@ target_link_libraries(pinmame
 )
 
 target_link_options(pinmame PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -715,7 +715,7 @@ target_link_libraries(vpinmame
 )
 
 target_link_options(vpinmame PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -720,7 +720,7 @@ target_link_libraries(vpinmame
 )
 
 target_link_options(vpinmame PUBLIC
-   $<$<CONFIG:RELEASE>:/SAFESEH:NO>
+   /SAFESEH:NO
    $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>
    $<$<CONFIG:RELEASE>:/OPT:REF>
    $<$<CONFIG:RELEASE>:/OPT:ICF>

--- a/src/config.c
+++ b/src/config.c
@@ -649,4 +649,46 @@ int config_write_mixer_config(config_file *cfg, const struct mixer_config *mixer
 	cfg->position = POSITION_AFTER_MIXER;
 	return CONFIG_ERROR_SUCCESS;
 }
+// DAR_DEBUG @20230506 Defining this for now without a filename just to avoid
+//                     linking errors for DEBUG builds
+//
+// logerror
+//
+#ifdef VPINMAME // VPM defines its own log function
+    FILE *config_get_logfile(void) { return errorlog ? logfile : NULL; }
+#else /* VPINMAME */
+	#if (!defined(PINMAME) || defined(MAME_DEBUG) || defined(_DEBUG)) // In PinMAME, log only in debug mode.
+		static FILE *logfile = NULL;
+		static int maxlogsize;
+		static int curlogsize;
+		static int errorlog;
+		static int erroroslog;
+		void CLIB_DECL logerror(const char *text, ...) {
+			va_list arg;
 
+			/* standard vfprintf stuff here */
+			va_start(arg, text);
+
+			if (errorlog && logfile)
+			{
+				curlogsize += vfprintf(logfile, text, arg);
+				if (curlogsize > maxlogsize * 1024)
+				{
+					fclose(logfile);
+					logfile = NULL;
+					exit(1);
+				}
+			}
+
+			//DAR_TODO find out where OutputDebugString is defined
+			//if (erroroslog)
+			//{
+			//	//extern int vsnprintf(char *s, size_t maxlen, const char *fmt, va_list _arg);
+			//	char buffer[2048];
+			//	vsnprintf(buffer, sizeof(buffer) / sizeof(buffer[0]), text, arg);
+			//	OutputDebugString(buffer);
+			//}
+			va_end(arg);
+		}
+	#endif /* PINMAME DEBUG */
+#endif /* VPINMAME */


### PR DESCRIPTION
I've made changes to the CMake files for all Windows projects to support using the workflow scripts to generate user-level project files that successfully compile in both RELEASE and DEBUG mode.  Ultimately, this will allow project files to always stay in step with the build, and enable the removal of the project files in source control.  For now, however, it is a first step to allow DEBUG builds with minimal changes.

I had to add a non-functioning definition for logerror in the config.c file, since it is not being provided by the other projects, such as VPinMAME and was causing linking errors.  A future pull request will make this logging function work in the standalone lib.

I have tested the CMake files and confirm they build without error on my machine for all Windows projects in RELEASE and DEBUG mode.