### PR TITLE
TimeFence: use semaphore instead of sleep

### DIFF
--- a/src/ios/video.c
+++ b/src/ios/video.c
@@ -232,6 +232,7 @@ void SetThrottleAdj(int adj)
  * throttle_speed
  */
 
+extern int time_fence_is_supported();
 static void throttle_speed(void) {
 	static double ticks_per_sleep_msec = 0;
 	cycles_t target;
@@ -239,7 +240,7 @@ static void throttle_speed(void) {
 	cycles_t cps;
 
 	// if we're only syncing on an emulation fence, bail now
-	if (options.time_fence != 0)
+	if (options.time_fence != 0 && time_fence_is_supported())
 		return;
 
 	profiler_mark(PROFILER_IDLE);

--- a/src/libpinmame/video.c
+++ b/src/libpinmame/video.c
@@ -380,6 +380,7 @@ void SetThrottleAdj(int adj)
 
 #if !defined(_WIN32) && !defined(_WIN64)
 
+extern int time_fence_is_supported();
 static void throttle_speed(void) {
 	static double ticks_per_sleep_msec = 0;
 	cycles_t target;
@@ -387,7 +388,7 @@ static void throttle_speed(void) {
 	cycles_t cps;
 
 	// if we're only syncing on an emulation fence, bail now
-	if (options.time_fence != 0)
+	if (options.time_fence != 0 && time_fence_is_supported())
 		return;
 
 	profiler_mark(PROFILER_IDLE);
@@ -447,7 +448,7 @@ void throttle_speed_part(int part, int totalparts)
 	//	return;
 
 	// if we're only syncing on an emulation fence, bail now
-	if (options.time_fence != 0)
+	if (options.time_fence != 0.0 && time_fence_is_supported())
 		return;
 
 	// this counts as idle time

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -381,7 +381,7 @@ STDMETHODIMP CController::Stop()
 		return S_OK;
 
 	// Disable time fence that could prevent the machine to stop
-	options.time_fence = 0.0;
+	put_TimeFence(0.0);
 
 	PostMessage(win_video_window, WM_CLOSE, 0, 0);
 	WaitForSingleObject(m_hThreadRun,INFINITE);

--- a/src/windows/video.c
+++ b/src/windows/video.c
@@ -734,6 +734,7 @@ static void throttle_speed(void)
 // to flipper input.  By distributing the emulation more evenly over a frame, it creates more opportunities
 // for the emulated machine to "see" the input and respond to it before the pinball simulator starts to draw its frame.
 
+extern int time_fence_is_supported();
 void throttle_speed_part(int part, int totalparts)
 {
 	static double ticks_per_sleep_msec = 0;
@@ -744,7 +745,7 @@ void throttle_speed_part(int part, int totalparts)
 		return;
 
 	// if we're only syncing on an emulation fence, bail now
-	if (options.time_fence != 0.0)
+	if (options.time_fence != 0.0 && time_fence_is_supported())
 		return;
 
 	// this counts as idle time

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -304,9 +304,14 @@ int vp_getModOutputType(int output, int no) {
 	return coreGlobals.physicOutputState[pos].type;
 }
 
+extern void time_fence_post(); // in cpuexec.c
 void vp_setTimeFence(double fenceInS)
 {
-	options.time_fence = fenceInS;
+	if (options.time_fence != fenceInS)
+	{
+		options.time_fence = fenceInS;
+		time_fence_post();
+	}
 }
 
 int vp_getMech(int mechNo) {


### PR DESCRIPTION
This PR gives a cleaner implementation using semaphore allowing clean syncing. The drawback is that it contains quite a lot more modification since ti has to implement portable semaphore for PinMame. I have tested it under Windows and it works very well. For Apple & Unix device, only build have been tested since I don't have any device to run it.