### PR TITLE
libpinmame:  Fix Dip Switch bug in wpc/core.c

### DIFF
--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -1929,7 +1929,7 @@ UINT64 core_getAllSol(void) {
 /  Get the status of a DIP bank (8 dips)
 /-----------------------------------------*/
 int core_getDip(int dipBank) {
-#ifdef VPINMAME
+#if defined(VPINMAME) || defined(LIBPINMAME)
   return vp_getDIP(dipBank);
 #else /* VPINMAME */
   return (readinputport(CORE_COREINPORT+1+dipBank/2)>>((dipBank & 0x01)*8))&0xff;


### PR DESCRIPTION
From the code in wpc/core.c ,  it looks like the intent was for LIBPINMAME to use the VP Interface.
```
#if defined(VPINMAME) || defined(LIBPINMAME)  
#include "vpintf.h"
```

This PR adds the same define for core_getDip function further down in the same file

 The code in win32com/Controller.cpp get_Dip and put_Dip functions also call to the VP Interface.
```
STDMETHODIMP CController::put_Dip(int nNo, int newVal)
{
	// TODO: Add your implementation code here. DONE
        vp_setDIP(nNo, newVal);
	return S_OK;
}
```


This change at least fixes the dipswitch reading on **standalone** branch of vpinball which would not read the 
`Controller.Dip()` 
when set .  

