### PR TITLE
Modified MUSIC type behavior to allow STOPS

### DIFF
--- a/src/wpc/altsound/altsound_ini_processor.cpp
+++ b/src/wpc/altsound/altsound_ini_processor.cpp
@@ -149,6 +149,7 @@ bool AltsoundIniProcessor::parse_altsound_ini(const string& path_in)
 	// parse MUSIC "STOP" behavior
 	// MUSIC streams only stop themselves
 	music_behavior.stops.set(static_cast<int>(BB::MUSIC), true); // MUSIC stops other MUSIC streams
+	success &= parseBehaviorValue(music_section, "stops", music_behavior.stops);
 
 	// DAR@20230823 Leaving this commented code for now in case it becomes necessary
 	// to activate this in the near future.  Will remove later, if not needed

--- a/src/wpc/altsound/gsound_processor.cpp
+++ b/src/wpc/altsound/gsound_processor.cpp
@@ -222,6 +222,12 @@ bool GSoundProcessor::handleCmd(const unsigned int cmd_combined_in)
 		return false;
 	}
 
+	// DAR@20231018
+	// Sometimes ROMs send sound commands at startup that result in unwanted
+	// sound playback.  These commands may be valid during normal runtime, so
+	// we don't want to simply ignore them.  Instead, authors can choose to
+	// skip a number of initial commands.  This can be set in the .ini file
+	// 
 	// Skip this command?
 	unsigned int skip_count = AltsoundProcessorBase::getSkipCount();
 	if (skip_count > 0) {
@@ -538,8 +544,6 @@ bool GSoundProcessor::processBehaviors(const BehaviorInfo& behavior, const Altso
 				ALT_DEBUG(0, "END GSoundProcessor::processBehaviors()");
 				return false;
 			}
-
-
 		}
 		else if (behavior.pauses.test(static_cast<size_t>(sampleBehaviorBit)))
 		{


### PR DESCRIPTION
Previous MUSIC sound type behavior did not allow it to stop other sound types.  This was by design, but it has been shown that the ability to allow MUSIC to stop SOLO streams would be beneficial.