### PR TITLE
Added per-game ability to skip initial n commands

### DIFF
--- a/src/wpc/altsound/altsound_ini_processor.cpp
+++ b/src/wpc/altsound/altsound_ini_processor.cpp
@@ -91,6 +91,25 @@ bool AltsoundIniProcessor::parse_altsound_ini(const string& path_in)
 	rom_volume_control = (rom_control == "1");
 	ALT_INFO(0, "Parsed \"rom_volume_ctrl\": %s", rom_volume_control ? "true" : "false");
 
+	// get skip count
+	string skip_count_str;
+	inipp::get_value(ini.sections["system"], "cmd_skip_count", skip_count_str);
+	try {
+		if (!skip_count_str.empty()) {
+			const int val = std::stoi(skip_count_str);
+			skip_count = val;
+			ALT_INFO(0, "Parsed \"cmd_skip_count\": %d", skip_count);
+		}
+	}
+	catch (const std::invalid_argument& e) {
+		ALT_ERROR(0, "Invalid number format while parsing cmd_skip_count value: %s\n", skip_count_str.c_str());
+		return false;
+	}
+	catch (const std::out_of_range& e) {
+		ALT_ERROR(0, "Number out of range while parsing cmd_skip_count value: %s\n", skip_count_str.c_str());
+		return false;
+	}
+
 	// get AltSound format type
 	inipp::get_value(ini.sections["format"], "format", altsound_format);
 	altsound_format = normalizeString(altsound_format);
@@ -566,7 +585,6 @@ bool AltsoundIniProcessor::create_altsound_ini(const std::string& path_in)
 		";                     to create custom testing scenarios. The\n"
 		";                     \"cmdlog.txt\" file is created in the \"tables\"\n"
 		";                     folder. This feature is turned off by default\n"
-		";                     NOTE: This is currently only supported for G-Sound format\n"
 		";\n"
 		"; rom_volume_ctrl   : the AltSound processor attempts to recreate original\n"
 		";                     playback behavior using commands sent from the ROM.\n"
@@ -574,11 +592,20 @@ bool AltsoundIniProcessor::create_altsound_ini(const std::string& path_in)
 		";                     muting of the playback volume. Setting this variable\n"
 		";                     to 0 turns this feature off.\n"
 		";                     NOTE: This option works for all AltSound formats\n"
+		";\n"
+		"; cmd_skip_count    : some ROMs send out spurious commands during initialization\n"
+		";                     which match valid runtime commands.  In this case, it is not\n"
+		";                     desirable to output sound, but want to allow later instances\n"
+		";                     to play normally.  This variable allows AltSound authors to\n"
+		";                     specify how many initial commands to ignore at startup.\n"
+		";                     NOTE:  If the record_sound_cmds flag is set, the skipped\n"
+		";                     commands will be included in the recording file.\n"
 		"; ----------------------------------------------------------------------------\n"
 		"\n"
 		"[system]\n"
 		"record_sound_cmds = 0\n"
 		"rom_volume_ctrl = 1\n"
+		"cmd_skip_count = 0\n"
 		"\n"
 		"; ----------------------------------------------------------------------------\n"
 		"; There are three supported AltSound formats:\n"

--- a/src/wpc/altsound/altsound_ini_processor.hpp
+++ b/src/wpc/altsound/altsound_ini_processor.hpp
@@ -54,8 +54,11 @@ public:
 	// Return parsed AltsoundFormat type
 	const std::string& getAltsoundFormat() const;
 
-	// Return parse ROM volume control flag
+	// Return parsed ROM volume control flag
 	const bool usingRomVolumeControl() const;
+
+	// Return parsed skip count value
+	const unsigned int AltsoundIniProcessor::getSkipCount() const;
 
 private: // functions
 	
@@ -90,6 +93,7 @@ private: // data
 	bool record_sound_commands = false;
 	bool rom_volume_control = true;
 	std::string altsound_format;
+	unsigned int skip_count = 0;
 };
 
 // ----------------------------------------------------------------------------
@@ -108,9 +112,15 @@ inline const std::string& AltsoundIniProcessor::getAltsoundFormat() const {
 
 
 // ----------------------------------------------------------------------------
+
 inline const bool AltsoundIniProcessor::usingRomVolumeControl() const {
 	return rom_volume_control;
 }
 
 // ----------------------------------------------------------------------------
+
+inline const unsigned int AltsoundIniProcessor::getSkipCount() const {
+	return skip_count;
+}
+
 #endif // ALTSOUND_INI_PROCESSOR_H

--- a/src/wpc/altsound/altsound_processor.cpp
+++ b/src/wpc/altsound/altsound_processor.cpp
@@ -101,6 +101,16 @@ bool AltsoundProcessor::handleCmd(const unsigned int cmd_combined_in)
 		return false;
 	}
 
+	// Skip this command?
+	unsigned int skip_count = AltsoundProcessorBase::getSkipCount();
+	if (skip_count > 0) {
+		--skip_count;
+		AltsoundProcessorBase::setSkipCount(skip_count);
+		ALT_DEBUG(0, "Sound command skipped, (%d) remaining", skip_count);
+		ALT_DEBUG(0, "END AltsoundProcessor::handleCmd()");
+		return true;
+	}
+
 	// get sample for playback
 	const unsigned int sample_idx = getSample(cmd_combined_in);
 

--- a/src/wpc/altsound/altsound_processor_base.cpp
+++ b/src/wpc/altsound/altsound_processor_base.cpp
@@ -42,7 +42,8 @@ extern bool rec_snd_cmds;
 AltsoundProcessorBase::AltsoundProcessorBase(const std::string& _game_name,
 	                                         const std::string& _vpm_path)
 : game_name(_game_name),
-  vpm_path(_vpm_path)
+  vpm_path(_vpm_path),
+  skip_count(0)
 {
 }
 

--- a/src/wpc/altsound/altsound_processor_base.hpp
+++ b/src/wpc/altsound/altsound_processor_base.hpp
@@ -52,20 +52,28 @@ public:
 	// external interface to stop playback of the current music stream
 	virtual bool stopMusic() = 0;
 
+	// ROM volume control accessor/nutator
 	void romControlsVol(const bool use_rom_vol);
 	bool romControlsVol();
 
+	// command recording flag mutator
 	void recordSoundCmds(const bool rec_sound_cmds);
 
 	// initialize processing state
 	virtual void init();
 
+	// master volume accessor/mutator
 	void setMasterVol(const float vol_in);
 	static float getMasterVol();
 
+	// global accessor/mutator
 	void setGlobalVol(const float vol_in);
 	static float getGlobalVol();
 
+	// command skip count accessor/mutator
+	void setSkipCount(const unsigned int skip_count_in);
+	const unsigned int getSkipCount() const;
+	
 public: // data
 	
 protected: // functions
@@ -97,10 +105,13 @@ protected: // functions
 	// set volume on provided stream
 	static bool setStreamVolume(HSTREAM stream_in, const float vol_in);
 
+	// Return ROM shortname
 	const std::string& getGameName();
 
+	// Return path to VPinMAME
 	const std::string& getVpmPath();
 
+	// Initialize log file
 	bool startLogging(const std::string& gameName);
 
 protected: // data
@@ -116,6 +127,7 @@ private: // data
 	bool use_rom_ctrl = true;
 	static float global_vol;
 	static float master_vol;
+	unsigned int skip_count;
 };
 
 // ----------------------------------------------------------------------------
@@ -126,38 +138,64 @@ inline const std::string& AltsoundProcessorBase::getGameName() {
 	return game_name;
 }
 
+// ----------------------------------------------------------------------------
+
 inline const std::string& AltsoundProcessorBase::getVpmPath() {
 	return vpm_path;
 }
+
+// ----------------------------------------------------------------------------
 
 inline void AltsoundProcessorBase::romControlsVol(const bool use_rom_vol) {
 	use_rom_ctrl = use_rom_vol;
 }
 
+// ----------------------------------------------------------------------------
+
 inline bool AltsoundProcessorBase::romControlsVol() {
 	return use_rom_ctrl;
 }
+
+// ----------------------------------------------------------------------------
 
 inline void AltsoundProcessorBase::recordSoundCmds(const bool rec_sound_cmds) {
 	rec_snd_cmds = rec_sound_cmds;
 }
 
+// ----------------------------------------------------------------------------
+
 inline void AltsoundProcessorBase::setMasterVol(const float vol_in) {
 	master_vol = vol_in;
 }
+
+// ----------------------------------------------------------------------------
 
 inline float AltsoundProcessorBase::getMasterVol() {
 	return master_vol;
 }
 
+// ----------------------------------------------------------------------------
+
 inline void AltsoundProcessorBase::setGlobalVol(const float vol_in) {
 	global_vol = vol_in;
 }
+
+// ----------------------------------------------------------------------------
 
 inline float AltsoundProcessorBase::getGlobalVol() {
 	return global_vol;
 }
 
 // ----------------------------------------------------------------------------
+
+inline const unsigned int AltsoundProcessorBase::getSkipCount() const {
+	return skip_count;
+}
+
+// ----------------------------------------------------------------------------
+
+inline void AltsoundProcessorBase::setSkipCount(const unsigned int skip_count_in) {
+	skip_count = skip_count_in;
+}
 
 #endif // ALTSOUND_PROCESSOR_BASE_HPP

--- a/src/wpc/altsound/gsound_processor.cpp
+++ b/src/wpc/altsound/gsound_processor.cpp
@@ -222,6 +222,16 @@ bool GSoundProcessor::handleCmd(const unsigned int cmd_combined_in)
 		return false;
 	}
 
+	// Skip this command?
+	unsigned int skip_count = AltsoundProcessorBase::getSkipCount();
+	if (skip_count > 0) {
+		--skip_count;
+		AltsoundProcessorBase::setSkipCount(skip_count);
+		ALT_DEBUG(0, "Sound command skipped, (%d) remaining", skip_count);
+		ALT_DEBUG(0, "END GSoundProcessor::handleCmd()");
+		return true;
+	}
+
 	// get sample for playback
 	const int sample_idx = ALT_CALL(getSample(cmd_combined_in));
 

--- a/src/wpc/altsound/snd_alt.cpp
+++ b/src/wpc/altsound/snd_alt.cpp
@@ -258,6 +258,7 @@ BOOL alt_sound_init(CmdData* cmds_out)
 	processor->setGlobalVol(1.0f);
 	processor->romControlsVol(ini_proc.usingRomVolumeControl());
 	processor->recordSoundCmds(ini_proc.recordSoundCmds());
+	processor->setSkipCount(ini_proc.getSkipCount());
 
 	// perform processor initialization (load samples, etc)
 	processor->init();


### PR DESCRIPTION
This feature was added to allow authors to specify a number of sound commands to skip at startup.  This was added to address the issue where commands are received at initialization that are valid during play, but not valid during initialization.  We don't want to ignore the command later during runtime, but we don't want to play sounds during initialization.  By specifying a skip count, 'n' commands are skipped initially, and then handled as expected once the skip count reaches 0.