### PR TITLE
Altsound: Fixed bug with parsing of WPCDCS, WPCSECURITY, WPC95DCS, and WPC95 commands

### DIFF
--- a/src/wpc/altsound/snd_alt.cpp
+++ b/src/wpc/altsound/snd_alt.cpp
@@ -412,9 +412,10 @@ void preprocess_commands(CmdData* cmds_out, int cmd_in)
 
 		ALT_DEBUG(0, "Hardware Generation: GEN_WPCDCS, GEN_WPCSECURITY, GEN_WPC95DCS, GEN_WPC95");
 
-		if (((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA)) // change volume?
-			||
-			((cmd_buffer[2] == 0x00) && (cmd_buffer[1] == 0x00) && (cmd_buffer[0] == 0x00))) // glitch in command buffer?
+		if (((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA))) // change volume?
+			// DAR@20240208 The check below is a very bad idea.  See https://github.com/vpinball/pinmame/issues/220
+			//||
+			//((cmd_buffer[2] == 0x00) && (cmd_buffer[1] == 0x00) && (cmd_buffer[0] == 0x00))) // glitch in command buffer?
 		{
 			if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA) && (cmd_buffer[1] == (cmd_buffer[0] ^ 0xFF))) { // change volume op (following first byte = volume, second = ~volume, if these don't match: ignore)
 				// DAR@20230518

--- a/src/wpc/altsound/snd_alt.cpp
+++ b/src/wpc/altsound/snd_alt.cpp
@@ -413,7 +413,11 @@ void preprocess_commands(CmdData* cmds_out, int cmd_in)
 		ALT_DEBUG(0, "Hardware Generation: GEN_WPCDCS, GEN_WPCSECURITY, GEN_WPC95DCS, GEN_WPC95");
 
 		if (((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA))) // change volume?
-			// DAR@20240208 The check below is a very bad idea.  See https://github.com/vpinball/pinmame/issues/220
+			// DAR@20240208 The check below is dangerous.  If this is still a 
+			//              problem, it would be better to revisit it when it
+			//              reappears to implement a more robust solution that
+			//              works for all systems
+			//              See https://github.com/vpinball/pinmame/issues/220
 			//||
 			//((cmd_buffer[2] == 0x00) && (cmd_buffer[1] == 0x00) && (cmd_buffer[0] == 0x00))) // glitch in command buffer?
 		{


### PR DESCRIPTION
It was brought to my attention that the Theatre of Magic altsound was exhibiting strange behavior.  On ball 1, the sounds would either not be playing or playing the incorrect sound.

After investigating this, it was discovered that code meant to signal a problem with parsing was actually causing a problem.  The details of the problem can be found [here](https://github.com/vpinball/pinmame/issues/220)

The fix involves simply removing the line of code that performs this check.  If the problem which caused this line to be necessary arises again, it should be re-evaluated and addressed with a more robust remedy.