### PR TITLE
Add build number to the COM Version method of VPM #249

### DIFF
--- a/installguide/Interface.html
+++ b/installguide/Interface.html
@@ -99,14 +99,16 @@ interface, with details below.</TD></TR>
         <TD WIDTH="50%" ALIGN="right">Read Only</TH></TD>
     <TR><TD VALIGN=top COLSPAN=2>
             <p>Returns the version number of Visual PinMAME as an 8-digit string
-            "vvmmbbrr":<BR><BR>
+            "vvmmbbrr.bbbb":<BR><BR>
         vv = Major version<BR>
         mm = Minor version<BR>
         bb = Beta version<BR>
-        rr = Revision<BR><BR>
+        rr = Revision<BR>
+        bbbb = Build number<BR><BR>
   	Example:<BR>
-  		A result of "00990201" signifies "Version 0.99 Beta 2 Rev A<BR><BR>
-  		If (Controller.Version&lt;"00990201") Then MsgBox "You need a newer
+  		A result of "00990201.4711" signifies "Version 0.99 Beta 2 Rev A build #4711<BR><BR>
+  		It is possible to amend the build number while checking the version, but not mandatory!<BR><BR>
+  		If (Controller.Version&lt;"00990201.4711") Then MsgBox "You need a newer
 version of VPinMAME." : Exit Sub
         </TD>
     </TR>

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -1742,10 +1742,10 @@ STDMETHODIMP CController::get_Version(BSTR *pVal)
 	int nVersionNo0, nVersionNo1, nVersionNo2, nVersionNo3;
 	GetProductVersion(&nVersionNo0, &nVersionNo1, &nVersionNo2, &nVersionNo3);
 
-	TCHAR szVersion[9];
-	wsprintf(szVersion, _T("%02i%02i%02i00"), nVersionNo0, nVersionNo1, nVersionNo2);
-	//Should output the version number as 03060000 without build number
-	//the build number does not have enough room^^
+	TCHAR szVersion[14];
+	wsprintf(szVersion, _T("%02i%02i%02i00.%04i"), nVersionNo0, nVersionNo1, nVersionNo2, nVersionNo3);
+	// Should output the version number as 03060000.0980
+	// The build number is returned after the decimal sign
 
 	CComBSTR bstrVersion(szVersion);
 


### PR DESCRIPTION
Currently the Version method returns a string as "03060000" for VPM 3.6, it would be an improvement if the build number would be added as decimal value like "03060000.0879" (allowing 4 decimal characters), meaning one would have to change the method to return a bigger string instead.