### PR TITLE
PWM: simplify enable API, add some Sega/DataEast tables, little fix

### DIFF
--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -32,12 +32,11 @@ Fix some external DMD alphanumeric mappings: GTS80B, GTS3, Hankin, Police Force,
 Added the emulation of physical bulbs & LEDs connected to binary outputs, for WPC, GTS3, SAM, Whitestar, Capcom and S11 hardware.
   This allows to dramatically improve e.g. lamp or flasher modulation (for example the pulsing lights below the princess of TOTAN,
   or the Sauron eye of LOTR, or slowly fading lamps in Breakshot). This needs to be enabled before use, the same way as for the existing
-  'modulated' solenoids: by setting SolMask(2) which is now a bitmask: 1 is legacy modulated solenoids, 2 is physical model for solenoid
-  outputs, 4 is physical model for lamps/GIs/Segment outputs. To be emulated correctly, devices connected to binary output must be defined.
-  PinMAME already has the definition for lots of them (to be found in MACHINE_INIT of each driver) but if the one you want is missing,
-  or you want to modify it, use 'SolMask(xx) = type' to change it, where xx is the output to be modified (see vp_setSolMask), and yy is
-  the type (see core.h). Also see the updated core scripts coming with VPX.
-  This also opens up the path for emulation of dimmed alphanumerical segments and strength modulated solenoids
+  'modulated' solenoids: by setting SolMask(2) to 1 for legacy modulated solenoids or 2 for physical model of all outputs.
+  To be emulated correctly, devices connected to binary output must be defined. PinMAME already has the definition for lots of them 
+  (to be found in MACHINE_INIT of each driver) but if the one you want is missing, or you want to modify it, use 'SolMask(xx) = type' 
+  to change it, where xx is the output to be modified (see vp_setSolMask), and yy is the type (see core.h). Also see the updated core 
+  scripts coming with VPX. This also opens up the path for emulation of dimmed alphanumerical segments and strength modulated solenoids
   (for example Capcom Kingpin, or the way most modern hardware handle Power/Hold and EOS switch).
 
 *** CORE/CPU ***

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -359,9 +359,8 @@ extern void video_update_core_dmd(struct mame_bitmap *bitmap, const struct recta
 
 /*-- Physical devices on binary outputs --*/
 
-#define CORE_MODOUT_ENABLE_LEGACY    1 /* Bitmask for options.usemodsol to enable legacy behavior (simple solenoid integration for WPC/SAM)  */
-#define CORE_MODOUT_ENABLE_SOLENOIDS 2 /* Bitmask for options.usemodsol to enable solenoids */
-#define CORE_MODOUT_ENABLE_LGIAS     4 /* Bitmask for options.usemodsol to enable Lamp/GI/AlphaSegments */
+#define CORE_MODOUT_ENABLE_MODSOL    1 /* Bitmask for options.usemodsol to enable legacy behavior (simple solenoid linear integration for WPC/SAM)  */
+#define CORE_MODOUT_ENABLE_PHYSOUT   2 /* Bitmask for options.usemodsol to enable physics output for solenoids/Lamp/GI/AlphaSegments */
 #define CORE_MODOUT_FORCE_ON       128 /* Bitmask for options.usemodsol for drivers that needs PWM integration to be performed whatever the user settings are */
 
 #define CORE_MODOUT_LAMP_MAX                   (CORE_MAXLAMPCOL*8) /* Maximum number of modulated outputs for lamps */

--- a/src/wpc/sims/wpc/full/bop.c
+++ b/src/wpc/sims/wpc/full/bop.c
@@ -712,9 +712,11 @@ static int bop_getMech(int mechNo) {
 
 static WRITE_HANDLER(parallel_0_out) {
   coreGlobals.lampMatrix[8] = coreGlobals.tmpLampMatrix[8] = data ^ 0xff;
+  core_write_pwm_output_8b(CORE_MODOUT_LAMP0 + 8 * 8, data ^ 0xff);
 }
 static WRITE_HANDLER(parallel_1_out) {
   coreGlobals.lampMatrix[9] = coreGlobals.tmpLampMatrix[9] = data ^ 0xff;
+  core_write_pwm_output_8b(CORE_MODOUT_LAMP0 + 9 * 8, data ^ 0xff);
 }
 static WRITE_HANDLER(qspin_0_out) {
   HC4094_data_w(1, data);

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -33,7 +33,7 @@ void vp_init(void) {
 int vp_getLamp(int lampNo) {
   if (coreData->lamp2m) lampNo = coreData->lamp2m(lampNo) - 8;
   /*-- Physical output mode: return a physically meaningful value depending on the output type --*/
-  if (coreGlobals.nLamps && (options.usemodsol & CORE_MODOUT_ENABLE_LGIAS))
+  if (coreGlobals.nLamps && (options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT))
 	 return (int)saturatedByte(coreGlobals.physicOutputState[CORE_MODOUT_LAMP0 + lampNo].value);
 #ifndef LIBPINMAME
   return (coreGlobals.lampMatrix[lampNo/8]>>(lampNo%8)) & 0x01;
@@ -57,7 +57,7 @@ int vp_getSolenoid(int solNo)
 int vp_getGI(int giNo)
 {
   /*-- Physical output mode: return a physically meaningful value depending on the output type --*/
-  if (coreGlobals.nGI && (options.usemodsol & CORE_MODOUT_ENABLE_LGIAS))
+  if (coreGlobals.nGI && (options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT))
 	 return (int)saturatedByte(coreGlobals.physicOutputState[CORE_MODOUT_GI0 + giNo].value);
   return coreGlobals.gi[giNo];
 }
@@ -69,7 +69,7 @@ int vp_getGI(int giNo)
 int vp_getChangedLamps(vp_tChgLamps chgStat) {
   int ii, idx = 0;
   /*-- fill in array --*/
-  if (coreGlobals.nLamps && (options.usemodsol & CORE_MODOUT_ENABLE_LGIAS))
+  if (coreGlobals.nLamps && (options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT))
   {
 	 for (ii = 0; ii < coreGlobals.nLamps; ii++) {
 		UINT8 val = saturatedByte(coreGlobals.physicOutputState[CORE_MODOUT_LAMP0 + ii].value);
@@ -132,8 +132,8 @@ int vp_getChangedSolenoids(vp_tChgSols chgStat)
 {
   int ii, idx = 0;
   if (coreGlobals.nSolenoids && (
-	  (options.usemodsol & CORE_MODOUT_ENABLE_SOLENOIDS) 
-  || ((core_gameData->gen & GEN_ALLWPC) && (options.usemodsol & CORE_MODOUT_ENABLE_LEGACY)) ))
+	  (options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT) 
+  || ((core_gameData->gen & GEN_ALLWPC) && (options.usemodsol & CORE_MODOUT_ENABLE_MODSOL)) ))
   {
     float state[CORE_MODOUT_SOL_MAX];
     core_getAllPhysicSols(state);
@@ -171,7 +171,7 @@ int vp_getChangedSolenoids(vp_tChgSols chgStat)
 /-------------------------------------*/
 int vp_getChangedGI(vp_tChgGIs chgStat) {
   /*-- Physical output mode: return a physically meaningful value depending on the output type --*/
-  if (coreGlobals.nGI && (options.usemodsol & CORE_MODOUT_ENABLE_LGIAS))
+  if (coreGlobals.nGI && (options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT))
   {
 	  int idx = 0;
 	  for (int i = 0; i < coreGlobals.nGI; i++) {
@@ -263,7 +263,7 @@ int vp_getSolMask(int no) {
 	else if (2001 <= no)
 		return vp_getModOutputType(VP_OUT_ALPHASEG, no - 2000);
 	else if (no == 2)
-		return options.usemodsol;
+		return options.usemodsol & ~CORE_MODOUT_FORCE_ON;
 	else if (no == 0 || no == 1)
 		return locals.solMask[no];
 	else
@@ -282,22 +282,22 @@ void vp_setModOutputType(int output, int no, int type) {
 	if (output == VP_OUT_SOLENOID && 1 <= no && no <= coreGlobals.nSolenoids)
 	{
 		pos = CORE_MODOUT_SOL0 + no - 1;
-		options.usemodsol |= CORE_MODOUT_ENABLE_SOLENOIDS;
+		options.usemodsol |= CORE_MODOUT_ENABLE_PHYSOUT;
 	}
 	else if (output == VP_OUT_GI && 1 <= no && no <= coreGlobals.nGI)
 	{
 		pos = CORE_MODOUT_GI0 + no - 1;
-		options.usemodsol |= CORE_MODOUT_ENABLE_LGIAS;
+		options.usemodsol |= CORE_MODOUT_ENABLE_PHYSOUT;
 	}
 	else if (output == VP_OUT_LAMP && 1 <= no && no <= coreGlobals.nLamps)
 	{
 		pos = CORE_MODOUT_LAMP0 + no - 1;
-		options.usemodsol |= CORE_MODOUT_ENABLE_LGIAS;
+		options.usemodsol |= CORE_MODOUT_ENABLE_PHYSOUT;
 	}
 	else if (output == VP_OUT_ALPHASEG && 1 <= no && no <= coreGlobals.nAlphaSegs)
 	{
 		pos = CORE_MODOUT_SEG0 + no - 1;
-		options.usemodsol |= CORE_MODOUT_ENABLE_LGIAS;
+		options.usemodsol |= CORE_MODOUT_ENABLE_PHYSOUT;
 	}
 	if (pos != -1)
 	{

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -1182,8 +1182,7 @@ static MACHINE_INIT(wpc) {
      int flashers[] = { 17, 18, 19, 20, 23, 24 };
      for (int i = 0; i < sizeof(flashers) / sizeof(int); i++)
         coreGlobals.physicOutputState[CORE_MODOUT_SOL0 + flashers[i] - 1].type = CORE_MODOUT_BULB_89_20V_DC_WPC;
-     // TODO check Helmet (seems they are 12V) wired at sol #21/#22 (motor ? but operator manual states flashers)
-     // TODO add Helmet lights
+     core_set_pwm_output_type(CORE_MODOUT_LAMP0 + 8 * 8, 16, CORE_MODOUT_BULB_44_18V_DC_WPC); // Helmet lights
   }
   else if (strncasecmp(gn, "br_l4", 5) == 0) { // Black Rose
      int flashers[] = { 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28 };
@@ -1403,7 +1402,7 @@ static MACHINE_INIT(wpc) {
         coreGlobals.physicOutputState[CORE_MODOUT_SOL0 + flashers[i] - 1].type = CORE_MODOUT_BULB_89_20V_DC_WPC;
   }
   // Legacy integrator for backward compatibility: not really needed, the new one gives better result but could be uncommented if bugs are found with existing tables
-  /*if (options.usemodsol & CORE_MODOUT_ENABLE_LEGACY)
+  /*if (options.usemodsol & CORE_MODOUT_ENABLE_MODSOL)
     core_set_pwm_output_type(CORE_MODOUT_SOL0, coreGlobals.nSolenoids, CORE_MODOUT_LEGACY_SOL_WPC);
     //for (int i = 0; i < coreGlobals.nSolenoids; i++)
     //  if (coreGlobals.physicOutputState[CORE_MODOUT_SOL0 + i].type == CORE_MODOUT_BULB_89_20V_DC_WPC)


### PR DESCRIPTION
The initial enable bitmask flag was made before I port everything to the new API. It is not needed anymore and would make things uselessly more complicated to understand, so just move to eanble new API by setting SolMask(2) to 2 which is fairly straightforward (I will update the VPX script for this).

Other things are just little improvments here and there