### PR TITLE
Fix global rom volume setting, and use verified volume behavior instead of linear for DCS

### DIFF
--- a/src/wpc/altsound/altsound_processor.cpp
+++ b/src/wpc/altsound/altsound_processor.cpp
@@ -271,6 +271,29 @@ void AltsoundProcessor::init()
 	ALT_DEBUG(0, "END AltsoundProcessor::init()");
 }
 
+// ----------------------------------------------------------------------------
+
+void AltsoundProcessorBase::setGlobalVol(const float vol_in)
+{
+	std::vector<float> vol(channel_stream.size());
+
+	for (size_t index = 0; index < channel_stream.size(); ++index) {
+		const auto stream = channel_stream[index];
+		if (stream) {
+			vol[index] = getStreamVolume(stream->hstream);
+		}
+	}
+
+	global_vol = vol_in;
+
+	for (size_t index = 0; index < channel_stream.size(); ++index) {
+		const auto stream = channel_stream[index];
+		if (stream) {
+			setStreamVolume(stream->hstream, vol[index]);
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 
 bool AltsoundProcessor::loadSamples()

--- a/src/wpc/altsound/altsound_processor_base.cpp
+++ b/src/wpc/altsound/altsound_processor_base.cpp
@@ -199,6 +199,20 @@ bool AltsoundProcessorBase::setStreamVolume(HSTREAM stream_in, const float vol_i
 
 // ----------------------------------------------------------------------------
 
+float AltsoundProcessorBase::getStreamVolume(HSTREAM stream_in)
+{
+	if (stream_in == BASS_NO_STREAM)
+		return -FLT_MAX;
+
+	float vol;
+	if (!BASS_ChannelGetAttribute(stream_in, BASS_ATTRIB_VOL, &vol))
+		return -FLT_MAX;
+	else
+		return vol/(global_vol * master_vol);
+}
+
+// ----------------------------------------------------------------------------
+
 bool AltsoundProcessorBase::createStream(void* syncproc_in, AltsoundStreamInfo* stream_out)
 {
 	ALT_DEBUG(0, "BEGIN AltsoundProcessorBase::createStream()");

--- a/src/wpc/altsound/altsound_processor_base.hpp
+++ b/src/wpc/altsound/altsound_processor_base.hpp
@@ -40,7 +40,7 @@ public:
 	// Copy constructor
 	AltsoundProcessorBase(AltsoundProcessorBase&) = delete;
 
-	// Standard Constructor
+	// Standard constructor
 	AltsoundProcessorBase(const std::string& game_name, const std::string& vpm_path);
 
 	// Destructor
@@ -52,7 +52,7 @@ public:
 	// external interface to stop playback of the current music stream
 	virtual bool stopMusic() = 0;
 
-	// ROM volume control accessor/nutator
+	// ROM volume control accessor/mutator
 	void romControlsVol(const bool use_rom_vol);
 	bool romControlsVol();
 
@@ -72,10 +72,10 @@ public:
 
 	// command skip count accessor/mutator
 	void setSkipCount(const unsigned int skip_count_in);
-	const unsigned int getSkipCount() const;
-	
+	unsigned int getSkipCount() const;
+
 public: // data
-	
+
 protected: // functions
 
 	// populate sample data
@@ -104,6 +104,9 @@ protected: // functions
 
 	// set volume on provided stream
 	static bool setStreamVolume(HSTREAM stream_in, const float vol_in);
+
+	// get volume on provided stream, -FLT_MAX on error
+	static float getStreamVolume(HSTREAM stream_in);
 
 	// Return ROM shortname
 	const std::string& getGameName();
@@ -176,19 +179,13 @@ inline float AltsoundProcessorBase::getMasterVol() {
 
 // ----------------------------------------------------------------------------
 
-inline void AltsoundProcessorBase::setGlobalVol(const float vol_in) {
-	global_vol = vol_in;
-}
-
-// ----------------------------------------------------------------------------
-
 inline float AltsoundProcessorBase::getGlobalVol() {
 	return global_vol;
 }
 
 // ----------------------------------------------------------------------------
 
-inline const unsigned int AltsoundProcessorBase::getSkipCount() const {
+inline unsigned int AltsoundProcessorBase::getSkipCount() const {
 	return skip_count;
 }
 

--- a/src/wpc/altsound/gsound_processor.cpp
+++ b/src/wpc/altsound/gsound_processor.cpp
@@ -802,7 +802,7 @@ void CALLBACK GSoundProcessor::common_callback(HSYNC handle, DWORD channel, DWOR
 		behavior = music_behavior;
 		// DAR@20230706
 		// This callback gets hit when the sample ends even if it's set to loop.
-		// If it's cleaned up here, it will not loop. This not desirable.  A future
+		// If it's cleaned up here, it will not loop. This is not desirable.  A future
 		// use may be to create an independent music callback that can limit the
 		// number of loops.
 		//cur_mus_stream_idx = UNSET_IDX;

--- a/src/wpc/altsound/snd_alt.cpp
+++ b/src/wpc/altsound/snd_alt.cpp
@@ -178,7 +178,7 @@ extern "C" void alt_sound_handle(int boardNo, int cmd)
 
 	//DAR@20230522 I don't know what this does yet
 	postprocess_commands(cmd_combined);
-	
+
 	OUTDENT;
 	ALT_DEBUG(0, "END alt_sound_handle()");
 	ALT_DEBUG(0, "");
@@ -410,32 +410,78 @@ void preprocess_commands(CmdData* cmds_out, int cmd_in)
 	{
 		// For future improvements, also check https://github.com/mjrgh/DCSExplorer/ for a lot of new info on the DCS inner workings
 
+		// E.g.: One more note on command processing: each byte of a command sequence must be received on the DCS side within 100ms of the previous byte.
+		//   The DCS software clears any buffered bytes if more than 100ms elapses between consecutive bytes.
+		//   This implies that a sender can wait a little longer than 100ms before sending the first byte of a new command if it wants to essentially reset the network connection,
+		//   ensuring that the DCS receiver doesn't think it's in the middle of some earlier partially-sent command sequence. 
+
 		ALT_DEBUG(0, "Hardware Generation: GEN_WPCDCS, GEN_WPCSECURITY, GEN_WPC95DCS, GEN_WPC95");
 
-		if (((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA))) // change volume?
+		if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] >= 0xAB) && (cmd_buffer[2] <= 0xB0) && (cmd_buffer[1] == (cmd_buffer[0] ^ 0xFF))) // per-DCS-channel mixing level, but on our interpretation level we do not have any knowledge about the internal channel structures of DCS
+		{
+			for (int i = 0; i < ALT_MAX_CMDS; ++i)
+				cmd_buffer[i] = ~0;
+
+			*cmd_counter = 0;
+			*cmd_filter = 1;
+		}
+		else
+		if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xC2)) // DCS software major version number
+		{
+			for (int i = 0; i < ALT_MAX_CMDS; ++i)
+				cmd_buffer[i] = ~0;
+
+			*cmd_counter = 0;
+			*cmd_filter = 1;
+		}
+		else
+		if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xC3)) // DCS software minor version number
+		{
+			for (int i = 0; i < ALT_MAX_CMDS; ++i)
+				cmd_buffer[i] = ~0;
+
+			*cmd_counter = 0;
+			*cmd_filter = 1;
+		}
+		else
+		if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] >= 0xBA) && (cmd_buffer[2] <= 0xC1) && (cmd_buffer[1] == (cmd_buffer[0] ^ 0xFF))) // mystery command, see http://mjrnet.org/pinscape/dcsref/DCS_format_reference.html#SpecialCommands
+		{
+			for (int i = 0; i < ALT_MAX_CMDS; ++i)
+				cmd_buffer[i] = ~0;
+
+			*cmd_counter = 0;
+			*cmd_filter = 1;
+		}
+		else
+		if (((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA))) // change master volume?
 			// DAR@20240208 The check below is dangerous.  If this is still a 
 			//              problem, it would be better to revisit it when it
 			//              reappears to implement a more robust solution that
 			//              works for all systems
 			//              See https://github.com/vpinball/pinmame/issues/220
+			// Maybe implementing the 'nothing happened in >100ms' reset queue (see above) would also resolve this??
 			//||
 			//((cmd_buffer[2] == 0x00) && (cmd_buffer[1] == 0x00) && (cmd_buffer[0] == 0x00))) // glitch in command buffer?
 		{
 			if ((cmd_buffer[3] == 0x55) && (cmd_buffer[2] == 0xAA) && (cmd_buffer[1] == (cmd_buffer[0] ^ 0xFF))) { // change volume op (following first byte = volume, second = ~volume, if these don't match: ignore)
 				// DAR@20230518
 				// I don't know why this is nerfing the volume.  It does not
-				// appear to work correctly in all cases. 
+				// appear to work correctly in all cases.
+				// Answer: This is according to the DCS format reference, see e.g.
+				// http://mjrnet.org/pinscape/dcsref/DCS_format_reference.html#SpecialCommands
 				if (processor->romControlsVol()) {
-					processor->setGlobalVol(std::min((float)cmd_buffer[1] / 127.f, 1.0f));
+					processor->setGlobalVol(std::min((float)cmd_buffer[1] / 127.f, 1.0f)); //!! input is 0..255 (or ..248 in practice) though?
+					// use
+					//   (cmd_buffer[1] == 0) ? 0.f : pow(0.981201, 255 - cmd_buffer[1])
+					// instead?
 					ALT_INFO(0, "Change volume %.02f", processor->getGlobalVol());
 				}
 			}
 			else
 				ALT_DEBUG(0, "filtered command %02X %02X %02X %02X", cmd_buffer[3], cmd_buffer[2], cmd_buffer[1], cmd_buffer[0]);
 
-			for (int i = 0; i < ALT_MAX_CMDS; ++i) {
+			for (int i = 0; i < ALT_MAX_CMDS; ++i)
 				cmd_buffer[i] = ~0;
-			}
 
 			*cmd_counter = 0;
 			*cmd_filter = 1;
@@ -625,7 +671,7 @@ void postprocess_commands(const unsigned int combined_cmd) {
 			processor->stopMusic();
 		}
 	}
-	
+
 	OUTDENT;
 	ALT_DEBUG(0, "END postprocess_commands()");
 }


### PR DESCRIPTION
@droscoe Could you please review this?
Maybe the buggy/delayed global rom volume setting is explaining your observations on weird behavior when previously using/testing this?

Also i'm not sure how to additionally tweak the new DCS global rom volume behavior. Previously, the linear volume setting used a magic '*2' for boosting, now i use a magic '*4' to compensate for the 'overall lower' volume behavior, but then i have also no clue why the previous '*2' was used.