### PR TITLE
Fix erroneous application of ducking for music samples

### DIFF
--- a/src/wpc/altsound/altsound_csv_parser.cpp
+++ b/src/wpc/altsound/altsound_csv_parser.cpp
@@ -104,7 +104,7 @@ bool AltsoundCsvParser::parse(std::vector<AltsoundSampleInfo>& samples_out)
 			// DUCK
 			if (std::getline(ss, field, ',')) {
 				float val = std::stof(trim(field));
-				entry.ducking = val < 0.0f ? -1.0f : val > 100.0f ? 1.0f : val / 100.0f;
+				entry.ducking = entry.channel == 0 ? 100.0f : val < 0.0f ? -1.0f : val > 100.0f ? 1.0f : val / 100.0f;
 			}
 			else {
 				ALT_ERROR(0, "Failed to parse sample DUCK value");


### PR DESCRIPTION
Normal convention is to set the ducking value for music samples on channel 0 to 100, since music should not duck music in traditional altsound packages.  However, setting it to anything other than 100 will cause music to duck other music samples.  Setting it to 0 will completely mute other music samples, which is undesirable.  This fix will force music sample ducking to 100, ensuring proper operation.