### PR TITLE
PWM: new implementation

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1007,7 +1007,7 @@ PINMAMEAPI void PinmameSetSolenoidMask(const int low, const uint32_t mask)
 
 PINMAMEAPI int PinmameGetMaxSolenoids()
 {
-	return (CORE_MAXSOL + CORE_MODSOL_MAX);
+	return CORE_MODOUT_SOL_MAX;
 }
 
 /******************************************************
@@ -1041,7 +1041,7 @@ PINMAMEAPI int PinmameGetChangedSolenoids(PinmameSolenoidState* const p_changedS
 
 PINMAMEAPI int PinmameGetMaxLamps()
 {
-	return (CORE_MAXLAMPCOL * 8) + CORE_MAXRGBLAMPS;
+	return CORE_MODOUT_LAMP_MAX;
 }
 
 /******************************************************
@@ -1075,7 +1075,7 @@ PINMAMEAPI int PinmameGetChangedLamps(PinmameLampState* const p_changedStates)
 
 PINMAMEAPI int PinmameGetMaxGIs()
 {
-	return CORE_MAXGI;
+	return CORE_MODOUT_GI_MAX;
 }
 
 /******************************************************
@@ -1109,7 +1109,7 @@ PINMAMEAPI int PinmameGetChangedGIs(PinmameGIState* const p_changedStates)
 
 PINMAMEAPI int PinmameGetMaxLEDs()
 {
-	return CORE_SEGCOUNT;
+	return CORE_MODOUT_SEG_MAX;
 }
 
 /******************************************************

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -1637,7 +1637,7 @@ STDMETHODIMP CController::put_LockDisplay(VARIANT_BOOL newVal)
  ****************************************************************************/
 STDMETHODIMP CController::get_SolMask(int nLow, long *pVal)
 {
-	if ( !pVal || (nLow<0) || (nLow>1) )
+	if ( !pVal)
 		return S_FALSE;
 
 	*pVal = vp_getSolMask(nLow);
@@ -1648,7 +1648,7 @@ STDMETHODIMP CController::get_SolMask(int nLow, long *pVal)
 STDMETHODIMP CController::put_SolMask(int nLow, long newVal)
 {
 	// TODO B2S hack, see vp_setSolMask()
-	if (!((0 <= nLow && nLow <= 2) || (1000 <= nLow && nLow < 1999)))
+	if (!((0 <= nLow && nLow <= 2) || (1000 <= nLow && nLow < 2999)))
 		return S_FALSE;
 
 	vp_setSolMask(nLow, newVal);

--- a/src/wpc/bulb.h
+++ b/src/wpc/bulb.h
@@ -11,6 +11,8 @@
 #define BULB_89   3
 #define BULB_MAX  4
 
+#define BULB_T_MAX 3400
+
 extern void bulb_init();
 extern double bulb_filament_temperature_to_emission(const double T);
 extern double bulb_emission_to_filament_temperature(const double p);

--- a/src/wpc/capcom.h
+++ b/src/wpc/capcom.h
@@ -7,7 +7,6 @@
 #include "core.h"
 #include "sim.h"
 
-extern PINMAME_VIDEO_UPDATE(cc_lamp16x8);
 extern PINMAME_VIDEO_UPDATE(cc_dmd128x32);
 extern PINMAME_VIDEO_UPDATE(cc_dmd256x64);
 extern void cap_UpdateSoundLEDS(int data);

--- a/src/wpc/capgames.c
+++ b/src/wpc/capgames.c
@@ -4,18 +4,19 @@
 #include "capcoms.h"
 #include "sndbrd.h"
 
-#define FLIP    FLIP_SWNO(5,6)
+// CPU controlled flipper coils. Fast flips are also provided but are not 100% correct since the hardware is CPU controlled and pulse modulated
+#define FLIP    FLIP_SWNO(5,6) + FLIP_SOL(FLIP_LL | FLIP_LR | FLIP_UR | FLIP_UL)
 
 /*-- DMD 128 X 32 --*/
 const core_tLCDLayout cc_dispDMD128x32[] = {
   {0,0,32,128,CORE_DMD,(genf *)cc_dmd128x32,NULL},
-  {33,0,8,16,CORE_DMD|CORE_DMDNOAA|CORE_NODISP,(genf *)cc_lamp16x8,NULL}, {0}
+  {0}
 };
 
 /*-- DMD 256 X 64 --*/
 const core_tLCDLayout cc_dispDMD256x64[] = {
   {0,0,64,256,CORE_DMD,(genf *)cc_dmd256x64,NULL},
-  {65,0,8,16,CORE_DMD|CORE_DMDNOAA|CORE_NODISP,(genf *)cc_lamp16x8,NULL}, {0}
+  {0}
 };
 
 // inverted switches for each game (by game number)
@@ -63,15 +64,16 @@ const core_tLCDLayout cc_dispDMD256x64[] = {
 // Kingpin had lots of values that changed, but only one value that goes from 128 to 0 during the bonus collection sequence
 
 #define INITGAMEFF(name, gameno, disp, balls, sb, lamps, fastflipaddr) \
-	CC_INPUT_PORTS_START(name, balls) CC_INPUT_PORTS_END \
-	static int name##_getsol(int solNo) { \
-		return (memory_region(REGION_CPU1)[fastflipaddr] > 0); \
-	} \
-	static core_tGameData name##GameData = {0,disp,{FLIP,0,lamps,1,sb,0,gameno,0, name##_getsol},NULL,{"", capInvSw##gameno}}; \
-	static void init_##name(void) { \
-		core_gameData = &name##GameData; \
-	}
-	
+   CC_INPUT_PORTS_START(name, balls) CC_INPUT_PORTS_END \
+   static int name##_getsol(int solNo) { \
+      return (memory_region(REGION_CPU1)[fastflipaddr] > 0); \
+   } \
+   static core_tGameData name##GameData = {0,disp,{FLIP,0,lamps,1,sb,0,gameno,0, name##_getsol},NULL,{"", capInvSw##gameno}}; \
+   static void init_##name(void) { \
+      core_gameData = &name##GameData; \
+   }
+
+
 /*-------------------------------------------------------------------
 / Goofy Hoops (Romstar game) (04/94)
 /-------------------------------------------------------------------*/
@@ -114,7 +116,7 @@ CORE_GAMEDEFNV(ghv101,"Goofy Hoops (Redemption)",1994,"Romstar",romstar,0)
 /*-------------------------------------------------------------------
 / Pinball Magic (10/95)
 /-------------------------------------------------------------------*/
-INITGAMEFF(pmv112, 1, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8, 0x9f3e)
+INITGAMEFF(pmv112, 1, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9, 0x9f3e)
 //Version 1.0.12
 CC_ROMSTART_4(pmv112,  "u1l_v112.bin",CRC(c8362623) SHA1(ebe37d3273e5cefd4fbc041ea3b15d59010b8160),
                        "u1h_v112.bin",CRC(f6232c74) SHA1(28bab61de2ece27aff4cbdd36b10c136a4b7c936),
@@ -128,7 +130,7 @@ CAPCOMS_SOUNDROM3("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e0
 CC_ROMEND
 CORE_GAMEDEFNV(pmv112,"Pinball Magic (1.0.12)",1995,"Capcom",cc2,0)
 //Redemption Version 1.0.12I
-INITGAMEFF(pmv112r, 2, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8, 0x9f3e)
+INITGAMEFF(pmv112r, 2, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9, 0x9f3e)
 CC_ROMSTART_4(pmv112r, "u1lv112i.bin",CRC(28d35969) SHA1(e19856402855847286db73c17510614d8b40c882),
                        "u1hv112i.bin",CRC(f70da65c) SHA1(0f98c95edd6f2821e3a67ff1805aa752a4d018c0),
                        "u2l_v10.bin", CRC(d3e4241d) SHA1(fe480ea2b3901e2e571f8871a0ebe63fbf152e28),
@@ -145,7 +147,7 @@ CORE_CLONEDEFNV(pmv112r,pmv112,"Pinball Magic (Redemption 1.0.12)",1995,"Capcom"
 / Airborne (03/96)
 /-------------------------------------------------------------------*/
 //Version 1.6
-INITGAMEFF(abv106, 3, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8, 0x0a7c6)
+INITGAMEFF(abv106, 3, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9, 0x0a7c6)
 CC_ROMSTART_4(abv106,  "u1l_v16.bin", CRC(59b258f1) SHA1(764496114609d65648e1c7b12409ec582037d8df),
                        "u1h_v16.bin", CRC(a4571905) SHA1(62fabc45e81c49125c047c6e5d268d4093b860bc),
                        "u2l_v10.bin", CRC(a15b1ec0) SHA1(673a283ddf670109a9728fefac2bcf493d70f23d),
@@ -158,7 +160,7 @@ CC_ROMEND
 CORE_GAMEDEFNV(abv106,"Airborne (1.6)",1996,"Capcom",cc2,0)
 
 //Version 1.5
-INITGAME(abv105, 3, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8)
+INITGAME(abv105, 3, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9)
 CC_ROMSTART_4(abv105,  "u1l_v15.bin", CRC(c66e8abc) SHA1(06e5b36dcb98eb33c7239592bb8e2485814789b3),
                        "u1h_v15.bin", CRC(de642229) SHA1(cb62d966f8088d069d66faec1554c63e504f18d6),
                        "u2l_v10.bin", CRC(a15b1ec0) SHA1(673a283ddf670109a9728fefac2bcf493d70f23d),
@@ -171,7 +173,7 @@ CC_ROMEND
 CORE_CLONEDEFNV(abv105,abv106,"Airborne (1.5)",1996,"Capcom",cc2,0)
 
 //Redemption Version 1.6I
-INITGAME(abv106r, 4, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8)
+INITGAME(abv106r, 4, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9)
 CC_ROMSTART_4(abv106r, "u1l_v16i.bin",CRC(7d7d2d85) SHA1(5c83022d7c0b61b15455942b3bdd0cf89fc75b57),
                        "u1h_v16i.bin",CRC(b9bc0c5a) SHA1(e6fc393b970a2c354e0b0150dafbbbea2a85b92d),
                        "u2l_v10.bin", CRC(a15b1ec0) SHA1(673a283ddf670109a9728fefac2bcf493d70f23d),
@@ -188,7 +190,7 @@ CORE_CLONEDEFNV(abv106r,abv106,"Airborne (Redemption 1.6)",1996,"Capcom",cc2,0)
 / Breakshot (05/96)                    (manual says BREAKSHOT or Breakshot, game says Break Shot, art implies BreakShot)
 /-------------------------------------------------------------------*/
 //Version 1.3
-INITGAMEFF(bsv103, 5, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0, 0xa7da)
+INITGAMEFF(bsv103, 5, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1, 0xa7da)
 CC_ROMSTART_2(bsv103,  "u1l_v13.bin", CRC(f8932dcc) SHA1(dab34e6c412655c60abeedc1f62254dce5ebb202),
                        "u1h_v13.bin", CRC(508c145d) SHA1(b019d445f87bca203646c616fdc295066da90921))
 //I'm told BS can run with the U24 from FF
@@ -199,7 +201,7 @@ CC_ROMEND
 CORE_GAMEDEFNV(bsv103,"Breakshot (1.3)",1996,"Capcom",cc1,0)
 
 //Version 1.2
-INITGAME(bsv102, 5, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0)
+INITGAME(bsv102, 5, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1)
 CC_ROMSTART_2(bsv102,  "u1l_v12.bin", CRC(3e61a32b) SHA1(7708f2c65eea44a872432581ad6ced16e3bbf9f9),
                        "u1h_v12.bin", CRC(2bfeb237) SHA1(87097d102beff2816cb61d58811dcdf9c04bc18e))
 CAPCOMS_SOUNDROM2("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e0252800b28274),
@@ -209,7 +211,7 @@ CC_ROMEND
 CORE_CLONEDEFNV(bsv102, bsv103,"Breakshot (1.2)",1996,"Capcom",cc1,0)
 
 //Redemption Version 1.0I
-INITGAME(bsv100r, 6, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0)
+INITGAME(bsv100r, 6, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1)
 CC_ROMSTART_2(bsv100r, "u1l_v10i.bin",CRC(304b4da8) SHA1(2643f304adce3543b792bd2d0ec8abe8d9a5478c),
                        "u1h_v10i.bin",CRC(c10b2aff) SHA1(a56af0903c8b8282baf63dc47741ef094cfd6a1c))
 //I'm told BS can run with the U24 from FF
@@ -220,7 +222,7 @@ CAPCOMS_SOUNDROM2a("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e
 CC_ROMEND
 CORE_CLONEDEFNV(bsv100r,bsv103,"Breakshot (Redemption 1.0)",1996,"Capcom",cc1,0)
 //Redemption Version 1.2I
-INITGAME(bsv102r, 7, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0)
+INITGAME(bsv102r, 7, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1)
 CC_ROMSTART_2(bsv102r, "u1l_v12i.bin",CRC(ed09e463) SHA1(74b4e3e93648e05e66a20f895133f1a0ba2ecb20),
                        "u1h_v12i.bin",CRC(71bf99e9) SHA1(cb48eb5c5df6b03022d9cb20c84dfdcc34a7d5ac))
 //I'm told BS can run with the U24 from FF
@@ -231,7 +233,7 @@ CAPCOMS_SOUNDROM2a("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e
 CC_ROMEND
 CORE_CLONEDEFNV(bsv102r,bsv103,"Breakshot (Redemption 1.2)",1996,"Capcom",cc1,0)
 //Beta Version 1.5
-INITGAME(bsb105, 8, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0)
+INITGAME(bsb105, 8, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1)
 CC_ROMSTART_2(bsb105,  "bsu1l_b1.05", CRC(053684c7) SHA1(cf104a6e9c245523e29989389654c12437d32776),
                        "bsu1h_b1.05", CRC(f1dc6db8) SHA1(da209872047a1deac88fe389bcc26bcf353f6df8))
 //I'm told BS can run with the U24 from FF
@@ -246,7 +248,7 @@ CORE_CLONEDEFNV(bsb105,bsv103,"Breakshot (Beta 1.5)",1996,"Capcom",cc1,0)
 //Version 1.04
 // Not 100% clear on FF address for this one.   Goes 0-255 at seemingly appropriate times,
 // but will disable flips for a short period on a tilt warning ("yellow card" on DMD).
-INITGAMEFF(ffv104, 9, cc_dispDMD256x64, 3, SNDBRD_CAPCOMS, 8, 0x010af)
+INITGAMEFF(ffv104, 9, cc_dispDMD256x64, 3, SNDBRD_CAPCOMS, 9, 0x010af)
 CC_ROMSTART_8(ffv104,  "u1l_v104.bin",CRC(375f4dd3) SHA1(0e3845afccf51a2d20e01afb371b8b7076a1ea79), // labeled as V1.04 in Pfutz' readme (see below)
                        "u1h_v104.bin",CRC(2133fc8e) SHA1(b4296f890a11aefdd09083636f416112e64fb0be), // dto.
                        "u2l_v104.bin",CRC(b74175ae) SHA1(dd0279e20a2ccb03dbea0087ab9d15a973543553), // dto.
@@ -282,7 +284,7 @@ CC_ROMEND
 CORE_CLONEDEFNV(ffv103,ffv104,"Flipper Football (1.03)",1996,"Capcom",cc2,0)
 
 //Version 1.01
-INITGAME(ffv101, 12, cc_dispDMD256x64, 3, SNDBRD_CAPCOMS, 8)
+INITGAME(ffv101, 12, cc_dispDMD256x64, 3, SNDBRD_CAPCOMS, 9)
 CC_ROMSTART_8(ffv101,  "u1l_v100.bin",CRC(1c0b776f) SHA1(a1cabe9646973a97000a8f42295dfcfbed3691fa),
                        "u1h_v100.bin",CRC(13590a38) SHA1(04cb048677b725a2563a12f18853372d5280d464),
                        "u2l_v100.bin",CRC(ee373854) SHA1(cf4814c8c18ab5ca6bf3f134e3c3f95e6f8fe870),
@@ -303,7 +305,7 @@ CORE_CLONEDEFNV(ffv101,ffv104,"Flipper Football (1.01)",1996,"Capcom",cc2,0)
 / Big Bang Bar - Beta (11/96)
 /-------------------------------------------------------------------*/
 //Beta Version 1.9
-INITGAMEFF(bbb109, 10, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8, 0x6234d)
+INITGAMEFF(bbb109, 10, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9, 0x6234d)
 CC_ROMSTART_4(bbb109,  "u1l_b19.bin", CRC(32be6cb0) SHA1(e6c73366d5b85c0e96878e275320f82004bb97b5),
                        "u1h_b19.bin", CRC(2bd1c06d) SHA1(ba81faa07b9d53f51bb981a82aa8684905516420),
                        "u2l_b17.bin", CRC(9bebf271) SHA1(01c85396b96ffb04e445c03d6d2d88cce7835664),
@@ -316,7 +318,7 @@ CAPCOMS_SOUNDROM4b("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e
 CC_ROMEND
 CORE_GAMEDEFNV(bbb109,"Big Bang Bar (Beta 1.9 US)",1996,"Capcom",cc2,0)
 
-INITGAME(bbb108, 10, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8)
+INITGAME(bbb108, 10, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9)
 CC_ROMSTART_4(bbb108,  "u1l_b18.bin", CRC(60a02e1e) SHA1(c2967b4ba0ce01cb9f4ed5ceb4ca5f16596fc75b),
                        "u1h_b18.bin", CRC(7a987a29) SHA1(5307b7feb8d86cf7dd51dd9c501b2539441b684e),
                        "u2l_b17.bin", CRC(9bebf271) SHA1(01c85396b96ffb04e445c03d6d2d88cce7835664),
@@ -337,7 +339,7 @@ CORE_CLONEDEFNV(bbb108,bbb109,"Big Bang Bar (Beta 1.8 US)",1996,"Capcom",cc2,0)
 //With the help of other people, I have found out that this is really version
 //"B1.05", not "V1.0".If you find a version 1.0, please contact me at
 //pfutz@mediaone.net
-INITGAMEFF(kpb105, 11, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 8, 0x70d5)
+INITGAMEFF(kpb105, 11, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 9, 0x70d5)
 CC_ROMSTART_2X(kpb105, "u1hu1l.bin", CRC(d2d42121) SHA1(c731e0b5c9b211574dda8aecbad799bc180a59db),
                        "u2hu2l.bin", CRC(9cd91371) SHA1(197a06a0ed6b661d798ed18b1db72215c28e1bc2))
 CAPCOMS_SOUNDROM4b("u24_v11.bin", CRC(d46212f4) SHA1(50f1279d995b597c468805b323e0252800b28274),
@@ -354,7 +356,7 @@ CORE_GAMEDEFNV(kpb105,"Kingpin (Beta 1.05)",1996,"Capcom",cc2,0) // previously k
 /*-------------------------------------------------------------------
 / Pool Player (Illinois Pinball, 2000)
 /-------------------------------------------------------------------*/
-INITGAME(pp100, 13, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 0)
+INITGAME(pp100, 13, cc_dispDMD128x32, 3, SNDBRD_CAPCOMS, 1)
 CC_ROMSTART_2(pp100, "u1l-v1_0.bin", CRC(cb14635e) SHA1(8d7bb25fdc7ee7f38eaf3cad6326cf678a81b85f),
                      "u1h-v1_0.bin", CRC(9839ff76) SHA1(79c3a9700d2e68ed7d83e669b2df543bcabf7164))
 //I'm told BS can run with the U24 from FF

--- a/src/wpc/s11.h
+++ b/src/wpc/s11.h
@@ -239,6 +239,7 @@ extern MACHINE_DRIVER_EXTERN(de_dmd642aS);
 #define S11_MUXDELAY     0x10 // Delay mux solenoid by one IRQ
 #define S11_SNDDELAY     0x20 // Sound delay for Pool Sharks
 #define S9_BREAKPIA      0x40 // cut one wire on the sound PIA for Still Crazy
+
 #if 0
 GEN_S9      BCDDISP
 GEN_S11

--- a/src/wpc/sims/wpc/full/cftbl.c
+++ b/src/wpc/sims/wpc/full/cftbl.c
@@ -465,7 +465,7 @@ static core_tGameData cftblGameData = {
   GEN_WPCFLIPTRON, wpc_dispDMD,
   {
     FLIP_SW(FLIP_L | FLIP_U) | FLIP_SOL(FLIP_L),
-    0,1,0,0,0,0,0, // 8 (or 12?) ramp lights; the pattern repeats every 4 lamps, so 1 extra column is enough
+    0,1,0,0,0,0,WPC_CFTBL, // 8 ramp lights 'Chase Light' wired between GI outputs 1/4 and 2 bit decoder wired on solenoid outputs 20/24 => directly handled in main WPC driver
     NULL, cftbl_handleMech, NULL, cftbl_drawMech,
     NULL
 #ifdef ENABLE_MECHANICAL_SAMPLES
@@ -482,21 +482,11 @@ static core_tGameData cftblGameData = {
   }
 };
 
-static WRITE_HANDLER(cftbl_wpc_w) {
-  UINT8 state;
-  wpc_w(offset, data);
-  if (offset == WPC_SOLENOID3) {
-    state = 1 << ((GET_BIT7 << 1) | GET_BIT3);
-    coreGlobals.lampMatrix[8] = coreGlobals.tmpLampMatrix[8] = (state << 4) | state;
-  }
-}
-
 /*---------------
 /  Game handling
 /----------------*/
 static void init_cftbl(void) {
   core_gameData = &cftblGameData;
-  install_mem_write_handler(0, 0x3fb0, 0x3fff, cftbl_wpc_w);
   hc55516_set_sample_clock(0, 22372);
 }
 

--- a/src/wpc/vpintf.h
+++ b/src/wpc/vpintf.h
@@ -12,9 +12,9 @@
 	#define GAME_NOCRC 0
 #endif
 
-typedef struct { int lampNo, currStat; } vp_tChgLamps[CORE_MAXLAMPCOL*8];
-typedef struct { int solNo,  currStat; } vp_tChgSols[CORE_MAXSOL + CORE_MODSOL_MAX];
-typedef struct { int giNo,   currStat; } vp_tChgGIs[CORE_MAXGI];
+typedef struct { int lampNo, currStat; } vp_tChgLamps[CORE_MODOUT_LAMP_MAX];
+typedef struct { int solNo,  currStat; } vp_tChgSols[CORE_MODOUT_SOL_MAX];
+typedef struct { int giNo,   currStat; } vp_tChgGIs[CORE_MODOUT_GI_MAX];
 typedef struct { int ledNo, chgSeg, currStat; } vp_tChgLED[CORE_SEGCOUNT];
 typedef struct { int sndNo; } vp_tChgSound[MAX_CMD_LOG];
 typedef struct { int nvramNo, oldStat, currStat; } vp_tChgNVRAMs[CORE_MAXNVRAM];
@@ -22,7 +22,7 @@ typedef struct { int nvramNo, oldStat, currStat; } vp_tChgNVRAMs[CORE_MAXNVRAM];
 #define VP_OUT_SOLENOID          0 /* Solenoid output type */
 #define VP_OUT_LAMP              1 /* Lamp output type */
 #define VP_OUT_GI                2 /* Global Illumination output type */
-#define VP_OUT_LED               3 /* LED segment output type */
+#define VP_OUT_ALPHASEG          3 /* Alpha Numeric segment output type */
 
 #define VP_MAXDIPBANKS 10
 /*----------------------------------------------------
@@ -59,13 +59,13 @@ INLINE int vp_getSwitch(int swNo) { return core_getSw(swNo); }
 /*------------------------------------
 /  get status of a solenoid (0=off, !0=on)
 /-------------------------------------*/
-INLINE int vp_getSolenoid(int solNo) { return core_getSol(solNo); }
+int vp_getSolenoid(int solNo);
 
 /*-------------------------------------------
-/  get status of a GIString (0=off, 1=on)
+/  get status of a GIString (0=off, !0=on)
 / (WPC games only)
 /-------------------------------------*/
-INLINE int vp_getGI(int giNo) { return coreGlobals.gi[giNo]; }
+int vp_getGI(int giNo);
 
 /*-------------------------------------------
 /  get all lamps changed since last call

--- a/src/wpc/wpc.h
+++ b/src/wpc/wpc.h
@@ -250,6 +250,11 @@ extern MACHINE_DRIVER_EXTERN(wpc_95S);
 #define wpc_m95DCSS      wpc_dcsS
 #define wpc_m95S         wpc_95S
 
+// Game specific options
+#define WPC_CFTBL       0x01 // CFTBL specific hardware: chase light 2 bit decoder from solenoid #3 output, wired through triacs to 2 GI outputs, leading to 8 additional PWM controlled GI
+#define WPC_PH          0x02 // Phantom Haus specific hardware (not really a pinball)
+
+
 int wpc_m2sw(int col, int row);
 void wpc_set_modsol_aux_board(int board);
 void wpc_set_fastflip_addr(int addr);

--- a/src/wpc/wpcgames.c
+++ b/src/wpc/wpcgames.c
@@ -60,7 +60,7 @@ static void ph_drawMech(BMTYPE **line) {
 }
 static core_tGameData phGameData = {
   GEN_WPC95, wpc_dispDMD64,
-  { FLIP_SWNO(0,0), 0,16,0,0,0,0,1, NULL, NULL, mech_getPos, ph_drawMech },
+  { FLIP_SWNO(0,0), 0,16,0,0,0,0,WPC_PH, NULL, NULL, mech_getPos, ph_drawMech },
   NULL,
   {
     "901 100031 64739 123",


### PR DESCRIPTION
This is a rewrite of the preliminary PWM support I added at the beginning of the 3.6 phase. While using it, quite a few limitations arise, so I rewrote it to:
- Supports variable rate data writing/integration (needed for fast hardware with <1ms strobes)
- Supports high frequency controller using a linear PWM preintegration applied on high frequency data before physics model (needed for fast hardware with <1ms strobes)
- Supports strobed/PWM lamp matrix (Stern Whitestar and SAM uses this a lot, but it also improves the rendering on other hardwares)
- Supports Alphanumeric segment dimming (not yet exposed to VPinMame)
- Extended to all GI & Solenoids outputs, including aux board (WPC's GI really benefits from this, flashers wired on aux board  have been missing)
- Allow output definition from PinMame driver as well as from client app (allow mods & variants, also allow to support more hardware configuration)

In turn, the rewrite led me to create a sort fo generalized physic output support, then port to it, trying to unify drivers around it. This led to remove (after porting them to the new physic output system) the following implementation:
- the initial modulated solenoids,
- the preliminary PWM introduced in 3.6
- RGB lamps (which were only used by SAM driver to output linearly modulated lights)

This commits includes implementations for the following drivers:
- WPC,
- S11,
- Sega/Stern Whitestar,
- Stern S.A.M.,
- Capcom,
- GTS3

While testing, it appeared that timings were wrong for Capcom hardware, so this commits also contains an improved Capcom driver with better timings (better U16 emulation, fix to MC68k core,...), needed to get correct lamp fading.

This commits also contains the physic hardware definition for the following games: all Capcoms, all WPC, most SAM, GNR for S11, LOTR for Whitestar, none of the GTS3.

The aim would be to have all the physic device connected to binary outputs defined on the PinMame side but it is too much work to be done straight away. Since the implementation allows to define physics device at runtime (for mods & variants), this also allows to define the missing hardware directly from the user application if we do not gather all the info for 3.6.

Using the new implementation is fairly straightforward (at least for games with hardware already defined): just set SolMask(2) = 6, then changed lamps / solenoids / gi will be 0..255 value relating to the main characteristic of the output (relative brightness for bulbs & LEDs).

Since this is a deep change, I think there will be bugs I jave missed, so this would benefit for large user testing. Also, @mkalkbrenner @jsm174 I tried to keep things clean for PPUC and LibPinMame (and PROC) but since I don't use them, the testing is fairly low.
