### PR TITLE
Update bulb characteristic to new measures

### DIFF
--- a/src/wpc/bulb.h
+++ b/src/wpc/bulb.h
@@ -9,12 +9,13 @@
 #define BULB_47   1
 #define BULB_86   2
 #define BULB_89   3
-#define BULB_MAX  4
+#define BULB_906  4
+#define BULB_MAX  5
 
 #define BULB_T_MAX 3400
 
 extern void bulb_init();
-extern float bulb_filament_temperature_to_emission(const float T);
+extern float bulb_filament_temperature_to_emission(const int bulb, const float T);
 extern void bulb_filament_temperature_to_tint(const float T, float* linear_RGB);
 extern double bulb_emission_to_filament_temperature(const double p);
 extern double bulb_cool_down_factor(const int bulb, const double T);

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -2558,7 +2558,7 @@ void core_update_pwm_output_bulb(const double now, const int index, const int is
       const float Ut = output->state.bulb.isAC ? (1.41421356f * sinf((float)(60.0 * 2.0 * PI) * (float)(output->state.bulb.prevIntegrationTimestamp - coreGlobals.lastACZeroCrossTimeStamp)) * output->state.bulb.prevIntegrationValue) : output->state.bulb.prevIntegrationValue;
       const float dT = dt * bulb_heat_up_factor(output->state.bulb.bulb, output->state.bulb.filament_temperature, Ut, output->state.bulb.serial_R);
       output->state.bulb.filament_temperature += dT < 1000.0f ? dT : 1000.0f; // Limit initial current surge (1ms is a bit long when emulating this part of the heating)
-      core_eye_flicker_fusion(output, bulb_filament_temperature_to_emission(output->state.bulb.filament_temperature));
+      core_eye_flicker_fusion(output, bulb_filament_temperature_to_emission(output->state.bulb.bulb, output->state.bulb.filament_temperature));
       output->state.bulb.prevIntegrationTimestamp += dt;
     }
     output->state.bulb.prevIntegrationTimestamp = output->state.bulb.integrationTimestamp;
@@ -2569,8 +2569,8 @@ void core_update_pwm_output_bulb(const double now, const int index, const int is
 
   #ifdef LOG_PWM_OUT
   if (index == LOG_PWM_OUT)
-    printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s F=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.filament_temperature), output->value, state ? "x" : "-", isFlip ? "/" : ".");
-    //printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.filament_temperature), output->value, ((coreGlobals.binaryOutputState[index >> 3] >> (index & 7)) & 1) ? "x" : "-");
+    printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s F=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.bulb, output->state.bulb.filament_temperature), output->value, state ? "x" : "-", isFlip ? "/" : ".");
+    //printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.bulb, output->state.bulb.filament_temperature), output->value, ((coreGlobals.binaryOutputState[index >> 3] >> (index & 7)) & 1) ? "x" : "-");
   #endif
 }
 
@@ -2619,7 +2619,7 @@ void core_update_pwm_output_led(const double now, const int index, const int isF
 
   #ifdef LOG_PWM_OUT
   if (index == LOG_PWM_OUT)
-    printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.filament_temperature), output->value, state ? "x" : "-");
+    printf("Output #%d t=%8.5f T=%5.0f e=%0.3f V=%0.3f S=%s\n", index, now, output->state.bulb.filament_temperature, bulb_filament_temperature_to_emission(output->state.bulb.bulb, output->state.bulb.filament_temperature), output->value, state ? "x" : "-");
   #endif
 }
 


### PR DESCRIPTION
@toxieainc these are just better bulb modelling based on real life measurements (bought a bunch of bulbs and some VPW members helped with measurements) but things are so interdependent (for example with the flicker/fusion filter) that it would be nice if you could have a look if things looks ok for you.

I have tested this with a bunch of tables supporting PWM and it looked good to me (still fading, but better for some fast blinks that I think were smoothed out by previous constants).