### PR TITLE
Fixed parsing bug. Moved sound cmd recording output. Added release information

### DIFF
--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -5,6 +5,21 @@ What's new in PinMAME:
 
 Version 3.6 (XX XXth, 2023) - "Sounds good III"
 ------------------------------------------------------------------------------
+"AltSound 2.0"
+- Completely re-written AltSound processing
+- Fixed existing bugs in original AltSound code
+- compatible with all existing AltSound library formats
+- New G-Sound library format.  Provides a new option for authors to develop
+  immersive, multi-layered AltSound packages
+- New AltSound configuration options via per-table .ini file.
+- Independent and configurable always-on AltSound logger
+- Ability to record live game sound commands.  Useful for testing sounds without
+  having to repeatedly create on live game.
+- Ability to script game sound commands (currently dev only feature).  Useful
+  for testing specific scenarios like mode progressions or sound mix behavior
+  without having to create them in a live game
+- Ability to playback recorded sound commands via standalone AltSound driver
+  preserving original game timing (currently dev only feature)
 
 Updated LISY support to 5.28-90 (Linux for Gottlieb System1 & System80, Bally, Atari, Williams and 'Home' Pinballs)
 

--- a/src/wpc/altsound/altsound_file_parser.cpp
+++ b/src/wpc/altsound/altsound_file_parser.cpp
@@ -76,7 +76,7 @@ bool AltsoundFileParser::parse(std::vector<AltsoundSampleInfo>& samples_out)
 	const std::string path_voice = "voice/";
 
 	for (int i = 0; i < 5; ++i) {
-		float default_gain = .1f;
+		float default_gain = 1.0f;
 		float default_ducking = 1.f; //!! default depends on type??
 
 		const std::string subpath = (i == 0) ? path_jingle :
@@ -178,7 +178,7 @@ bool AltsoundFileParser::parse(std::vector<AltsoundSampleInfo>& samples_out)
 						sample.fname = PATH2 + '/' + entry2->d_name;
 
 						memcpy(id, ptr + 1, 6);
-						sample.id = std::stoul(trim(id), nullptr, 16);
+						sample.id = std::stoul(trim(id), nullptr);
 
 						sample.gain = gain;
 						sample.ducking = ducking;

--- a/src/wpc/altsound/altsound_processor_base.cpp
+++ b/src/wpc/altsound/altsound_processor_base.cpp
@@ -118,7 +118,7 @@ bool AltsoundProcessorBase::startLogging(const std::string& gameName) {
 		return false;
 	}
 
-	std::string recording_fname = gameName + "-cmdlog.txt";
+	std::string recording_fname = vpm_path + "/altsound/" + gameName+ "/cmdlog.txt";
 	logFile.open(recording_fname);
 	if (!logFile.is_open()) {
 		ALT_ERROR(1, "Failed to open log file: %s", recording_fname.c_str());


### PR DESCRIPTION
- Fixed a parsing bug for PinSound library formats
- Moved sound command log to <VPinMAME>/altsound/<ROM name> folder
- Updated "what's new" information to include AltSound changes