### PR TITLE
Add external synchronization using a time fence

### DIFF
--- a/src/cpuexec.c
+++ b/src/cpuexec.c
@@ -205,6 +205,8 @@ static void *interleave_boost_timer;
 static void *interleave_boost_timer_end;
 static double perfect_interleave;
 
+// PinMame: time fence global offset
+static double time_fence_global_offset;
 
 
 /*************************************
@@ -409,6 +411,7 @@ void cpu_run(void)
 
 		/* loop until the user quits or resets */
 		time_to_reset = 0;
+		time_fence_global_offset = 0.0;
 		while (!time_to_quit && !time_to_reset)
 		{
 			profiler_mark(PROFILER_EXTRA);
@@ -835,10 +838,20 @@ void usleep(unsigned int usec)
 static void cpu_timeslice(void)
 {
 	// PinMame: allow external synchronization by suspending emulation when a time fence is reached
-	if (options.time_fence != 0.0 && timer_get_time() >= options.time_fence)
+	// When synchronization is lost, adjust global offset of external clock to resync on it.
+	if (options.time_fence != 0.0)
 	{
-		usleep(100);
-		return;
+		const double now = timer_get_time();
+		if (now >= time_fence_global_offset + options.time_fence)
+		{
+			if (now >= time_fence_global_offset + options.time_fence + 1.0)
+				time_fence_global_offset = now - options.time_fence;
+			else
+				usleep(100);
+			return;
+		}
+		else if (now < time_fence_global_offset + options.time_fence - 1.0)
+			time_fence_global_offset = now - options.time_fence;
 	}
 
 	double target = timer_time_until_next_timer();

--- a/src/ios/video.c
+++ b/src/ios/video.c
@@ -238,6 +238,10 @@ static void throttle_speed(void) {
 	cycles_t curr;
 	cycles_t cps;
 
+	// if we're only syncing on an emulation fence, bail now
+	if (options.time_fence != 0)
+		return;
+
 	profiler_mark(PROFILER_IDLE);
 
 	curr = osd_cycles();

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1051,6 +1051,15 @@ PINMAMEAPI void PinmameSetModOutputType(const int output, const int no, const PI
 }
 
 /******************************************************
+ * PinmameSetTimeFence
+ ******************************************************/
+
+PINMAMEAPI void PinmameSetTimeFence(const double timeInS)
+{
+	vp_setTimeFence(timeInS);
+}
+
+/******************************************************
  * PinmameGetMaxSolenoids
  ******************************************************/
 

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -454,6 +454,7 @@ PINMAMEAPI uint32_t PinmameGetSolenoidMask(const int low);
 PINMAMEAPI void PinmameSetSolenoidMask(const int low, const uint32_t mask);
 PINMAMEAPI PINMAME_MOD_OUTPUT_TYPE PinmameGetModOutputType(const int output, const int no);
 PINMAMEAPI void PinmameSetModOutputType(const int output, const int no, const PINMAME_MOD_OUTPUT_TYPE type);
+PINMAMEAPI void PinmameSetTimeFence(const double timeInS);
 PINMAMEAPI int PinmameGetMaxSolenoids();
 PINMAMEAPI int PinmameGetSolenoid(const int solNo);
 PINMAMEAPI int PinmameGetChangedSolenoids(PinmameSolenoidState* const p_changedStates);

--- a/src/libpinmame/video.c
+++ b/src/libpinmame/video.c
@@ -386,6 +386,10 @@ static void throttle_speed(void) {
 	cycles_t curr;
 	cycles_t cps;
 
+	// if we're only syncing on an emulation fence, bail now
+	if (options.time_fence != 0)
+		return;
+
 	profiler_mark(PROFILER_IDLE);
 
 	curr = osd_cycles();
@@ -441,6 +445,10 @@ void throttle_speed_part(int part, int totalparts)
 	//// if we're only syncing to the refresh, bail now
 	//if (win_sync_refresh)
 	//	return;
+
+	// if we're only syncing on an emulation fence, bail now
+	if (options.time_fence != 0)
+		return;
 
 	// this counts as idle time
 	profiler_mark(PROFILER_IDLE);

--- a/src/mame.h
+++ b/src/mame.h
@@ -223,8 +223,9 @@ struct GameOptions
 	int		debug_height;	/* requested height of debugger bitmap */
 	int		debug_depth;	/* requested depth of debugger bitmap */
 
-	int		at91jit;
-	int		usemodsol; 
+	int		at91jit;       /* PinMame: enable AT91 just in time compiler (x86 only) */
+	int		usemodsol;     /* PinMame: enable & setup physic model tied to binary outputs */
+	double	time_fence;    /* PinMame: enable & setup cpu time limit when using external synchronization */
 
 	#ifdef MESS
 	UINT32 ram;

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -380,6 +380,9 @@ STDMETHODIMP CController::Stop()
 	if ( m_hThreadRun==INVALID_HANDLE_VALUE )
 		return S_OK;
 
+	// Disable time fence that could prevent the machine to stop
+	options.time_fence = 0.0;
+
 	PostMessage(win_video_window, WM_CLOSE, 0, 0);
 	WaitForSingleObject(m_hThreadRun,INFINITE);
 	
@@ -1717,6 +1720,17 @@ STDMETHODIMP CController::put_ModOutputType(int output, int no, int newVal)
 		return S_FALSE;
 
 	vp_setModOutputType(output, no, newVal);
+
+	return S_OK;
+}
+
+/****************************************************************************
+ * IController.TimeFence property: sets a time marker that suspend the 
+ * emulation when reached until the time fence is moved further away.
+ ****************************************************************************/
+STDMETHODIMP CController::put_TimeFence(double timeInS)
+{
+	vp_setTimeFence(timeInS);
 
 	return S_OK;
 }

--- a/src/win32com/Controller.h
+++ b/src/win32com/Controller.h
@@ -203,6 +203,8 @@ public:
 
 	STDMETHOD(get_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[out, retval]*/ int* pVal);
 	STDMETHOD(put_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[in]*/ int newVal);
+
+	STDMETHOD(put_TimeFence)(/*[in]*/ double fenceIns);
 };
 
 #endif // !defined(AFX_Controller_H__D2811491_40D6_4656_9AA7_8FF85FD63543__INCLUDED_)

--- a/src/win32com/VPinMAME.idl
+++ b/src/win32com/VPinMAME.idl
@@ -258,6 +258,7 @@ import "ocidl.idl";
 		[propget, id(87), helpstring("property ROMName")] HRESULT ROMName([out, retval] BSTR *pVal);
 		[propget, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [out, retval] int *pVal);
 		[propput, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [in] int newVal);
+		[propput, id(89), helpstring("property TimeFence")] HRESULT TimeFence([in] double timeInS);
 	};
 
 	// WSHDlg and related interfaces

--- a/src/windows/video.c
+++ b/src/windows/video.c
@@ -743,6 +743,10 @@ void throttle_speed_part(int part, int totalparts)
 	if (win_sync_refresh)
 		return;
 
+	// if we're only syncing on an emulation fence, bail now
+	if (options.time_fence != 0.0)
+		return;
+
 	// this counts as idle time
 	profiler_mark(PROFILER_IDLE);
 

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -304,6 +304,11 @@ int vp_getModOutputType(int output, int no) {
 	return coreGlobals.physicOutputState[pos].type;
 }
 
+void vp_setTimeFence(double fenceInS)
+{
+	options.time_fence = fenceInS;
+}
+
 int vp_getMech(int mechNo) {
 #if defined(VPINMAME) || defined(LIBPINMAME)
   extern int g_fHandleMechanics;

--- a/src/wpc/vpintf.h
+++ b/src/wpc/vpintf.h
@@ -117,6 +117,11 @@ void vp_setModOutputType(int output, int no, int type);
 int vp_getModOutputType(int output, int no);
 
 /*-----------
+/  set a time fence where emulation is suspended when reached
+/-----------*/
+void vp_setTimeFence(double timeInS);
+
+/*-----------
 / Mechanics
 /------------*/
 void vp_setMechData(int para, int data);


### PR DESCRIPTION
The existing implementation uses subdivided vblank (virtual ones at 60Hz) to perform emulation synchronization. This works well but can lead to some latency when used with a physic emulator like Visual Pinball X.

For example, the following MSVC Concurrency Viewer shot shows the VPinMame thread (last one above DX GPU threads). The blue part is when VPinMame is ahead of time, therefore sleeping to catch up, the green dots shows frame ticks of VPX (on a 144Hz display).
![image](https://github.com/vpinball/pinmame/assets/2796036/d71d04c0-6b3d-453b-8963-2d544cfce937)

The problem is that input and physics (leading to switch triggers) can happen during these sleeping periods (with some additional latency while waiting for synchronization between VPX & VPM). Example of these are nearby optos like in XMen or Stern's Star Trek, video modes like 'Walk the Plank' in Black Rose, or flipper bats controlled by the microcontroller (leading to the need of fastflip hack).

The proposed change allow PinMame to be synchronized externally against an externally controlled main clock giving a time fence that PinMame will honor. Using this (and the latest changes in VPX 10.8.1), the previous MSVC concurrency viewer become the following (VPinMame is the last Worker Thread, unlabelled green span at the bottom are VPX syncing to VPM, dots are frame marker):
![image](https://github.com/vpinball/pinmame/assets/2796036/3d43d278-4ef2-4e60-b668-689bb723628d)

Here, you see VPM catching up at the pace of VPX, keeping a maximum margin of 1ms between the two. Both of them are synchronizing in between, leading to better synchronized emulation.

Input latency in this scheme could theoretically be down to 1.5ms: average of 0.5ms between input and script trigger (which sets VPM switch state) on VPX side, then average of 0.5ms between switch state and VPM catching up, then again average of 0.5ms between VPM emulation and next VPX sync. So not that far from fast flips, but extended to all input/outputs between PinMame and emulation app (the real value is higher for the time being since VPX is still missing some threading improvment to move nearly all of the rendering outside of the main game logic thread).