### PR TITLE
Fixed hang if using PinSound and Studio is not running

### DIFF
--- a/src/wpc/altsound/altsound_csv_parser.cpp
+++ b/src/wpc/altsound/altsound_csv_parser.cpp
@@ -85,12 +85,11 @@ bool AltsoundCsvParser::parse(std::vector<AltsoundSampleInfo>& samples_out)
 				}
 				else {
 					int val = std::stoi(trimmed);
-					if (val == 0 || val == 1) {
+					if (val == 0 || val == 1 || val == -1) {
 						entry.channel = val;
 					}
 					else {
-						ALT_ERROR(0, "Invalid sample CHANNEL value");
-						success = false;
+						ALT_WARNING(1, "Invalid sample CHANNEL value: %d", val);
 						entry.channel = -1;  // assign some default value
 						break;
 					}

--- a/src/wpc/altsound/altsound_csv_parser.cpp
+++ b/src/wpc/altsound/altsound_csv_parser.cpp
@@ -91,7 +91,6 @@ bool AltsoundCsvParser::parse(std::vector<AltsoundSampleInfo>& samples_out)
 					else {
 						ALT_WARNING(1, "Invalid sample CHANNEL value: %d", val);
 						entry.channel = -1;  // assign some default value
-						break;
 					}
 				}
 			}

--- a/src/wpc/altsound/altsound_file_parser.cpp
+++ b/src/wpc/altsound/altsound_file_parser.cpp
@@ -256,7 +256,7 @@ float AltsoundFileParser::parseFileValue(const std::string& filePath)
 		return -1.0f;
 	}
 
-	if (fclose(f) != 0) { // Check for closing success
+	if (fclose(f) != 0) {
 		// failed to close file
 		return -1.0f;
 	}

--- a/src/wpc/altsound/altsound_processor.cpp
+++ b/src/wpc/altsound/altsound_processor.cpp
@@ -38,9 +38,7 @@ extern std::mutex io_mutex;
 // Instance of global array of BASS channels 
 extern StreamArray channel_stream;
 
-//extern float master_vol;
-//extern float global_vol;
-
+// Reference to global logger instance
 extern AltsoundLogger alog;
 
 constexpr unsigned int UNSET_IDX = std::numeric_limits<unsigned int>::max();
@@ -244,7 +242,6 @@ void AltsoundProcessor::init()
 	cur_mus_stream = nullptr;
 	cur_jin_stream = nullptr;
 
-	//LOG(("BEGIN AltsoundProcessor::init()"));
 	if (!loadSamples()) {
 		ALT_ERROR(0, "FAILED AltsoundProcessor::loadSamples()");
 		is_initialized = false;
@@ -335,7 +332,7 @@ unsigned int AltsoundProcessor::getSample(const unsigned int cmd_combined_in)
 
 			// num_samples now contains the number of samples with the same ID
 			// pick one to play at random
-			sample_idx = (unsigned int)i + rand() % num_samples;
+			sample_idx = static_cast<unsigned int>(i) + rand() % num_samples;
 			break;
 		}
 	}
@@ -406,14 +403,12 @@ bool AltsoundProcessor::process_jingle(AltsoundStreamInfo* stream_out)
 		if (stream_out->stop_music) {
 			// STOP field set. Stop current music stream
 			if (!stopMusicStream()) {
-				//success = false;
 				ALT_WARNING(0, "FAILED AltsoundProcessor::stopMusicStream()");
 			}
 		}
 		else if (stream_out->ducking < 0.0f) {
 			// Pause current music stream
 			if (BASS_ChannelPause(cur_mus_stream->hstream)) {
-				//success = false;
 				ALT_WARNING(0, "FAILED BASS_ChannelPause(): %s", get_bass_err());
 			}
 		}

--- a/src/wpc/altsound/altsound_processor_base.cpp
+++ b/src/wpc/altsound/altsound_processor_base.cpp
@@ -145,6 +145,8 @@ bool AltsoundProcessorBase::startLogging(const std::string& gameName) {
 	return true;
 }
 
+// ---------------------------------------------------------------------------
+
 bool AltsoundProcessorBase::findFreeChannel(unsigned int& channel_out)
 {
 	ALT_INFO(0, "BEGIN: AltsoundProcessorBase::findFreeChannel()");
@@ -152,7 +154,7 @@ bool AltsoundProcessorBase::findFreeChannel(unsigned int& channel_out)
 
 	const auto it = std::find(channel_stream.begin(), channel_stream.end(), nullptr);
 	if (it != channel_stream.end()) {
-		channel_out = (unsigned int)std::distance(channel_stream.begin(), it);
+		channel_out = static_cast<unsigned int>(std::distance(channel_stream.begin(), it));
 		ALT_INFO(1, "Found free channel: %02u", channel_out);
 		
 		OUTDENT;
@@ -201,7 +203,7 @@ bool AltsoundProcessorBase::createStream(void* syncproc_in, AltsoundStreamInfo* 
 	ALT_DEBUG(0, "BEGIN AltsoundProcessorBase::createStream()");
 	INDENT;
 
-	const std::string short_path = getShortPath(stream_out->sample_path); // supports logging
+	const std::string short_path = getShortPath(stream_out->sample_path);
 	unsigned int ch_idx;
 	
 	if (!ALT_CALL(findFreeChannel(ch_idx))) {
@@ -215,7 +217,7 @@ bool AltsoundProcessorBase::createStream(void* syncproc_in, AltsoundStreamInfo* 
 	stream_out->channel_idx = ch_idx; // store channel assignment
 	const bool loop = stream_out->loop;
 
-  // Create playback stream
+    // Create playback stream
 	HSTREAM hstream = BASS_StreamCreateFile(FALSE, stream_out->sample_path.c_str(), 0, 0, loop ? BASS_SAMPLE_LOOP : 0);
 
 	if (hstream == BASS_NO_STREAM) {

--- a/src/wpc/altsound/gsound_csv_parser.cpp
+++ b/src/wpc/altsound/gsound_csv_parser.cpp
@@ -90,7 +90,6 @@ bool GSoundCsvParser::parse(std::vector<GSoundSampleInfo>& samples_out)
 			// Read TYPE field
 			if (std::getline(ss, field, ',')) {
 				field = trim(field);
-				//field = toLower(field);
 				std::transform(field.begin(), field.end(), field.begin(), ::tolower);
 				entry.type = field;
 

--- a/src/wpc/altsound/gsound_processor.cpp
+++ b/src/wpc/altsound/gsound_processor.cpp
@@ -24,7 +24,6 @@
 #include <string>
 
 // Local includes
-//#include "osdepend.h"
 #include "gsound_csv_parser.hpp"
 
 using std::string;
@@ -164,7 +163,7 @@ extern BehaviorInfo solo_behavior;
 extern BehaviorInfo overlay_behavior;
 
 // convenience structure for working with behaviors
-std::unordered_map<AltsoundSampleType, BehaviorInfo*> behavior_map = { //!! meh
+std::unordered_map<AltsoundSampleType, BehaviorInfo*> behavior_map = {
 	{MUSIC, &music_behavior},
 	{CALLOUT, &callout_behavior},
 	{SFX, &sfx_behavior},
@@ -182,8 +181,6 @@ GSoundProcessor::GSoundProcessor(const std::string& _game_name, const std::strin
   is_stable(true), // future use
   generator(std::random_device()()) // seed random number generator
 {
-	//// perform initialization (load samples, etc)
-	//init();
 }
 
 GSoundProcessor::~GSoundProcessor()
@@ -435,7 +432,7 @@ unsigned int GSoundProcessor::getSample(const unsigned int cmd_combined_in)
 			// Each matching sample has equal chance (1/matching_sample_count) to
 			// become the selected one.
 			if (distribution(generator) % matching_sample_count == 0) {
-				sample_idx = (unsigned int)i;
+				sample_idx = static_cast<unsigned int>(i);
 			}
 		}
 	}
@@ -860,13 +857,6 @@ bool GSoundProcessor::adjustStreamVolumes()
 		const auto& stream = *streamPtr; // Dereference pointer for readability
 		float ducking_value = 1.0f;
 
-		//std::unordered_map<AltsoundSampleType, BehaviorInfo*> behavior_map = {
-		//	{MUSIC, &music_behavior},
-		//	{CALLOUT, &callout_behavior},
-		//	{SFX, &sfx_behavior},
-		//	{SOLO, &solo_behavior},
-		//	{OVERLAY, &overlay_behavior}
-		//};
 		const float grp_vol = behavior_map[stream.stream_type]->group_vol;
 
 		const AltsoundSampleType stream_type = stream.stream_type;

--- a/src/wpc/altsound/snd_alt.cpp
+++ b/src/wpc/altsound/snd_alt.cpp
@@ -5,14 +5,6 @@
 
 #include "snd_alt.h"
 
-//#if defined(_WIN32)
-//  #include <direct.h>
-//  #define CURRENT_DIRECTORY _getcwd
-//#else
-//  #include <unistd.h>
-//  #define CURRENT_DIRECTORY getcwd
-//#endif
-
 // Std Library includes
 #include <algorithm>
 #include <ctime>
@@ -45,6 +37,7 @@
 using std::string;
 using std::endl;
 
+// Global logging instance
 AltsoundLogger alog("altsound.log");
 
 // Data structure to hold sample behaviors
@@ -96,8 +89,6 @@ bool use_rom_ctrl = true;
 
 // get path to VPinMAME
 std::string get_vpinmame_path();
-
-//std::string trim(const std::string& str);
 
 // ---------------------------------------------------------------------------
 // Functional code
@@ -261,14 +252,6 @@ BOOL alt_sound_init(CmdData* cmds_out)
 		ALT_DEBUG(0, "END alt_sound_init()");
 		return FALSE;
 	}
-
-	/*if (!processor) {
-		ALT_ERROR(0, "FAILED: Unable to create AltSound processor");
-		
-		OUTDENT;
-		ALT_DEBUG(0, "END alt_sound_init()");
-		return FALSE;
-	}*/
 	ALT_INFO(0, "%s processor created", format.c_str());
 
 	processor->setMasterVol(1.0f);
@@ -325,7 +308,6 @@ BOOL alt_sound_init(CmdData* cmds_out)
 // ---------------------------------------------------------------------------
 
 extern "C" void alt_sound_exit() {
-	//DAR_TODO clean up internal storage?
 	ALT_DEBUG(0, "BEGIN alt_sound_exit()");
 	INDENT;
 

--- a/src/wpc/snd_cmd.c
+++ b/src/wpc/snd_cmd.c
@@ -351,6 +351,17 @@ void reinit_pinSound(void)
 
 	// create a mail slot to talk to the PinSound Studio
 	hFilePinSound = makeWriteSlot(PinSoundStudioSlotName);
+
+	// DAR@20230901
+	// If PinSound Studio is not running, this will return a bad handle.
+	// If we allow the attempt to make a read slot to occur in this case,
+	// the table will fail to load and hang indefinitely.  Handling the
+	// failure here prevents that
+	if (hFilePinSound == INVALID_HANDLE_VALUE) {
+		LOG(("Error:  Failed to create PinSound write slot!"));
+		return;
+	}
+
 	// create slot to receive response from the PinSound Studio
 	hFilePinMAME = makeReadSlot(PinMAMESlotName);
 


### PR DESCRIPTION
This PR addresses #126 

The problem was with opening a write mail slot .  This obviously fails if PinSound Studio is not running, but we were not checking this.  We then proceed to try to open a read mail slot with a bad file handle.  This causes the code to hang in 64-bit.  By checking for the bad handle and aborting the function, the problem is resolved.
