### PR TITLE
feat: sdl2

### DIFF
--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -62,7 +62,7 @@ jobs:
 
       - if: matrix.os == 'ubuntu-latest'
         run: |    
-          sudo apt install libx11-dev libxv-dev libasound2-dev sdl2-dev
+          sudo apt install libx11-dev libxv-dev libasound2-dev libsdl2-dev
       - name: Build xpinmame-${{ matrix.platform }}
         run: |
           cp cmake/xpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -61,8 +61,8 @@ jobs:
           brew install sdl2
 
       - if: matrix.os == 'ubuntu-latest'
-        run: |    
-          sudo apt install libasound2-dev libsdl2-dev
+        run: |
+          sudo apt update && sudo apt install libasound2-dev libsdl2-dev
       - name: Build xpinmame-${{ matrix.platform }}
         run: |
           cp cmake/xpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -62,7 +62,7 @@ jobs:
 
       - if: matrix.os == 'ubuntu-latest'
         run: |    
-          sudo apt install libx11-dev libxv-dev libasound2-dev
+          sudo apt install libx11-dev libxv-dev libasound2-dev sdl2-dev
       - name: Build xpinmame-${{ matrix.platform }}
         run: |
           cp cmake/xpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -58,11 +58,11 @@ jobs:
       - uses: actions/checkout@v4
       - if: matrix.os == 'macos-latest'
         run: |
-          brew install xquartz
+          brew install sdl2
 
       - if: matrix.os == 'ubuntu-latest'
         run: |    
-          sudo apt install libx11-dev libxv-dev libasound2-dev libsdl2-dev
+          sudo apt install libasound2-dev libsdl2-dev
       - name: Build xpinmame-${{ matrix.platform }}
         run: |
           cp cmake/xpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt

--- a/cmake/xpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/xpinmame/CMakeLists_linux-x64.txt
@@ -107,9 +107,10 @@ add_compile_definitions(
    XMAMEROOT="/usr/local/share/xpinmame"
    HAVE_SNPRINTF
    HAVE_GETTIMEOFDAY
-   #SYSDEP_DSP_ALSA
-   #SYSDEP_MIXER_ALSA
-   SYSDEP_DSP_OSS
+#   SYSDEP_DSP_ALSA
+#   SYSDEP_MIXER_ALSA
+   SYSDEP_DSP_SDL
+   SDL_DEBUG
 )
 
 add_executable(xpinmame
@@ -625,10 +626,11 @@ add_executable(xpinmame
    src/unix/sysdep/sysdep_mixer.c
 #   src/unix/sysdep/dsp-drivers/alsa.c
 #   src/unix/sysdep/mixer-drivers/alsa.c
-   src/unix/sysdep/dsp-drivers/oss.c
-   src/unix/video-drivers/x11.c
-   src/unix/video-drivers/xinput.c
-   src/unix/video-drivers/x11_window.c
+   src/unix/sysdep/dsp-drivers/sdl.c
+#   src/unix/video-drivers/x11.c
+#   src/unix/video-drivers/xinput.c
+#   src/unix/video-drivers/x11_window.c
+   src/unix/video-drivers/sdl.c
    src/unix/joystick-drivers/joy_i386.c
    src/unix/joystick-drivers/joy_pad.c
    src/unix/joystick-drivers/joy_x11.c
@@ -649,6 +651,10 @@ find_package(
    ALSA
 )
 
+find_package(
+   SDL2
+)
+
 target_include_directories(xpinmame PUBLIC
    src
    src/wpc
@@ -659,6 +665,7 @@ target_include_directories(xpinmame PUBLIC
    ${X11_X11_INCLUDE_PATH}
    ${X11_Xv_INCLUDE_PATH}
    ${ALSA_INCLUDE_DIRS}
+   ${SDL2_INCLUDE_DIRS}
 )
 
 target_link_libraries(xpinmame PUBLIC
@@ -667,6 +674,7 @@ target_link_libraries(xpinmame PUBLIC
    ${X11_Xv_LIB}
    ${X11_Xext_LIB}
    ${ALSA_LIBRARIES}
+   ${SDL2_LIBRARIES}
 )
 
 set_target_properties(xpinmame PROPERTIES

--- a/cmake/xpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/xpinmame/CMakeLists_linux-x64.txt
@@ -103,7 +103,7 @@ add_compile_definitions(
    USE_MITSHM
    USE_XV
    USE_HWSCALE
-   DISPLAY_METHOD="x11"
+   DISPLAY_METHOD="SDL2"
    XMAMEROOT="/usr/local/share/xpinmame"
    HAVE_SNPRINTF
    HAVE_GETTIMEOFDAY
@@ -643,16 +643,16 @@ find_package(
    ZLIB REQUIRED
 )
 
-find_package(
-   X11 REQUIRED
-)
+#find_package(
+#   X11
+#)
 
 find_package(
    ALSA
 )
 
 find_package(
-   SDL2
+   SDL2 REQUIRED
 )
 
 target_include_directories(xpinmame PUBLIC
@@ -662,17 +662,17 @@ target_include_directories(xpinmame PUBLIC
    src/cpu/m68000/generated_by_m68kmake
    src/unix
    src/unix/sysdep
-   ${X11_X11_INCLUDE_PATH}
-   ${X11_Xv_INCLUDE_PATH}
+#   ${X11_X11_INCLUDE_PATH}
+#   ${X11_Xv_INCLUDE_PATH}
    ${ALSA_INCLUDE_DIRS}
    ${SDL2_INCLUDE_DIRS}
 )
 
 target_link_libraries(xpinmame PUBLIC
    ZLIB::ZLIB
-   ${X11_X11_LIB}
-   ${X11_Xv_LIB}
-   ${X11_Xext_LIB}
+#   ${X11_X11_LIB}
+#   ${X11_Xv_LIB}
+#   ${X11_Xext_LIB}
    ${ALSA_LIBRARIES}
    ${SDL2_LIBRARIES}
 )

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -102,6 +102,10 @@ add_compile_definitions(
    SYSDEP_DSP_COREAUDIO
 )
 
+add_definitions(
+   "-D__forceinline=__attribute__((always_inline)) inline"
+)
+
 add_executable(xpinmame 
    src/artwork.c
    src/artwork.h

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -77,7 +77,6 @@ add_compile_definitions(
    HAS_SAA1099=1
    HAS_QSOUND=1
 
-   INLINE=static __inline
    LSB_FIRST
    x11
    stricmp=strcasecmp
@@ -100,6 +99,10 @@ add_compile_definitions(
    HAVE_GETTIMEOFDAY
 
    SYSDEP_DSP_COREAUDIO
+)
+
+add_definitions(
+    "-DINLINE=static inline __attribute__((always_inline))"
 )
 
 add_executable(xpinmame 

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -77,7 +77,6 @@ add_compile_definitions(
    HAS_SAA1099=1
    HAS_QSOUND=1
 
-   INLINE=static __inline
    LSB_FIRST
    x11
    stricmp=strcasecmp

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -77,7 +77,7 @@ add_compile_definitions(
    HAS_SAA1099=1
    HAS_QSOUND=1
 
-   INLINE=__inline
+   INLINE=static __inline
    LSB_FIRST
    x11
    stricmp=strcasecmp

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -94,7 +94,7 @@ add_compile_definitions(
    USE_XV
    USE_HWSCALE
    NAME="xpinmame"
-   DISPLAY_METHOD="x11"
+   DISPLAY_METHOD="SDL2"
    XMAMEROOT="/usr/local/share/xpinmame"
    HAVE_SNPRINTF
    HAVE_GETTIMEOFDAY
@@ -612,9 +612,10 @@ add_executable(xpinmame
    src/unix/sysdep/sysdep_dsp.c 
    src/unix/sysdep/sysdep_mixer.c 
    src/unix/sysdep/dsp-drivers/coreaudio.c 
-   src/unix/video-drivers/x11.c 
-   src/unix/video-drivers/xinput.c 
-   src/unix/video-drivers/x11_window.c 
+#   src/unix/video-drivers/x11.c
+#   src/unix/video-drivers/xinput.c
+#   src/unix/video-drivers/x11_window.c
+   src/unix/video-drivers/sdl.c
    src/unix/joystick-drivers/joy_i386.c 
    src/unix/joystick-drivers/joy_pad.c 
    src/unix/joystick-drivers/joy_x11.c 
@@ -627,8 +628,12 @@ find_package(
    ZLIB
 )
 
+#find_package(
+#   X11
+#)
+
 find_package(
-   X11
+   SDL2 REQUIRED
 )
 
 find_library(
@@ -641,16 +646,18 @@ target_include_directories(xpinmame PUBLIC
    src/cpu/m68000
    src/cpu/m68000/generated_by_m68kmake
    src/unix
-   ${X11_X11_INCLUDE_PATH}
-   ${X11_Xv_INCLUDE_PATH}
+#   ${X11_X11_INCLUDE_PATH}
+#   ${X11_Xv_INCLUDE_PATH}
+   ${SDL2_INCLUDE_DIRS}
 )
 
 target_link_libraries(xpinmame PUBLIC
    ZLIB::ZLIB
-   ${X11_X11_LIB}
-   ${X11_Xv_LIB} 
-   ${X11_Xext_LIB}
+ #  ${X11_X11_LIB}
+ #  ${X11_Xv_LIB}
+ #  ${X11_Xext_LIB}
    ${COREAUDIO_FRAMEWORK}
+   ${SDL2_LIBRARIES}
 )
 
 set_target_properties(xpinmame PROPERTIES

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -77,6 +77,7 @@ add_compile_definitions(
    HAS_SAA1099=1
    HAS_QSOUND=1
 
+   INLINE=__inline
    LSB_FIRST
    x11
    stricmp=strcasecmp
@@ -99,10 +100,6 @@ add_compile_definitions(
    HAVE_GETTIMEOFDAY
 
    SYSDEP_DSP_COREAUDIO
-)
-
-add_definitions(
-   "-D__forceinline=__attribute__((always_inline)) inline"
 )
 
 add_executable(xpinmame 

--- a/src/driver.h
+++ b/src/driver.h
@@ -628,7 +628,7 @@ const struct GameDriver driver_##NAME =         \
 
 ***************************************************************************/
 
-extern struct GameDriver *drivers[];
+extern const struct GameDriver *drivers[];
 extern const struct GameDriver *test_drivers[];
 
 #endif

--- a/src/unix/sysdep/dsp-drivers/sdl.c
+++ b/src/unix/sysdep/dsp-drivers/sdl.c
@@ -30,33 +30,22 @@ Version 0.1, January 2002
 
 
 */
+
+// SDL defines this to __inline__ which no longer works with gcc 5+ ?
+// TODO find the correct way to handle this, similar issue with ALSA
+#ifndef SDL_FORCE_INLINE
+#if ( (defined(__GNUC__) && (__GNUC__ >= 5)))
+#define SDL_FORCE_INLINE __attribute__((always_inline)) static inline
+#endif
+#endif /* take the definition from SDL */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
-#include "SDL.h"
+#include "SDL2/SDL.h"
 #include "sysdep/sysdep_dsp.h"
 #include "sysdep/sysdep_dsp_priv.h"
 #include "sysdep/plugin_manager.h"
-
-#ifdef __BEOS__
-#define BUFFERSIZE 1470 * 4 /* in my experience, BeOS likes buffers to be 4x */
-#else
-#define BUFFERSIZE 1024
-#endif
-
-/* private variables */
-static struct {
-	Uint8 *data;
-    int amountRemain;
-    int amountWrite;
-    int amountRead;
-    int tmp;
-    Uint32 soundlen;
-    int sound_n_pos;
-    int sound_w_pos;
-    int sound_r_pos;
-} sample; 
 
 /* callback function prototype */
 static void sdl_fill_sound(void *unused, Uint8 *stream, int len);
@@ -78,6 +67,10 @@ const struct plugin_struct sysdep_dsp_sdl = {
    NULL, /* no exit */
    sdl_dsp_create,
    3     /* high priority */
+};
+
+struct sdl_info {
+   SDL_AudioDeviceID id;
 };
 
 /* public methods (static but exported through the sysdep_dsp or plugin
@@ -105,14 +98,6 @@ static void *sdl_dsp_create(const void *flags)
    		sdl_dsp_destroy(dsp);
    		return NULL;
    }
-
-   
-   if (!(sample.data = calloc(BUFFERSIZE, sizeof(Uint8))))
-   {
-   		fprintf(stderr, "error malloc failed for data\n");
-   		sdl_dsp_destroy(dsp);
-   		return NULL;
-   }
    
    /* fill in the functions and some data */
    dsp->_priv = priv;
@@ -120,39 +105,58 @@ static void *sdl_dsp_create(const void *flags)
    dsp->destroy = sdl_dsp_destroy;
    dsp->hw_info.type = params->type;
    dsp->hw_info.samplerate = params->samplerate;
-    
-    
-   /* set the number of bits */
+
    audiospec->format = (dsp->hw_info.type & SYSDEP_DSP_16BIT)?
    							AUDIO_S16SYS : AUDIO_S8;
-   
-   /* set the number of channels */
    audiospec->channels = (dsp->hw_info.type & SYSDEP_DSP_STEREO)? 2:1;
-         
-   /* set the samplerate */
    audiospec->freq = dsp->hw_info.samplerate;
-   
-   /* set samples size */
-   audiospec->samples = BUFFERSIZE;
-   
-   /* set callback funcion */
-   audiospec->callback = sdl_fill_sound;
-   
-   audiospec->userdata = NULL;
-   
+
    /* Open audio device */
    if(SDL_WasInit(SDL_INIT_VIDEO)!=0)   /* If sdl video system is already */
       SDL_InitSubSystem(SDL_INIT_AUDIO);/* initialized, we just initialize */
    else									/* the audio subsystem */
    	  SDL_Init(SDL_INIT_AUDIO);   		/* else we MUST use "SDL_Init" */
    										/* (untested) */
-   if (SDL_OpenAudio(audiospec, NULL) != 0) { 
-   		fprintf(stderr, "failed opening audio device\n");
-   		return NULL;
-   }
-   SDL_PauseAudio(0);
+
+	fprintf(stderr, "sdl info: driver = %s\n", SDL_GetCurrentAudioDriver());
+
+	// get audio subsystem and open a queue with above spec
+	SDL_AudioSpec *obtained;
+	if (!(obtained = calloc(1, sizeof(SDL_AudioSpec))))
+	{
+		fprintf(stderr, "sdl error: malloc failed for SDL_AudioSpec\n");
+		sdl_dsp_destroy(dsp);
+		return NULL;
+	}
+
+	const SDL_AudioDeviceID id = SDL_OpenAudioDevice(NULL, 0, audiospec, obtained, 0);
+	if (id == 0) {
+		fprintf(stderr, "sdl error: SDL_OpenAudioDevice() failed: %s\n", SDL_GetError());
+		return NULL;
+	}
+
+	// free the spec
+	free(audiospec);
+
+	// print the id
+	fprintf(stderr, "sdl info: device id = %d\n", id);
+	// print the obtained contents
+	fprintf(stderr, "sdl info: obtained->format = %d\n", obtained->format);
+	fprintf(stderr, "sdl info: obtained->channels = %d\n", obtained->channels);
+	fprintf(stderr, "sdl info: obtained->freq = %d\n", obtained->freq);
+	fprintf(stderr, "sdl info: obtained->samples = %d\n", obtained->samples);
+	fprintf(stderr, "sdl info: obtained->callback = %p\n", obtained->callback);
+	fprintf(stderr, "sdl info: obtained->userdata = %p\n", obtained->userdata);
+
+	// resume playing on device
+	SDL_PauseAudioDevice(id, 0);
+
+	struct sdl_info *info = (struct sdl_info *)calloc(1, sizeof(struct sdl_info));
+	info->id = id;
+
+	dsp->_priv = info;
    
-   fprintf(stderr, "info: audiodevice %s set to %dbit linear %s %dHz\n",
+   fprintf(stderr, "sdl info: audiodevice %s set to %dbit linear %s %dHz\n",
       device, (dsp->hw_info.type & SYSDEP_DSP_16BIT)? 16:8,
       (dsp->hw_info.type & SYSDEP_DSP_STEREO)? "stereo":"mono",
       dsp->hw_info.samplerate);
@@ -171,74 +175,19 @@ static void sdl_dsp_destroy(struct sysdep_dsp_struct *dsp)
 static int sdl_dsp_write(struct sysdep_dsp_struct *dsp, unsigned char *data,
    int count)
 {
-	/* sound_n_pos = normal position
-	   sound_r_pos = read position
-	   and so on.					*/
-	int result = 0;
-	Uint8 *src;
-	SDL_LockAudio();
-	
-	sample.amountRemain = BUFFERSIZE - sample.sound_n_pos;
-	sample.amountWrite = (dsp->hw_info.type & SYSDEP_DSP_STEREO)? count * 4 : count * 2;
-	
-	if(sample.amountRemain <= 0) {
-		SDL_UnlockAudio();
-		return(result);
+	// count is the number of samples to write
+	const int len = (dsp->hw_info.type & SYSDEP_DSP_STEREO)? count * 4 : count * 2;
+
+	// get device id from dsp
+	const struct sdl_info *info = (struct sdl_info *)dsp->_priv;
+	const SDL_AudioDeviceID dev = info->id;
+
+	const int result = SDL_QueueAudio(dev, data, len);
+	if (result != 0) {
+		fprintf(stderr, "error: SDL_QueueAudio() failed: %s\n", SDL_GetError());
+		return 0;
 	}
-	
-	if(sample.amountRemain < sample.amountWrite) sample.amountWrite = sample.amountRemain;
-		result = (int)sample.amountWrite;
-		sample.sound_n_pos += sample.amountWrite;
-		
-		src = (Uint8 *)data;
-		sample.tmp = BUFFERSIZE - sample.sound_w_pos;
-		
-		if(sample.tmp < sample.amountWrite){
-			memcpy(sample.data + sample.sound_w_pos, src, sample.tmp);
-			sample.amountWrite -= sample.tmp;
-			src += sample.tmp;
-			memcpy(sample.data, src, sample.amountWrite);			
-			sample.sound_w_pos = sample.amountWrite;
-		}
-		else{
-			memcpy( sample.data + sample.sound_w_pos, src, sample.amountWrite);
-			sample.sound_w_pos += sample.amountWrite;
-		}
-		SDL_UnlockAudio();
-		
 	return	count;
-}
-
-/* Private method */
-static void sdl_fill_sound(void *unused, Uint8 *stream, int len) 
-{
-	int result;
-	Uint8 *dst;
-	SDL_LockAudio();
-	sample.amountRead = len;
-	if(sample.sound_n_pos <= 0)
-		SDL_UnlockAudio();
-		
-		if(sample.sound_n_pos<sample.amountRead) sample.amountRead = sample.sound_n_pos;
-		result = (int)sample.amountRead;
-		sample.sound_n_pos -= sample.amountRead;
-		
-		dst = (Uint8*)stream;
-		
-		sample.tmp = BUFFERSIZE - sample.sound_r_pos;
-		if(sample.tmp<sample.amountRead){
-			memcpy( dst, sample.data + sample.sound_r_pos, sample.tmp);
-			sample.amountRead -= sample.tmp;
-			dst += sample.tmp;
-			memcpy( dst, sample.data, sample.amountRead);	
-			sample.sound_r_pos = sample.amountRead;
-		}
-		else{
-			memcpy( dst, sample.data + sample.sound_r_pos, sample.amountRead);
-			sample.sound_r_pos += sample.amountRead;
-		}
-	SDL_UnlockAudio();
-
 }
 
 #endif /* ifdef SYSDEP_DSP_SDL */

--- a/src/unix/video-drivers/sdl.c
+++ b/src/unix/video-drivers/sdl.c
@@ -782,6 +782,54 @@ int sdl_keycode_to_key(const SDL_Keycode key_code)
          return KEY_ALT;
       case SDLK_RALT:
          return KEY_ALTGR;
+      case SDLK_CAPSLOCK:
+         return KEY_CAPSLOCK;
+      case SDLK_INSERT:
+         return KEY_INSERT;
+      case SDLK_DELETE:
+         return KEY_DEL;
+      case SDLK_HOME:
+         return KEY_HOME;
+      case SDLK_END:
+         return KEY_END;
+      case SDLK_PAGEUP:
+         return KEY_PGUP;
+      case SDLK_PAGEDOWN:
+         return KEY_PGDN;
+      case SDLK_MENU:
+         return KEY_MENU;
+      case SDLK_KP_ENTER:
+         return KEYCODE_ENTER_PAD;
+      case SDLK_KP_PLUS:
+         return KEY_PLUS_PAD;
+      case SDLK_KP_MINUS:
+         return KEY_MINUS_PAD;
+      // case SDLK_KP_MULTIPLY:
+      //    return KEY_ASTERISK;
+      case SDLK_KP_DIVIDE:
+         return KEY_SLASH_PAD;
+      // case SDLK_KP_PERIOD:
+      //    return KEY_PERIOD_PAD;
+      case SDLK_KP_0:
+         return KEY_0_PAD;
+      case SDLK_KP_1:
+         return KEY_1_PAD;
+      case SDLK_KP_2:
+         return KEY_2_PAD;
+      case SDLK_KP_3:
+         return KEY_3_PAD;
+      case SDLK_KP_4:
+         return KEY_4_PAD;
+      case SDLK_KP_5:
+         return KEY_5_PAD;
+      case SDLK_KP_6:
+         return KEY_6_PAD;
+      case SDLK_KP_7:
+         return KEY_7_PAD;
+      case SDLK_KP_8:
+         return KEY_8_PAD;
+      case SDLK_KP_9:
+         return KEY_9_PAD;
       default:
          return KEY_NONE;
       }

--- a/src/unix/video-drivers/sdl.c
+++ b/src/unix/video-drivers/sdl.c
@@ -905,7 +905,7 @@ void sysdep_update_keyboard()
             fprintf(stderr, "SDL: Text input: %s\n", event.text.text);
 #endif
             kevent.unicode = event.text.text[0];
-            kevent.scancode = KEYCODE_OTHER;
+            kevent.scancode = KEY_NONE;
             xmame_keyboard_register_event(&kevent);
             break;
          case SDL_QUIT:

--- a/src/wpc/driver.c
+++ b/src/wpc/driver.c
@@ -12,7 +12,7 @@ const struct GameDriver driver_0 = {
 #  undef DRIVERNV
 #  define DRIVER(name, ver) &driver_##name##_##ver,
 #  define DRIVERNV(name) &driver_##name,
-struct GameDriver *drivers[] = {
+const struct GameDriver *drivers[] = {
 #  include "driver.c"
 0 /* end of array */
 };


### PR DESCRIPTION
I ported the SDL code to SDL2.

X11 is ancient tech that is going away.
`xpinmame` on linux now builds against SDL2 for graphics and sound.

Some light crackling on the sound, probably something to do with pinmame not coming up with audio data in time?

```
SDL_AUDIODRIVER=pipewire SDL_VIDEODRIVER=wayland ./build/xpinmame -rompath ~/.pinmame/roms -nvram_directory ~/.pinmame/nvram  t2_l8
```

![image](https://github.com/vpinball/pinmame/assets/161305/3b123e4a-cacb-45fd-889e-be0bce686265)

No luck with hidpi for now
