### PR TITLE
PWM: perform integration on physout read instead of digital out write

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1068,7 +1068,8 @@ PINMAMEAPI int PinmameGetSolenoid(const int solNo)
 	if (!_isRunning)
 		return 0;
 
-	core_request_pwm_output_update();
+   if (options.usemodsol & (CORE_MODOUT_FORCE_ON | CORE_MODOUT_ENABLE_PHYSOUT_SOLENOIDS | CORE_MODOUT_ENABLE_MODSOL))
+      core_update_pwm_outputs(CORE_MODOUT_SOL0 + solNo - 1, 1);
 
 	return vp_getSolenoid(solNo);
 }
@@ -1082,7 +1083,7 @@ PINMAMEAPI int PinmameGetChangedSolenoids(PinmameSolenoidState* const p_changedS
 	if (!_isRunning)
 		return -1;
 
-	core_request_pwm_output_update();
+   core_update_pwm_solenoids();
 
 	vp_tChgSols chgSols;
 	const int count = vp_getChangedSolenoids(chgSols);
@@ -1109,7 +1110,8 @@ PINMAMEAPI int PinmameGetLamp(const int lampNo)
 	if (!_isRunning)
 		return 0;
 
-	core_request_pwm_output_update();
+   if (options.usemodsol & (CORE_MODOUT_FORCE_ON | CORE_MODOUT_ENABLE_PHYSOUT_LAMPS))
+      core_update_pwm_outputs(CORE_MODOUT_LAMP0 + lampNo - 1, 1);
 
 	return vp_getLamp(lampNo);
 }
@@ -1123,7 +1125,7 @@ PINMAMEAPI int PinmameGetChangedLamps(PinmameLampState* const p_changedStates)
 	if (!_isRunning)
 		return -1;
 
-	core_request_pwm_output_update();
+   core_update_pwm_lamps();
 
 	vp_tChgLamps chgLamps;
 	const int count = vp_getChangedLamps(chgLamps);
@@ -1149,8 +1151,9 @@ PINMAMEAPI int PinmameGetGI(const int giNo)
 {
 	if (!_isRunning)
 		return 0;
-
-	core_request_pwm_output_update();
+   
+   if (options.usemodsol & (CORE_MODOUT_FORCE_ON | CORE_MODOUT_ENABLE_PHYSOUT_GI))
+      core_update_pwm_outputs(CORE_MODOUT_GI0 + giNo - 1, 1);
 
 	return vp_getGI(giNo);
 }
@@ -1164,7 +1167,7 @@ PINMAMEAPI int PinmameGetChangedGIs(PinmameGIState* const p_changedStates)
 	if (!_isRunning)
 		return -1;
 
-	core_request_pwm_output_update();
+   core_update_pwm_gis();
 
 	vp_tChgGIs chgGIs;
 	const int count = vp_getChangedGI(chgGIs);
@@ -1191,7 +1194,7 @@ PINMAMEAPI int PinmameGetChangedLEDs(const uint64_t mask, const uint64_t mask2, 
 	if (!_isRunning)
 		return -1;
 
-	core_request_pwm_output_update();
+   core_update_pwm_segments();
 
 	vp_tChgLED chgLEDs;
 	const int count = vp_getChangedLEDs(chgLEDs, mask, mask2);


### PR DESCRIPTION
This PR moves the CPU load out of the emulation thread to solve the 'stuck' flipper bats and audio glitches (audio buffer underflow ?) observed lately by some users. It seems to solve these bugs and also remove any latency caused by PWM implementation. The drawback is that the CPU loads is moved to the caller thread (for example VPX).

The algorithm used is simple enough to not require any synchronization primitive between the 2 threads. It may lead to incorrect output values on arch that do not perform float (4 bytes) read/write as a single operation. std::atomic with relaxed memory access could be used but I think this would be overkill.

Theoretically, I think there is another seldom situation that can defeat this `no sync` design which is described in the following code that would handle it correctly. I also think that this is overkill for the intent (if wanted, simply replace in `core_update_pwm_outputs`):
```
      // Perform integration of flip states that appended since last integration and before now if any
      float prevTimeStamp = output->flipTimeStamps[output->lastIntegrationFlipPos];
      while (output->lastIntegrationFlipPos != output->flipBufferPos)
      {
         output->lastIntegrationFlipPos = (output->lastIntegrationFlipPos + 1) % FLIP_BUFFER_SIZE;
         float nextTimeStamp = output->flipTimeStamps[output->lastIntegrationFlipPos];
         if (nextTimeStamp > prevTimeStamp)
         {
            output->integrator(nextTimeStamp, index, TRUE, (output->lastIntegrationFlipPos & 1) ^ 1);
            prevTimeStamp = nextTimeStamp;
         }
         else
         {
            // We don't perform any thread synchronization and only expect float read/writes to be atomic at the CPU level (true for x86)
            // But since we read/write 2 values (the time stamp and the read pos) and since these operations can be reordered by the compiler or CPU
            // A situation were we would read a circular buffer position while the corresponding timestamp has not yet be written can theoretically happen
            // We detect this situation by validating that the timestamps are always increasing if not, the timestamp has not yet be written, so delay
            // its integration.
            output->lastIntegrationFlipPos = (output->lastIntegrationFlipPos + FLIP_BUFFER_SIZE - 1) % FLIP_BUFFER_SIZE;
            break;
         }
      }
```


To go further some other optimizations could be performed if needed:
- test adding an integrator thread in between the PinMame thread and the VPX thread to leverage CPU cores (adds a bit of latency, also a bit of overhead but spread the load better between cores),
- replace bulb model with a more simple model for parts where the behavior is more linear (for example stable states, especially for cooling down)