### PR TITLE
Support WPC UARTs (8251 from Printer Option Kit & 16C450 from WPC95)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .project
 build/
 /CMakeLists.txt
+/.vs/
+/obj/
+/release/

--- a/PinMAME_VC2008.vcproj
+++ b/PinMAME_VC2008.vcproj
@@ -47,7 +47,7 @@
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -135,7 +135,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
 				AssemblerListingLocation="$(IntDir)\"
@@ -225,7 +225,7 @@
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -313,7 +313,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="1"
 				AssemblerListingLocation="$(IntDir)\"
@@ -3126,6 +3126,46 @@
 					</FileConfiguration>
 				</File>
 				<File
+					RelativePath=".\src\windows\serial.c"
+					>
+					<FileConfiguration
+						Name="Release|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							ObjectFile="$(IntDir)\Windows\"
+							ProgramDataBaseFileName="$(IntDir)\Windows\$(TargetName).pdb"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Debug|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							ObjectFile="$(IntDir)\Windows\"
+							ProgramDataBaseFileName="$(IntDir)\Windows\$(TargetName).pdb"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Release with MAME Debugger|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							ObjectFile="$(IntDir)\Windows\"
+							ProgramDataBaseFileName="$(IntDir)\Windows\$(TargetName).pdb"
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="Debug with MAME Debugger|Win32"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							ObjectFile="$(IntDir)\Windows\"
+							ProgramDataBaseFileName="$(IntDir)\Windows\$(TargetName).pdb"
+						/>
+					</FileConfiguration>
+				</File>
+				<File
 					RelativePath=".\src\windows\sound.c"
 					>
 					<FileConfiguration
@@ -4079,6 +4119,14 @@
 				</File>
 				<File
 					RelativePath=".\src\wpc\techno.c"
+					>
+				</File>
+				<File
+					RelativePath=".\src\wpc\uart_16c450.c"
+					>
+				</File>
+				<File
+					RelativePath=".\src\wpc\uart_8251.c"
 					>
 				</File>
 				<File

--- a/PinMAME_VC2012.vcxproj
+++ b/PinMAME_VC2012.vcxproj
@@ -176,7 +176,7 @@
     <ClCompile>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -231,7 +231,7 @@
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -270,7 +270,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -310,7 +310,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -349,7 +349,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -397,7 +397,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -436,7 +436,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -476,7 +476,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>src;src\wpc;src\windows;src\vc;src\cpu\m68000\generated_by_m68kmake;ext\zlib;ext\dinput\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__LP64__;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_MBCS;LSB_FIRST;CLIB_DECL=__cdecl;DECL_SPEC=__cdecl;inline=__inline;__inline__=__inline;INLINE=__inline;DIRECTINPUT_VERSION=0x0700;DIRECTDRAW_VERSION=0x0300;NONAMELESSUNION;_WINDOWS;MAMEVER=7300;PINMAME;PINMAME_NO_UNUSED;PINMAME_HOST_UART;MAME_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -1120,6 +1120,24 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
       <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
       <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
     </ClCompile>
+    <ClCompile Include="src\windows\serial.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|Win32'">$(IntDir)Windows\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|x64'">$(IntDir)Windows\</ObjectFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|Win32'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|x64'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Windows\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Windows\</ObjectFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release with MAME Debugger|Win32'">$(IntDir)Windows\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release with MAME Debugger|x64'">$(IntDir)Windows\</ObjectFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release with MAME Debugger|Win32'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release with MAME Debugger|x64'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Windows\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Windows\</ObjectFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)Windows\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
     <ClCompile Include="src\windows\sound.c">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|Win32'">$(IntDir)Windows\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug with MAME Debugger|x64'">$(IntDir)Windows\</ObjectFileName>
@@ -1370,6 +1388,8 @@ copy "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)"
     <ClCompile Include="src\wpc\taitogames.c" />
     <ClCompile Include="src\wpc\taitos.c" />
     <ClCompile Include="src\wpc\techno.c" />
+    <ClCompile Include="src\wpc\uart_16c450.c" />
+    <ClCompile Include="src\wpc\uart_8251.c" />
     <ClCompile Include="src\wpc\vd.c" />
     <ClCompile Include="src\wpc\vpintf.c" />
     <ClCompile Include="src\wpc\wico.c" />

--- a/PinMAME_VC2012.vcxproj.filters
+++ b/PinMAME_VC2012.vcxproj.filters
@@ -648,6 +648,9 @@
     <ClCompile Include="src\windows\rc.c">
       <Filter>Source Files\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="src\windows\serial.c">
+      <Filter>Source Files\Windows</Filter>
+    </ClCompile>
     <ClCompile Include="src\windows\snprintf.c">
       <Filter>Source Files\Windows</Filter>
     </ClCompile>
@@ -981,6 +984,12 @@
     <ClCompile Include="src\wpc\techno.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
+    <ClCompile Include="src\wpc\uart_16c450.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
+    <ClCompile Include="src\wpc\uart_8251.c">
+      <Filter>Source Files\PinMAME</Filter>
+    </ClCompile>
     <ClCompile Include="src\wpc\vd.c">
       <Filter>Source Files\PinMAME</Filter>
     </ClCompile>
@@ -1036,6 +1045,9 @@
       <Filter>Source Files\PinMAME\sims\wpc\full_wpc</Filter>
     </ClCompile>
     <ClCompile Include="src\wpc\sims\wpc\full\dd_wpc.c">
+      <Filter>Source Files\PinMAME\sims\wpc\full_wpc</Filter>
+    </ClCompile>
+    <ClCompile Include="src\wpc\sims\wpc\full\dm.c">
       <Filter>Source Files\PinMAME\sims\wpc\full_wpc</Filter>
     </ClCompile>
     <ClCompile Include="src\wpc\sims\wpc\full\drac.c">
@@ -1117,9 +1129,6 @@
       <Filter>Source Files\PinMAME\sims\wpc\prelim_wpc</Filter>
     </ClCompile>
     <ClCompile Include="src\wpc\sims\wpc\prelim\dh.c">
-      <Filter>Source Files\PinMAME\sims\wpc\prelim_wpc</Filter>
-    </ClCompile>
-    <ClCompile Include="src\wpc\sims\wpc\full\dm.c">
       <Filter>Source Files\PinMAME\sims\wpc\prelim_wpc</Filter>
     </ClCompile>
     <ClCompile Include="src\wpc\sims\wpc\prelim\dw.c">

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -80,6 +80,7 @@ add_compile_definitions(
    MAMEVER=7300
    PINMAME
    PINMAME_NO_UNUSED
+   PINMAME_HOST_UART
 
    LSB_FIRST
    DIRECTINPUT_VERSION=0x0700
@@ -547,6 +548,11 @@ add_executable(pinmame WIN32
    src/wpc/taitos.c
    src/wpc/taitos.h
    src/wpc/techno.c
+   src/wpc/uart_16c450.c
+   src/wpc/uart_16c450.h
+   src/wpc/uart_8251.c
+   src/wpc/uart_8251.h
+   src/wpc/uart_host.h
    src/wpc/vd.c
    src/wpc/vpintf.c
    src/wpc/vpintf.h
@@ -589,6 +595,7 @@ add_executable(pinmame WIN32
    src/windows/pattern.h
    src/windows/rc.c
    src/windows/rc.h
+   src/windows/serial.c
    src/windows/sound.c
    src/windows/ticker.c
    src/windows/video.c

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -82,6 +82,7 @@ add_compile_definitions(
    MAMEVER=7300
    PINMAME
    PINMAME_NO_UNUSED
+   PINMAME_HOST_UART
 
    LSB_FIRST
    DIRECTINPUT_VERSION=0x0700
@@ -553,6 +554,11 @@ add_executable(pinmame WIN32
    src/wpc/taitos.c
    src/wpc/taitos.h
    src/wpc/techno.c
+   src/wpc/uart_16c450.c
+   src/wpc/uart_16c450.h
+   src/wpc/uart_8251.c
+   src/wpc/uart_8251.h
+   src/wpc/uart_host.h
    src/wpc/vd.c
    src/wpc/vpintf.c
    src/wpc/vpintf.h
@@ -595,6 +601,7 @@ add_executable(pinmame WIN32
    src/windows/pattern.h
    src/windows/rc.c
    src/windows/rc.h
+   src/windows/serial.c
    src/windows/sound.c
    src/windows/ticker.c
    src/windows/video.c

--- a/cmake/xpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/xpinmame/CMakeLists_linux-x64.txt
@@ -82,6 +82,7 @@ add_compile_definitions(
    MAMEVER=7300
    PINMAME
    PINMAME_NO_UNUSED
+   PINMAME_HOST_UART
    SAM_INCLUDE_COLORED
    NAME="xpinmame"
 
@@ -568,6 +569,11 @@ add_executable(xpinmame
    src/wpc/taitos.c
    src/wpc/taitos.h
    src/wpc/techno.c
+   src/wpc/uart_16c450.c
+   src/wpc/uart_16c450.h
+   src/wpc/uart_8251.c
+   src/wpc/uart_8251.h
+   src/wpc/uart_host.h
    src/wpc/vd.c
    src/wpc/vpintf.c
    src/wpc/vpintf.h
@@ -609,6 +615,7 @@ add_executable(xpinmame
    src/unix/effect.c
    src/unix/ticker.c
    src/unix/parallel.c
+   src/unix/serial.c
    src/unix/sysdep/rc.c
    src/unix/sysdep/misc.c
    src/unix/sysdep/plugin_manager.c

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -89,6 +89,7 @@ add_compile_definitions(
    MAMEVER=7300
    MAMENAME="PINMAME"
    PINMAME_NO_UNUSED
+   PINMAME_HOST_UART
    USE_MITSHM
    USE_XV
    USE_HWSCALE
@@ -556,6 +557,11 @@ add_executable(xpinmame
    src/wpc/taitos.c
    src/wpc/taitos.h
    src/wpc/techno.c
+   src/wpc/uart_16c450.c
+   src/wpc/uart_16c450.h
+   src/wpc/uart_8251.c
+   src/wpc/uart_8251.h
+   src/wpc/uart_host.h
    src/wpc/vd.c
    src/wpc/vpintf.c
    src/wpc/vpintf.h
@@ -597,6 +603,7 @@ add_executable(xpinmame
    src/unix/effect.c 
    src/unix/ticker.c 
    src/unix/parallel.c 
+   src/unix/serial.c
    src/unix/sysdep/rc.c 
    src/unix/sysdep/misc.c 
    src/unix/sysdep/plugin_manager.c 

--- a/src/driver.h
+++ b/src/driver.h
@@ -101,7 +101,9 @@ typedef struct {
 #endif /* PROC_SUPPORT */
   int vgmwrite; // bool
   int force_mono_to_stereo; // bool
+#ifdef PINMAME_HOST_UART
   char *serial_device;         /* COM or /dev/tty mapped to WPC95 UART */
+#endif
 } tPMoptions;
 extern tPMoptions pmoptions;
 struct pinMachine {

--- a/src/driver.h
+++ b/src/driver.h
@@ -101,6 +101,7 @@ typedef struct {
 #endif /* PROC_SUPPORT */
   int vgmwrite; // bool
   int force_mono_to_stereo; // bool
+  char *serial_device;         /* COM or /dev/tty mapped to WPC95 UART */
 } tPMoptions;
 extern tPMoptions pmoptions;
 struct pinMachine {

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -94,7 +94,7 @@ struct rc_option pinmame_opts[] = {
 	{ "virtual_dmd", NULL, rc_bool,&pmoptions.virtual_dmd,  "1",  0, 0, NULL, "Enable DMD emulation" },
 #endif
 #ifdef PINMAME_HOST_UART
-	{ "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC95 UART" },
+	{ "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "/dev/tty serial port mapped to WPC UART" },
 #endif
 	{ NULL,	NULL, rc_end, NULL, NULL, 0, 0,	NULL, NULL }
 };

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -93,6 +93,9 @@ struct rc_option pinmame_opts[] = {
 	{ "p-roc",NULL, rc_string,&pmoptions.p_roc, "None",  0, 0, NULL, "YAML Machine description file" },
 	{ "virtual_dmd", NULL, rc_bool,&pmoptions.virtual_dmd,  "1",  0, 0, NULL, "Enable DMD emulation" },
 #endif
+#ifdef PINMAME_HOST_UART
+	{ "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC95 UART" },
+#endif
 	{ NULL,	NULL, rc_end, NULL, NULL, 0, 0,	NULL, NULL }
 };
 #endif /* PINMAME */

--- a/src/unix/serial.c
+++ b/src/unix/serial.c
@@ -1,0 +1,156 @@
+/*
+    POSIX serial port code for uart_host.h based on the XBee ANSI C Library:
+        https://github.com/tomlogic/xbee_ansic_library/
+
+    Originally written by Tom Collins <tom@tomlogic.com> and released under
+    an MPL 2.0 License.
+
+    This PinMAME adaptation written July 2024 by Tom Collins.
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "uart_host.h"
+
+static int uart_fd;
+
+#if 0
+#define ERRMSG(...)      fprintf(stderr, __VA_ARGS__)
+#else
+#define ERRMSG(...)
+#endif
+
+// Pass "/dev/ttyXXX" as device.
+int uart_open(const char *device, data32_t baudrate)
+{
+    int err, fd;
+    
+    fd = open(device, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) {
+        ERRMSG("%s: open('%s') failed (errno=%d)\n", __FUNCTION__,
+            device, errno);
+        return -errno;
+    }
+
+    // Configure file descriptor to not block on read() if there aren't
+    // any characters available.
+    fcntl(fd, F_SETFL, FNDELAY);
+
+    uart_fd = fd;
+    err = uart_baudrate(baudrate);
+    if (err) {
+        uart_fd = 0;
+    }
+    
+    return err;
+}
+
+
+int uart_close(void)
+{
+    int result = 0;
+    
+    if (close(uart_fd) == -1)
+    {
+        ERRMSG("%s: close(%d) failed (errno=%d)\n", __FUNCTION__,
+            uart_fd, errno);
+        result = -errno;
+    }
+    uart_fd = -1;
+
+    return result;
+}
+
+
+#define _BAUDCASE(b)        case b: baud = B ## b; break
+int uart_baudrate(data32_t baudrate)
+{
+    struct termios options;
+    speed_t baud;
+
+    switch (baudrate)
+    {
+        _BAUDCASE(0);
+        _BAUDCASE(300);
+        _BAUDCASE(600);
+        _BAUDCASE(1200);
+        _BAUDCASE(2400);
+        _BAUDCASE(4800);
+        _BAUDCASE(9600);
+        _BAUDCASE(19200);
+        _BAUDCASE(38400);
+        _BAUDCASE(57600);
+        _BAUDCASE(115200);
+#ifdef B230400
+        _BAUDCASE(230400);
+#endif
+#ifdef B460800
+        _BAUDCASE(460800);
+#endif
+#ifdef B921600
+        _BAUDCASE(921600);
+#endif
+        default:
+            return -EINVAL;
+    }
+
+    // Get the current options for the port...
+    if (tcgetattr(uart_fd, &options) == -1)
+    {
+        ERRMSG("%s: %s failed (%d) for %" PRIu32 "\n",
+            __FUNCTION__, "tcgetattr", errno, baudrate);
+        return -errno;
+    }
+
+    // Set the baud rates...
+    cfsetispeed(&options, baud);
+    cfsetospeed(&options, baud);
+
+    // disable any processing of serial input/output
+    cfmakeraw(&options);
+
+    // ignore modem status lines (blocked write() on macOS)
+    options.c_cflag |= CLOCAL;
+
+    // Set the new options for the port, waiting until buffered data is sent
+    if (tcsetattr(uart_fd, TCSADRAIN, &options) == -1)
+    {
+        ERRMSG("%s: %s failed (%d)\n", __FUNCTION__, "tcsetattr", errno);
+        return -errno;
+    }
+
+    return 0;
+}
+
+
+int uart_getch(void)
+{
+    data8_t value;
+
+    if (read(uart_fd, &value, 1) == -1) {
+        if (errno == EAGAIN) {
+            return -EAGAIN;
+        }
+        ERRMSG("%s: error %d\n", __FUNCTION__, errno);
+        return -errno;
+    }
+
+    return value;
+}
+
+
+int uart_putch(data8_t value)
+{
+    if (write(uart_fd, &value, 1) < 0) {
+        ERRMSG("%s: error %d\n", __FUNCTION__, errno);
+        return -errno;
+    }
+    
+    return 0;
+}

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -102,6 +102,7 @@ struct rc_option pinmame_opts[] = {
 #endif /* PROC_SUPPORT */
         { "vgmwrite", NULL, rc_bool, &pmoptions.vgmwrite, "0", 0, 0, NULL, "Enable to write a VGM of the current session (name is based on romname)" },
         { "force_stereo", NULL, rc_bool, &pmoptions.force_mono_to_stereo, "0", 0, 0, NULL, "Always force stereo output (e.g. to better support multi channel sound systems)" },
+        { "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC95 UART" },
         { NULL, NULL, rc_end, NULL, NULL, 0, 0, NULL, NULL }
 };
 #endif /* PINMAME */

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -102,7 +102,9 @@ struct rc_option pinmame_opts[] = {
 #endif /* PROC_SUPPORT */
         { "vgmwrite", NULL, rc_bool, &pmoptions.vgmwrite, "0", 0, 0, NULL, "Enable to write a VGM of the current session (name is based on romname)" },
         { "force_stereo", NULL, rc_bool, &pmoptions.force_mono_to_stereo, "0", 0, 0, NULL, "Always force stereo output (e.g. to better support multi channel sound systems)" },
+#ifdef PINMAME_HOST_UART
         { "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC95 UART" },
+#endif
         { NULL, NULL, rc_end, NULL, NULL, 0, 0, NULL, NULL }
 };
 #endif /* PINMAME */

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -103,7 +103,7 @@ struct rc_option pinmame_opts[] = {
         { "vgmwrite", NULL, rc_bool, &pmoptions.vgmwrite, "0", 0, 0, NULL, "Enable to write a VGM of the current session (name is based on romname)" },
         { "force_stereo", NULL, rc_bool, &pmoptions.force_mono_to_stereo, "0", 0, 0, NULL, "Always force stereo output (e.g. to better support multi channel sound systems)" },
 #ifdef PINMAME_HOST_UART
-        { "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC95 UART" },
+        { "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "COM port mapped to WPC UART" },
 #endif
         { NULL, NULL, rc_end, NULL, NULL, 0, 0, NULL, NULL }
 };

--- a/src/windows/serial.c
+++ b/src/windows/serial.c
@@ -1,0 +1,148 @@
+/*
+    Windows serial port code for uart_16c450.c based on the XBee ANSI C Library:
+        https://github.com/tomlogic/xbee_ansic_library/
+
+    Originally written by Tom Collins <tom@tomlogic.com> and released under
+    an MPL 2.0 License.
+
+    This PinMAME adaptation written July 2024 by Tom Collins.
+*/
+
+#include <stdio.h>
+#include <windows.h>
+
+#include "uart_host.h"
+
+static HANDLE uart_hCom;
+
+#if 0
+#define ERRMSG(...)      fprintf(stderr, __VA_ARGS__)
+#else
+#define ERRMSG(...)
+#endif
+
+// Pass "COM99" as device.
+int uart_open(const char *device, data32_t baudrate)
+{
+    char            buffer[20];
+    HANDLE          hCom;
+    COMMTIMEOUTS    timeouts;
+    int             err;
+
+    // filename needs to be \\.\COM99 where "99" is the comport number
+
+    snprintf(buffer, sizeof buffer, "\\\\.\\%s", device);
+    hCom = CreateFileA(buffer, GENERIC_READ | GENERIC_WRITE,
+                       0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hCom == INVALID_HANDLE_VALUE) {
+        ERRMSG("%s: error %lu opening handle to %s\n", __FUNCTION__,
+               GetLastError(), buffer);
+        return -EIO;
+    }
+
+    // Set up transmit and receive buffers.
+    SetupComm(hCom, 128, 128);
+
+    /*  Set the COMMTIMEOUTS structure.  Per MSDN documentation for
+        ReadIntervalTimeout, "A value of MAXDWORD, combined with zero values
+        for both the ReadTotalTimeoutConstant and ReadTotalTimeoutMultiplier
+        members, specifies that the read operation is to return immediately
+        with the bytes that have already been received, even if no bytes have
+        been received."
+    */
+    if (!GetCommTimeouts(hCom, &timeouts)) {
+        ERRMSG("%s: %s failed (%lu initializing %s)\n",
+               __FUNCTION__, "GetCommTimeouts", GetLastError(), device);
+        CloseHandle(hCom);
+        return -EIO;
+    }
+
+    timeouts.ReadIntervalTimeout = MAXDWORD;
+    timeouts.ReadTotalTimeoutMultiplier = 0;
+    timeouts.ReadTotalTimeoutConstant = 0;
+    if (!SetCommTimeouts(hCom, &timeouts)) {
+        ERRMSG("%s: %s failed (%lu initializing %s)\n",
+               __FUNCTION__, "SetCommTimeouts", GetLastError(), device);
+        CloseHandle(hCom);
+        return -EIO;
+    }
+
+    PurgeComm(hCom, PURGE_TXCLEAR | PURGE_TXABORT |
+              PURGE_RXCLEAR | PURGE_RXABORT);
+
+    uart_hCom = hCom;
+
+    err = uart_baudrate(baudrate);
+
+    if (err) {
+        uart_hCom = NULL;
+    }
+
+    return err;
+}
+
+
+int uart_close(void)
+{
+    CloseHandle(uart_hCom);
+    uart_hCom = NULL;
+
+    return 0;
+}
+
+
+int uart_baudrate(data32_t baudrate)
+{
+    DCB         dcb;
+
+    if (uart_hCom == NULL) {
+        return -EINVAL;
+    }
+
+    memset(&dcb, 0, sizeof dcb);
+    dcb.DCBlength = sizeof dcb;
+    if (!GetCommState(uart_hCom, &dcb)) {
+        ERRMSG("%s: %s failed (%lu)\n",
+               __FUNCTION__, "GetComState", GetLastError());
+        return -EIO;
+    }
+    dcb.BaudRate = baudrate;
+    dcb.ByteSize = 8;
+    dcb.Parity = NOPARITY;
+    dcb.StopBits = ONESTOPBIT;
+    dcb.fAbortOnError = FALSE;
+
+    if (!SetCommState(uart_hCom, &dcb)) {
+        ERRMSG("%s: %s failed (%lu)\n",
+               __FUNCTION__, "SetComState", GetLastError());
+        return -EIO;
+    }
+
+    return 0;
+}
+
+
+int uart_getch(void)
+{
+    DWORD dwRead;
+    data8_t value;
+
+    if (!ReadFile(uart_hCom, &value, 1, &dwRead, NULL)) {
+        ERRMSG("%s: ReadFile error %lu\n", __FUNCTION__, GetLastError());
+    }
+
+    return dwRead ? value : -EIO;
+}
+
+
+int uart_putch(data8_t value)
+{
+    DWORD dwWrote;
+
+    if (!WriteFile(uart_hCom, &value, 1, &dwWrote, NULL)) {
+        ERRMSG("%s: WriteFile error %lu\n", __FUNCTION__, GetLastError());
+        return -EIO;
+    }
+
+    return 0;
+}

--- a/src/wpc/uart_16c450.c
+++ b/src/wpc/uart_16c450.c
@@ -1,0 +1,234 @@
+/*
+    Code for emulating the 16C450 UART found on the WPC95-AV board.
+
+    This is a bare-bones emulator that only supports the features used by
+    NBA Fastbreak and the printout features from the service menu.  For
+    example, it does not include any code for interrupts.
+
+    Written July 2024 by Tom Collins <tom@tomlogic.com>
+*/
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include "uart_16c450.h"
+
+#include "timer.h"
+
+#if 0
+#define DEBUG_OUT(...)  printf(__VA_ARGS__)
+#else
+#define DEBUG_OUT(...)
+#endif
+
+enum uart_16c450_reg {
+    RBR = 0,    /* DLAB=0, read-only */
+    THR = 0,    /* DLAB=0, write-only */
+    IER = 1,    /* DLAB=0 */
+    DLL = 0,    /* DLAB=1 */
+    DLM = 1,    /* DLAB=1 */
+    IIR = 2,    /* read-only */
+    LCR = 3,
+    MCR = 4,
+    LSR = 5,
+    MSR = 6,
+    SCR = 7,
+};
+
+static data8_t reg_RBR, reg_THR, reg_IER, reg_IIR = 0x01, reg_LCR, 
+               reg_MCR, reg_LSR = 0x60, reg_MSR, reg_SCR;
+static data16_t reg_divisor;
+static data32_t byte_time_us;       // time (in uS) to send a byte at the current baudrate
+static double THR_clear, TX_clear;
+
+#define REGBIT(reg, bit)    ((reg_ ## reg >> bit) & 1)
+
+#define ERBF    REGBIT(IER, 0)
+#define ETBE    REGBIT(IER, 1)
+#define ELSI    REGBIT(IER, 2)
+#define EDSSI   REGBIT(IER, 3)
+
+#define WLS     (reg_LCR & 0x03)
+#define STB     REGBIT(LCR, 2)
+#define PEN     REGBIT(LCR, 3)
+#define EPS     REGBIT(LCR, 4)
+#define MRKSPC  REGBIT(LCR, 5)
+#define BREAK   REGBIT(LCR, 6)
+#define DLAB    REGBIT(LCR, 7)
+
+#define DR      REGBIT(LSR, 0)
+#define OE      REGBIT(LSR, 1)
+#define PE      REGBIT(LSR, 2)
+#define FE      REGBIT(LSR, 3)
+#define BI      REGBIT(LSR, 4)
+#define THRE    REGBIT(LSR, 5)
+#define TEMT    REGBIT(LSR, 6)
+
+
+const char *uart_16c450_regname(int reg, int write)
+{
+    switch (reg) {
+    case IIR:       return write ? "err" : "IIR";   // IIR is read-only
+    case LCR:       return "LCR";
+    case MCR:       return "MCR";
+    case LSR:       return "LSR";
+    case MSR:       return "MSR";
+    case SCR:       return "SCR";
+    default:
+        if (DLAB) switch (reg) {
+        case DLL:   return "DLL";
+        case DLM:   return "DLM";
+        }
+        else switch (reg) {
+        case THR:   return write ? "THR" : "RBR";
+        case IER:   return "IER";
+        }
+    }
+
+    return "???";
+}
+
+
+static data8_t update_LSR(void)
+{
+    int byte_read;
+    double now;
+
+    now = timer_get_time();
+    if (now > THR_clear) {
+        reg_LSR |= (1 << 5);        // set THRE (Transmit Holding Register Empty)
+    }
+    if (now > TX_clear) {
+        reg_LSR |= (1 << 6);        // set TEMPT (Transmitter Empty)
+    }
+
+    // If we don't already have a byte waiting in RBR, attempt to load one
+    if (!DR) {
+        byte_read = uart_getch();
+        if (byte_read >= 0) {
+            reg_RBR = (data8_t) byte_read;
+            reg_LSR |= (1 << 0);    // set DR (Data Ready)
+        }
+    }
+
+    return reg_LSR;
+}
+
+static void uart_send(data8_t value)
+{
+    double now;
+
+    uart_putch(value);          // Send the byte out on the UART interface
+
+    // Set up timers to simulate the time necessary to clear the Transmit Holding
+    // Register and the actual transmitter shift register.
+    now = timer_get_time();
+    if (now > TX_clear) {
+        // can go straight into transmitter
+        TX_clear = now + TIME_IN_USEC(byte_time_us);
+        reg_LSR &= ~(1 << 6);         // clear transmitter empty (TEMPT) bit
+    }
+    else if (now > THR_clear) {
+        // Byte goes into Transmit Holding Register, then passed to transmitter once
+        // it's done sending the current byte.
+        THR_clear = TX_clear;
+
+        // transmitter now has an extra byte to send
+        TX_clear += TIME_IN_USEC(byte_time_us);
+
+        // clear holding register & transmitter empty (THRE/TEMPT) bits
+        reg_LSR &= ~(1 << 5 | 1 << 6);              
+    }
+    else {
+        // record an error?  overwrite the outbound byte?
+        DEBUG_OUT("uart: sending when THR in use\n");
+    }
+}
+
+data8_t uart_16c450_read(int reg)
+{
+    //DEBUG_OUT("r %s\n", uart_16c450_regname(reg, 0));
+
+    switch (reg) {
+    case IIR:       return reg_IIR;
+    case LCR:       return reg_LCR;
+    case MCR:       return reg_MCR;
+    case LSR:       return update_LSR();
+    case MSR:       return reg_MSR;
+    case SCR:       return reg_SCR;
+    default:
+        if (DLAB) switch (reg) {
+        case DLL:   return reg_divisor >> 8;
+        case DLM:   return reg_divisor & 0xFF;
+        }
+        else switch (reg) {
+        case RBR:   // read stored byte
+            reg_LSR &= ~0x01;       // clear data ready (DR) bit
+            return reg_RBR;
+        case IER:   return reg_IER;
+        }
+    }
+    DEBUG_OUT("uart: unhandled register\n");
+    return 0;
+}
+
+int uart_16c450_write(int reg, data8_t value)
+{
+    int baudrate;
+
+    if (reg < 0 || reg > 7) {
+        return -EINVAL;
+    }
+//    DEBUG_OUT("w %s=0x%02x\n", uart_16c450_regname(reg, 1), value);
+    switch (reg) {
+    case LCR:
+        if ((reg_LCR & 0x40) != (value & 0x40)) {
+            DEBUG_OUT(" uart %s break\n", (value & 0x40) ? "set" : "clear");
+        }
+        if ((reg_LCR & 0x80) != (value & 0x80)) {
+            DEBUG_OUT(" uart %s DLAB\n", (value & 0x80) ? "set" : "clear");
+        }
+        reg_LCR = value;
+        DEBUG_OUT(" uart %u bits, %u stop, %s parity\n",
+                  5 + WLS, 1 + STB,
+                  PEN ? (MRKSPC ? (EPS ? "mark" : "space") : (EPS ? "even" : "odd")) : "no");
+        break;
+
+    case MCR:       reg_MCR = value;    break;
+    case LSR:       reg_LSR = value;    break;
+    case MSR:       reg_MSR = value;    break;
+    case SCR:       reg_SCR = value;    break;
+    default:
+        if (DLAB) {
+            switch (reg) {
+            case DLL:
+                reg_divisor = (reg_divisor & 0xFF00) | value;
+                break;
+            case DLM:
+                reg_divisor = (reg_divisor & 0x00FF) | (value << 8);
+                break;
+            }
+            if (reg_divisor) {
+                // 2MHz system clock, 16x oversampling by UART
+                baudrate = 2000000 / (16 * reg_divisor);
+
+                // estimate byte time based on 10 bits/byte (start + data + stop)
+                // (1,000,000 us/s) / (baudrate bits/s / 10 bits/byte) 
+                byte_time_us = 1000000 / (baudrate / 10);
+
+                DEBUG_OUT("divisor=%u (%ubps)\n", reg_divisor, baudrate);
+
+                // round baudrate to a multiple of 100 for our serial port
+                baudrate = ((baudrate + 50) / 100) * 100;
+                uart_baudrate(baudrate);
+            }
+        }
+        else switch (reg) {
+        case THR:   uart_send(value); break;
+        case IER:   reg_IER = value;    break;
+        }
+    }
+
+    return 0;
+}

--- a/src/wpc/uart_16c450.c
+++ b/src/wpc/uart_16c450.c
@@ -5,6 +5,10 @@
     NBA Fastbreak and the printout features from the service menu.  For
     example, it does not include any code for interrupts.
 
+    But, unlike the 8251 UART emulator, we attempt to simulate the baudrate
+    for outbound bytes in case it matters for the Championship Link feature
+    of NBA Fastbreak.
+
     Written July 2024 by Tom Collins <tom@tomlogic.com>
 */
 
@@ -13,6 +17,7 @@
 #include <stdio.h>
 
 #include "uart_16c450.h"
+#include "uart_host.h"
 
 #include "timer.h"
 

--- a/src/wpc/uart_16c450.h
+++ b/src/wpc/uart_16c450.h
@@ -12,11 +12,3 @@
 // 16C450 emulation
 data8_t uart_16c450_read(int reg);
 int uart_16c450_write(int reg, data8_t value);
-
-/*  Platform-specific code to connect with an actual serial port,
-    Provided by either windows/serial.c or unix/serial.c.
-*/
-int uart_open(const char *device, data32_t baudrate);
-int uart_baudrate(data32_t baudrate);
-int uart_getch(void);
-int uart_putch(data8_t value);

--- a/src/wpc/uart_16c450.h
+++ b/src/wpc/uart_16c450.h
@@ -1,0 +1,22 @@
+/*
+    Code for emulating the 16C450 UART found on the WPC95-AV board.
+
+    This is a bare-bones emulator that only supports the features used by
+    NBA Fastbreak and the printout features from the service menu.  For
+    example, it does not include any code for interrupts.
+
+    Written July 2024 by Tom Collins <tom@tomlogic.com>
+*/
+#include "memory.h"
+
+// 16C450 emulation
+data8_t uart_16c450_read(int reg);
+int uart_16c450_write(int reg, data8_t value);
+
+/*  Platform-specific code to connect with an actual serial port,
+    Provided by either windows/serial.c or unix/serial.c.
+*/
+int uart_open(const char *device, data32_t baudrate);
+int uart_baudrate(data32_t baudrate);
+int uart_getch(void);
+int uart_putch(data8_t value);

--- a/src/wpc/uart_8251.c
+++ b/src/wpc/uart_8251.c
@@ -1,0 +1,138 @@
+/*
+    Code for emulating the 8251 UART found on the WPC Printer Option Kit.
+
+    This is a bare-bones emulator that only supports the features used by
+    the printout features from the service menu.  There isn't any attempt
+    to simulate the baudrate setting.  The emulated UART is always ready
+    to receive bytes, and hands them off to the host UART immediately.
+
+    Written July 2024 by Tom Collins <tom@tomlogic.com>
+*/
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include "uart_8251.h"
+#include "uart_host.h"
+
+#if 0
+#define DEBUG_OUT(...)  printf(__VA_ARGS__)
+#else
+#define DEBUG_OUT(...)
+#endif
+
+// 8251 UART mapped to address WPC_BASE + 0x13 (DATA) and WPC_BASE + 0x14 (CTRL)
+#define REG_DATA    0x13
+#define REG_CTRL    0x14
+
+// The kit's baud rate generator is a separate circuit, but we handle it here as well.
+// Writes to REG_BAUD are a clock divider.  0=9600, 1=4800, 2=2400, 3=1200, 4=600, 5=300.
+#define REG_BAUD    0x15
+
+#define MODE_BAUD(m)        ((m >> 0) & 0x03)
+#define MODE_LENGTH(m)      ((m >> 2) & 0x03)
+#define MODE_PARITY_EN(m)   ((m >> 4) & 0x01)
+#define MODE_PARITY_EVEN(m) ((m >> 5) & 0x01)
+
+// If MODE_BAUD(m) != 0, we're in asynchronous mode.
+#define MODE_STOP(m)        ((m >> 6) & 0x03)
+
+// If MODE_BAUD(m) == 0, we're in synchronous mode.
+#define MODE_SYNC_DETECT(m) ((m >> 6) & 0x01)
+#define MODE_SINGLE_SYNC(m) ((m >> 7) & 0x01)
+
+// Macros to parse bits in the command byte sent from the host.
+#define CMD_TX_ENABLE(c)    ((c >> 0) & 0x01)
+#define CMD_DTR_ENABLE(c)   ((c >> 1) & 0x01)
+#define CMD_RX_ENABLE(c)    ((c >> 2) & 0x01)
+#define CMD_SEND_BREAK(c)   ((c >> 3) & 0x01)
+#define CMD_ERROR_RESET(c)  ((c >> 4) & 0x01)
+#define CMD_RTS_ENABLE(c)   ((c >> 5) & 0x01)
+#define CMD_CHIP_RESET(c)   ((c >> 6) & 0x01)
+#define CMD_ENTER_HUNT(c)   ((c >> 7) & 0x01)
+
+
+// Bitmasks for setting the status byte sent to the host
+#define STATUS_TX_READY     (1 >> 0)
+#define STATUS_RX_READY     (1 >> 1)
+#define STATUS_TX_EMPTY     (1 >> 2)
+#define STATUS_PARITY_ERR   (1 >> 3)
+#define STATUS_OVERRUN_ERR  (1 >> 4)
+#define STATUS_FRAME_ERR    (1 >> 5)
+#define STATUS_SYNC_DET     (1 >> 6)
+#define STATUS_DSR          (1 >> 7)
+
+
+static int mode_loaded = 0;
+
+static data8_t mode, command;
+static data8_t rx_byte;
+static data8_t status = (STATUS_DSR | STATUS_TX_READY | STATUS_TX_EMPTY);
+static int baud = 9600;
+static int rx_ready = 0;
+
+data8_t uart_8251_read(int reg)
+{
+    int byte_read;
+
+//    DEBUG_OUT("r 0x%x\n", reg);
+    switch (reg) {
+    case REG_CTRL:
+        // if we don't already have a byte ready, try to read one
+        if (!(status & STATUS_RX_READY)) {
+            byte_read = uart_getch();
+            if (byte_read >= 0) {
+                rx_byte = (data8_t)byte_read;
+                status |= STATUS_RX_READY;
+            }
+        }
+        return status;
+
+    case REG_DATA:
+        // clear the RX_READY bit and return the buffered byte
+        status &= ~STATUS_RX_READY;
+        return rx_byte;
+    }
+
+    // ROM should never read REG_BAUD.  We need a copy of the schematic to
+    // know how actual hardware would respond.
+    return 0x00;
+}
+
+int uart_8251_write(int reg, data8_t value)
+{
+    switch (reg) {
+        case REG_CTRL:
+            if (!mode_loaded) {
+                mode_loaded = 1;
+                mode = value;
+                DEBUG_OUT("mode=0x%02x\n", mode);
+            }
+            else {
+                command = value;
+                if (CMD_CHIP_RESET(command)) {
+                    // next write will set a new mode
+                    mode_loaded = 0;
+                }
+                DEBUG_OUT("cmd=0x%02x\n", command);
+            }
+            break;
+
+        case REG_DATA:
+            uart_putch(value);
+            if (isprint(value) || value == '\r' || value == '\n') {
+                DEBUG_OUT("%c", value);
+            }
+            else {
+                DEBUG_OUT("\nprt 0x%x\n", value);
+            }
+            break;
+
+        case REG_BAUD:
+            baud = 9600 / (value + 1);
+            DEBUG_OUT("%ubps\n", baud);
+            break;
+    }
+    return 0;
+}

--- a/src/wpc/uart_8251.c
+++ b/src/wpc/uart_8251.c
@@ -130,7 +130,7 @@ int uart_8251_write(int reg, data8_t value)
             break;
 
         case REG_BAUD:
-            baud = 9600 / (value + 1);
+            baud = 9600 / (1 << value);
             DEBUG_OUT("%ubps\n", baud);
             break;
     }

--- a/src/wpc/uart_8251.h
+++ b/src/wpc/uart_8251.h
@@ -1,0 +1,13 @@
+/*
+    Code for emulating the 8251 UART found on the WPC Printer Option Kit.
+
+    This is a bare-bones emulator that only supports the features used by
+    the printout features from the service menu. 
+
+    Written July 2024 by Tom Collins <tom@tomlogic.com>
+*/
+#include "memory.h"
+
+// 8251 emulation
+data8_t uart_8251_read(int reg);
+int uart_8251_write(int reg, data8_t value);

--- a/src/wpc/uart_host.h
+++ b/src/wpc/uart_host.h
@@ -1,0 +1,12 @@
+/*  Platform-specific host code to connect with an actual serial port,
+    Provided by either windows/serial.c or unix/serial.c.
+
+    Written July 2024 by Tom Collins <tom@tomlogic.com>
+*/
+
+#include "memory.h"
+
+int uart_open(const char *device, data32_t baudrate);
+int uart_baudrate(data32_t baudrate);
+int uart_getch(void);
+int uart_putch(data8_t value);

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -1215,7 +1215,11 @@ static MACHINE_INIT(wpc) {
   if (pmoptions.serial_device != NULL) {
     // use default baud rate; game will set a baud rate at startup
     if (uart_open(pmoptions.serial_device, 9600) < 0) {
+      printf("serial_device: failed to open %s.\n", pmoptions.serial_device);
       pmoptions.serial_device = NULL;       // open failed, disable UART
+    }
+    else {
+      printf("serial_device: WPC serial port redirected to %s.\n", pmoptions.serial_device);
     }
   }
 #endif

--- a/src/wpc/wpc.h
+++ b/src/wpc/wpc.h
@@ -159,9 +159,9 @@ extern const core_tLCDLayout wpc_dispDMD[];
 #define WPC_PRINTBUSY     (0x3fc0 - WPC_BASE) /* xxxxx  R: Printer ready ??? */
 #define WPC_PRINTDATA     (0x3fc1 - WPC_BASE) /* xxxxx  W: send to printer */
 #define WPC_PRINTDATAX    (0x3fc2 - WPC_BASE) /* xxxxx  W: 0: Printer data available */
-#define WPC_SERIAL_DATA   (0x3fc3 - WPC_BASE)
-#define WPC_SERIAL_CTRL   (0x3fc4 - WPC_BASE)
-#define WPC_SERIAL_BAUD   (0x3fc5 - WPC_BASE)
+#define WPC_SERIAL_DATA   (0x3fc3 - WPC_BASE) /* xxxxx  8251 UART of WPC Printer Option Kit */
+#define WPC_SERIAL_CTRL   (0x3fc4 - WPC_BASE) /* xxxxx  8251 UART of WPC Printer Option Kit */
+#define WPC_SERIAL_BAUD   (0x3fc5 - WPC_BASE) /* xxxxx  baud rate divider (0=9600, 1=4800, ..., 5=300) */
 /* Ticket dispenser board */
 #define WPC_TICKET_DISP   (0x3fc6 - WPC_BASE)
 /* Fliptronics 2 Board */


### PR DESCRIPTION
This draft pull request adds support for WPC serial ports used for printing, and for NBA Fastbreak's "Championship Link" feature.  I have emulated enough of the 8251 UART on the WPC Printer Option Kit and the 16C450 UART on the WPC95 AV board to support how the ROMs made use of them.  Related to #289.

In addition, I've added basic UART support for Windows and Unix (POSIX) platforms, based on code I wrote for another Open Source project (MPL 2.0 License).

This allows for connecting the emulated UART to a physical serial port on the host, or a virtual serial port created with a tool such as `socat` on Unix or `com0com` on Windows.

I have tested Visual Studio 2019 builds using Virtual Serial Port Driver by Electronic team, and CMake builds on macOS using XQuartz and `socat`.

I have had some success NBA Fastbreak's Championship Link between PinMAME (VS2019, Windows 10 VM) and a physical machine.  I think the problems I ran into were due to limited resources in my VM (attempting to run PinMAME, the virtual serial port relay, and PyCharm to monitor/dump/annotate the communications simultaneously).  This confirmed for me that the 16C450 emulation works bi-directionally.  I don't know whether WPC ROMs did any reading from the 8251 UART on the WPC Printer Option Kit.

I've updated many of the make/cmake files for the PinMAME target only.  I don't know if this feature is appropriate for other targets or not.  I have not tested generation of Visual Studio files from the manually edited VS2008/VS2012 project files.

Looking for feedback from @toxieainc, @jsm174, and others on code-related and/or build-related changes.  I could see possibly supporting a filename as the `serial_device` parameter to allow for dumping printouts to disk instead of a serial port.