### PR TITLE
Add documentation for -serial_device

### DIFF
--- a/release/pinmame.txt
+++ b/release/pinmame.txt
@@ -185,6 +185,8 @@ Instructions
 
 Command line switches
 ---------------------
+  For a full list of command-line options, pass `-showusage` to PinMAME.
+  
   These options can be set on the command line or in mame.cfg:
 
   -[no]dmd_compact   off = Display a more DMD like display (space between dots)
@@ -253,6 +255,12 @@ PinMAME Specific Command line switches
   -dmd_blue0        (Amount of blue displayed for not being lit)
 
   (for more information on the settings above, see "Changing the Look of the DMD")
+  
+  -[no]force_stereo     (Always force stereo output to better support multi-channel sound)
+  -serial_device <dev>  ("COMx" on Windows or "/dev/ttyXXX" on Unix; the device mapped to
+                         the WPC serial port of the Printer Kit or WPC95 AV board)
+  -sound_mode 0-3       (Sound processing mode; 0=PinMAME, 1=Alternative, 2=PinSound,
+                         3=PinSound + Recordings)
 
 VGM sound file dump
 -------------------

--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -45,7 +45,8 @@ Added the emulation of physical bulbs & LEDs connected to binary outputs, for WP
 
 In addition to the TILDE key, now also the YEN key on respective keyboard mappings will work to bring up the internal PinMAME menu
 
-Support WPC UARTs (8251 from Printer Option Kit & 16C450 from WPC95), also making the 'Championship Link' mode of NBAFB work (incl. PinMAME <-> real machine)
+Support WPC UARTs (8251 from Printer Option Kit & 16C450 from WPC95), also enabling the 'Championship Link' mode of NBAFB  (incl. PinMAME <-> real machine).  Configured via `-serial_device` command-line option.
+  Note that the NBAFB Championship Link usually gets out of sync and aborts when connected to a real machine.  If trying to link two copies of PinMAME, it's necessary to have different WPC serial numbers (hardcoded in nbaf.c) for each instance of PinMAME.
 
 *** CORE/CPU ***
 Fixed WPC General Illumination (GI) Dimming (most noticably if more than one GI line is involved, also all 8 levels are now handled properly)


### PR DESCRIPTION
Minor documentation improvements from #290.  Provides more details in `whatsnew.txt` and adds some missing command-line options to `pinmame.txt`.