### PR TITLE
Add data exchange through a global shared state block

### DIFF
--- a/cmake/libpinmame/CMakeLists.txt
+++ b/cmake/libpinmame/CMakeLists.txt
@@ -504,6 +504,7 @@ set(PINMAME_SOURCES
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/pinmame/CMakeLists_win-x64.txt
+++ b/cmake/pinmame/CMakeLists_win-x64.txt
@@ -444,6 +444,7 @@ add_executable(pinmame WIN32
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/pinmame/CMakeLists_win-x86.txt
+++ b/cmake/pinmame/CMakeLists_win-x86.txt
@@ -450,6 +450,7 @@ add_executable(pinmame WIN32
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/pinmame32/CMakeLists_win-x64.txt
+++ b/cmake/pinmame32/CMakeLists_win-x64.txt
@@ -449,6 +449,7 @@ add_executable(pinmame32 WIN32
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/pinmame32/CMakeLists_win-x86.txt
+++ b/cmake/pinmame32/CMakeLists_win-x86.txt
@@ -452,6 +452,7 @@ add_executable(pinmame32 WIN32
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/vpinmame/CMakeLists_win-x64.txt
+++ b/cmake/vpinmame/CMakeLists_win-x64.txt
@@ -450,6 +450,7 @@ add_library(vpinmame SHARED
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/vpinmame/CMakeLists_win-x86.txt
+++ b/cmake/vpinmame/CMakeLists_win-x86.txt
@@ -453,6 +453,7 @@ add_library(vpinmame SHARED
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/xpinmame/CMakeLists_linux-x64.txt
+++ b/cmake/xpinmame/CMakeLists_linux-x64.txt
@@ -463,6 +463,7 @@ add_executable(xpinmame
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/cmake/xpinmame/CMakeLists_osx-x64.txt
+++ b/cmake/xpinmame/CMakeLists_osx-x64.txt
@@ -453,6 +453,7 @@ add_executable(xpinmame
    src/wpc/peyper.c
    src/wpc/peyper.h
    src/wpc/peypergames.c
+   src/libpinmame/pinmamedef.h
    src/wpc/play.c
    src/wpc/play.h
    src/wpc/playgames.c

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -654,7 +654,7 @@ int StartGame(const int gameNum)
  * PinmameGetGame
  ******************************************************/
 
-PINMAMEAPI PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback, const void* p_userData)
+PINMAMEAPI PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback, void* const p_userData)
 {
 	if (!_p_Config)
 		return PINMAME_STATUS_CONFIG_NOT_SET;
@@ -686,7 +686,7 @@ PINMAMEAPI PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCa
  * PinmameGetGames
  ******************************************************/
 
-PINMAMEAPI PINMAME_STATUS PinmameGetGames(PinmameGameCallback callback, const void* p_userData)
+PINMAMEAPI PINMAME_STATUS PinmameGetGames(PinmameGameCallback callback, void* const p_userData)
 {
 	if (!_p_Config)
 		return PINMAME_STATUS_CONFIG_NOT_SET;
@@ -885,6 +885,8 @@ PINMAMEAPI PINMAME_STATUS PinmameRun(const char* const p_name)
 
 	if (gameNum < 0)
 		return PINMAME_STATUS_GAME_NOT_FOUND;
+
+   OnStateChange(2); // Starting state
 
 	vp_init();
 
@@ -1407,7 +1409,25 @@ PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates)
  * PinmameSetUserData
  ******************************************************/
 
-PINMAMEAPI void PinmameSetUserData(const void* p_userData)
+PINMAMEAPI void PinmameSetUserData(void* const p_userData)
 {
 	_p_userData = (void*)p_userData;
+}
+
+/******************************************************
+ * PinmameGetStateBlock
+ ******************************************************/
+
+PINMAMEAPI int PinmameGetStateBlock(const unsigned int updateMask, pinmame_tMachineOutputState** pp_outputState)
+{
+	if (!_isRunning)
+		return -1;
+
+	pinmame_tMachineOutputState* p_outputState = (pinmame_tMachineOutputState*)core_getOutputState(updateMask);
+	if (!p_outputState)
+		return -1;
+
+	*pp_outputState = p_outputState;
+
+	return 0;
 }

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -17,6 +17,10 @@
 #define PINMAME_MAX_MECHSW 20
 #define PINMAME_ACCUMULATOR_SAMPLES 8192 // from mixer.c
 
+#define UINT32 uint32_t
+#define UINT8  uint8_t
+#include "pinmamedef.h"
+
 typedef enum {
 	PINMAME_LOG_LEVEL_DEBUG = 0,
 	PINMAME_LOG_LEVEL_INFO = 1,
@@ -394,19 +398,19 @@ typedef struct {
 	unsigned int standardcode;
 } PinmameKeyboardInfo;
 
-typedef void (PINMAMECALLBACK *PinmameGameCallback)(PinmameGame* p_game, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnStateUpdatedCallback)(int state, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnDisplayAvailableCallback)(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnDisplayUpdatedCallback)(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, const void* p_userData);
-typedef int (PINMAMECALLBACK *PinmameOnAudioAvailableCallback)(PinmameAudioInfo* p_audioInfo, const void* p_userData);
-typedef int (PINMAMECALLBACK *PinmameOnAudioUpdatedCallback)(void* p_buffer, int samples, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnMechAvailableCallback)(int mechNo, PinmameMechInfo* p_mechInfo, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInfo* p_mechInfo, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size, const void* p_userData);
-typedef int (PINMAMECALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnLogMessageCallback)(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, const void* p_userData);
-typedef void (PINMAMECALLBACK *PinmameOnSoundCommandCallback)(int boardNo, int cmd, const void* p_userData);
+typedef void (PINMAMECALLBACK *PinmameGameCallback)(PinmameGame* p_game, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnStateUpdatedCallback)(int state, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnDisplayAvailableCallback)(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnDisplayUpdatedCallback)(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, void* const p_userData);
+typedef int (PINMAMECALLBACK *PinmameOnAudioAvailableCallback)(PinmameAudioInfo* p_audioInfo, void* const p_userData);
+typedef int (PINMAMECALLBACK *PinmameOnAudioUpdatedCallback)(void* p_buffer, int samples, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnMechAvailableCallback)(int mechNo, PinmameMechInfo* p_mechInfo, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnMechUpdatedCallback)(int mechNo, PinmameMechInfo* p_mechInfo, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnSolenoidUpdatedCallback)(PinmameSolenoidState* p_solenoidState, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnConsoleDataUpdatedCallback)(void* p_data, int size, void* const p_userData);
+typedef int (PINMAMECALLBACK *PinmameIsKeyPressedFunction)(PINMAME_KEYCODE keycode, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnLogMessageCallback)(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, void* const p_userData);
+typedef void (PINMAMECALLBACK *PinmameOnSoundCommandCallback)(int boardNo, int cmd, void* const p_userData);
 
 typedef struct {
 	const PINMAME_AUDIO_FORMAT audioFormat;
@@ -426,8 +430,8 @@ typedef struct {
 	PinmameOnSoundCommandCallback cb_OnSoundCommand;
 } PinmameConfig;
 
-PINMAMEAPI PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback, const void* p_userData);
-PINMAMEAPI PINMAME_STATUS PinmameGetGames(PinmameGameCallback callback, const void* p_userData);
+PINMAMEAPI PINMAME_STATUS PinmameGetGame(const char* const p_name, PinmameGameCallback callback, void* const p_userData);
+PINMAMEAPI PINMAME_STATUS PinmameGetGames(PinmameGameCallback callback, void* const p_userData);
 PINMAMEAPI void PinmameSetConfig(const PinmameConfig* const p_config);
 PINMAMEAPI void PinmameSetPath(const PINMAME_FILE_TYPE fileType, const char* const p_path);
 PINMAMEAPI int PinmameGetCheat();
@@ -476,4 +480,6 @@ PINMAMEAPI void PinmameSetDIP(const int dipBank, const int value);
 PINMAMEAPI int PinmameGetMaxNVRAM();
 PINMAMEAPI int PinmameGetNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates);
-PINMAMEAPI void PinmameSetUserData(const void* p_userData);
+PINMAMEAPI void PinmameSetUserData(void* const p_userData);
+PINMAMEAPI int PinmameGetStateBlock(const unsigned int updateMask, pinmame_tMachineOutputState** pp_outputState);
+

--- a/src/libpinmame/pinmamedef.h
+++ b/src/libpinmame/pinmamedef.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// This file contains definitions used inside PinMame and for external integration through libpinmame
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Complete machine output state, provided in a global state block
+//
+// 0 length array is a non standard extension used intentionally here. 
+// Corresponding warning #4200 is therefore disabled when needed.
+//
+
+// Digital output instantaneous states
+
+#pragma warning(disable : 4200) 
+typedef struct
+{
+   double       updateTimestamp;
+   unsigned int nOutputs;
+   UINT32       outputBitset[];  // Bitset array of nOutputs bits with their current binary state
+} pinmame_tBinaryStates;
+
+
+// Controlled device states
+
+typedef enum {
+   PINMAME_DEVICE_STATE_TYPE_CUSTOM,   // Custom state defined by each driver (value maybe either binary of 0/1 or 0/255, or modulated between 0..255)
+   PINMAME_DEVICE_STATE_TYPE_BULB,     // Bulb state defined by its relative luminance and average filament temperature
+   PINMAME_DEVICE_STATE_TYPE_LED,      // LED state defined by its relative luminance
+   PINMAME_DEVICE_STATE_TYPE_SOLENOID, // Solenoid (not yet defined)
+   PINMAME_DEVICE_STATE_TYPE_STEPPER,  // Stepper motor (not yet defined)
+} pinmame_tDeviceCategory;
+
+typedef enum {
+   PINMAME_DEVICE_TYPE_UNDEFINED,      // Hardware type identifier
+   PINMAME_DEVICE_TYPE_VFD_BLUE,       // VFD used for segment display
+   PINMAME_DEVICE_TYPE_VFD_GREEN,      // VFD used for segment display
+   PINMAME_DEVICE_TYPE_NEON_PLASMA,    // Neon Plasma display (Panaplex, Burroughs,...) used for segment and dot matrix display
+   PINMAME_DEVICE_TYPE_LED_RED,        // 
+} pinmame_tDeviceType;
+
+typedef struct
+{
+   pinmame_tDeviceCategory category;
+   pinmame_tDeviceType     type;
+   unsigned int            mapping;     // Device mapping to a user understandable id (for example lamp matrix are usually numbered by row/column and not index)
+   char*                   name;        // Device name (for example "GI", "Flipper", "Lamp 1", ...)
+   union
+   {
+      // PINMAME_DEVICE_STATE_TYPE_CUSTOM
+      UINT8 customState;            // Custom value, depending on each driver definition
+      
+      // PINMAME_DEVICE_STATE_TYPE_BULB
+      struct
+      {
+         float luminance;           // relative luminance to bulb rating (equals 1.f when bulb is under its rating voltage after heating stabilization)
+         float filamentTemperature; // perceived filament temperature (equals to bulb filament rating when bulb is at its rating voltage after heating stabilization)
+      } bulb;
+      
+      // PINMAME_DEVICE_STATE_TYPE_LED
+      float ledLuminance;           // relative luminance to bulb design (equals 1.f when LED is pulsed at its designed PWM)
+
+      // PINMAME_DEVICE_STATE_TYPE_SOLENOID
+      // To be added in a later revision
+
+      // PINMAME_DEVICE_STATE_TYPE_STEPPER
+      // To be added in a later revision
+   };
+} pinmame_tDeviceState;
+
+#pragma warning(disable : 4200)
+typedef struct
+{
+   double               updateTimestamp;
+   unsigned int         nDevices;
+   unsigned int         stateByteSize;   // sizeof(pinmame_tDeviceState), to be used to access states since the size of a single state may evolve in future revisions
+   pinmame_tDeviceState states[];        // array of nDevices * stateByteSize with the current device states
+} pinmame_tDeviceStates;
+
+
+// Alphanumeric segment displays
+
+// Individual segment layouts inside a display (usually made of multiple elements)
+typedef enum {
+   PINMAME_SEG_LAYOUT_7,          //  7 segments
+   PINMAME_SEG_LAYOUT_7C,         //  7 segments with comma
+   PINMAME_SEG_LAYOUT_7D,         //  7 segments with dot
+   PINMAME_SEG_LAYOUT_9,          //  9 segments
+   PINMAME_SEG_LAYOUT_9C,         //  9 segments with comma
+   PINMAME_SEG_LAYOUT_14,         // 14 segments
+   PINMAME_SEG_LAYOUT_14D,        // 14 segments with dot
+   PINMAME_SEG_LAYOUT_14DC,       // 14 segments with dot and comma
+   PINMAME_SEG_LAYOUT_16,         // 16 segments
+} pinmame_tSegElementType;
+
+typedef struct
+{
+   pinmame_tSegElementType type;               // see PINMAME_SEG_LAYOUT_xxx
+   float                   luminance[16];      // relative luminance of each segment (from 7 to 16)
+} pinmame_tAlphaSegmentState;
+
+typedef struct
+{
+   unsigned int            nElements;         // Number of elements (each element is composed of 7 to 16 segments)
+   pinmame_tDeviceType     type;              // Hardware reference (Panaplex, VFD, ...)
+} pinmame_tAlphaDisplayDef;
+
+#pragma warning(disable : 4200)
+typedef struct
+{
+   double                   updateTimestamp;
+   unsigned int             nDisplays;        // Number of displays (each display is composed of multiple elements)
+   pinmame_tAlphaDisplayDef displayDefs[];    // Definition of each display (number of elements, hardware type,...)
+   // pinmame_tAlphaSegmentState states[];    // State of each display element as a linear array
+} pinmame_tAlphaStates;
+#define PINMAME_STATE_BLOCK_FIRST_ALPHA_FRAME(pAlphaState) ((pinmame_tAlphaSegmentState*)((UINT8*)(pAlphaState) + sizeof(pinmame_tAlphaStates) + (pAlphaState->nDisplays) * sizeof(pinmame_tAlphaDisplayDef)))
+
+
+// DMD and video displays
+
+typedef enum {
+   PINMAME_FRAME_FORMAT_LUM,     // Linear luminance (for monochrome DMD)
+   PINMAME_FRAME_FORMAT_RGB,     // sRGB (for video frame)
+   PINMAME_FRAME_FORMAT_BP2,     // 2 bitplanes, only used to identify frames
+   PINMAME_FRAME_FORMAT_BP4      // 4 bitplanes, only used to identify frames
+} pinmame_tFrameDataFormat;
+
+#pragma warning(disable : 4200)
+typedef struct
+{
+   unsigned int             structSize;      // Struct size including header and frame data in bytes (for safe DMD/Display array iteration)
+   unsigned int             displayId;       // Unique Id, shared between render frame and raw frame used for frame identification
+   double                   updateTimestamp;
+   unsigned int             width;
+   unsigned int             height;
+   pinmame_tFrameDataFormat dataFormat;
+   unsigned int             frameId;
+   UINT8                    frameData[];     // The display frame data which size depends on width, height and data format
+} pinmame_tFrameState;
+
+typedef struct
+{
+   unsigned int nDisplays;
+   // pinmame_tFrameState displays[]; // Array of nDisplays * pinmame_tFrameState (can't be directly declared since frame size is undefined)
+} pinmame_tDisplayStates;
+#define PINMAME_STATE_BLOCK_FIRST_DISPLAY_FRAME(pDisplayState) ((pinmame_tFrameState*)((UINT8*)(pDisplayState) + sizeof(pinmame_tDisplayStates)))
+#define PINMAME_STATE_BLOCK_NEXT_DISPLAY_FRAME(pFrameState) ((pinmame_tFrameState*)((UINT8*)(pFrameState) + (pFrameState)->structSize))
+
+
+// Global output state block
+
+typedef struct
+{
+   unsigned int versionID;                               // Data block format version (current version
+   pinmame_tBinaryStates*  controlledOutputBinaryStates; // Binary state (instantaneous state of controlled output)
+   pinmame_tDeviceStates*  controlledDeviceStates;       // Device state (state of the emulated device)
+   pinmame_tDeviceStates*  lampMatrixStates;             // State of emulated lamps powered from a strobed lamp matrix
+   pinmame_tAlphaStates*   alphaDisplayStates;           // State of alphanumeric segment displays
+   pinmame_tDisplayStates* displayStates;                // State of displays and DMDs
+   pinmame_tDisplayStates* rawDMDStates;                 // Raw logic state of DMDs (stable view of the stae that can be used for frame identification)
+} pinmame_tMachineOutputState;
+
+#define PINMAME_STATE_REQMASK_GPOUTPUT_BINARY_STATE 0x01
+#define PINMAME_STATE_REQMASK_GPOUTPUT_DEVICE_STATE 0x02
+#define PINMAME_STATE_REQMASK_LAMP_DEVICE_STATE     0x04
+#define PINMAME_STATE_REQMASK_ALPHA_DEVICE_STATE    0x08
+#define PINMAME_STATE_REQMASK_DISPLAY_STATE         0x10
+#define PINMAME_STATE_REQMASK_RAW_DMD_STATE         0x20
+#define PINMAME_STATE_REQMASK_ALL                   0x3F
+

--- a/src/libpinmame/test.cpp
+++ b/src/libpinmame/test.cpp
@@ -134,13 +134,13 @@ void DumpAlphanumeric(int index, UINT16* p_displayData, PinmameDisplayLayout* p_
 		printf("%s\n", output[row]);
 }
 
-void PINMAMECALLBACK Game(PinmameGame* game, const void* p_userData)
+void PINMAMECALLBACK Game(PinmameGame* game, void* const p_userData)
 {
 	printf("Game(): name=%s, description=%s, manufacturer=%s, year=%s, flags=%lu, found=%d\n",
 		game->name, game->description, game->manufacturer, game->year, (unsigned long)game->flags, game->found);
 }
 
-void PINMAMECALLBACK OnStateUpdated(int state, const void* p_userData)
+void PINMAMECALLBACK OnStateUpdated(int state, void* const p_userData)
 {
 	printf("OnStateUpdated(): state=%d\n", state);
 
@@ -161,7 +161,7 @@ void PINMAMECALLBACK OnStateUpdated(int state, const void* p_userData)
 	PinmameSetMech(1, &mechConfig);
 }
 
-void PINMAMECALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, const void* p_userData)
+void PINMAMECALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisplayLayout* p_displayLayout, void* const p_userData)
 {
 	printf("OnDisplayAvailable(): index=%d, displayCount=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
 		index,
@@ -175,7 +175,7 @@ void PINMAMECALLBACK OnDisplayAvailable(int index, int displayCount, PinmameDisp
 		p_displayLayout->length);
 }
 
-void PINMAMECALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, const void* p_userData)
+void PINMAMECALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDisplayLayout* p_displayLayout, void* const p_userData)
 {
 	printf("OnDisplayUpdated(): index=%d, type=%d, top=%d, left=%d, width=%d, height=%d, depth=%d, length=%d\n",
 		index,
@@ -197,7 +197,7 @@ void PINMAMECALLBACK OnDisplayUpdated(int index, void* p_displayData, PinmameDis
 	}
 }
 
-int PINMAMECALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo, const void* p_userData)
+int PINMAMECALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo, void* const p_userData)
 {
 	printf("OnAudioAvailable(): format=%d, channels=%d, sampleRate=%.2f, framesPerSecond=%.2f, samplesPerFrame=%d, bufferSize=%d\n",
 		p_audioInfo->format,
@@ -209,17 +209,17 @@ int PINMAMECALLBACK OnAudioAvailable(PinmameAudioInfo* p_audioInfo, const void* 
 	return p_audioInfo->samplesPerFrame;
 }
 
-int PINMAMECALLBACK OnAudioUpdated(void* p_buffer, int samples, const void* p_userData)
+int PINMAMECALLBACK OnAudioUpdated(void* p_buffer, int samples, void* const p_userData)
 {
 	return samples;
 }
 
-void PINMAMECALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState, const void* p_userData)
+void PINMAMECALLBACK OnSolenoidUpdated(PinmameSolenoidState* p_solenoidState, void* const p_userData)
 {
 	printf("OnSolenoidUpdated: solenoid=%d, state=%d\n", p_solenoidState->solNo,  p_solenoidState->state);
 }
 
-void PINMAMECALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo, const void* p_userData)
+void PINMAMECALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo, void* const p_userData)
 {
 	printf("OnMechAvailable: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
 		mechNo,
@@ -230,7 +230,7 @@ void PINMAMECALLBACK OnMechAvailable(int mechNo, PinmameMechInfo* p_mechInfo, co
 		p_mechInfo->speed);
 }
 
-void PINMAMECALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo, const void* p_userData)
+void PINMAMECALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo, void* const p_userData)
 {
 	printf("OnMechUpdated: mechNo=%d, type=%d, length=%d, steps=%d, pos=%d, speed=%d\n",
 		mechNo,
@@ -241,17 +241,17 @@ void PINMAMECALLBACK OnMechUpdated(int mechNo, PinmameMechInfo* p_mechInfo, cons
 		p_mechInfo->speed);
 }
 
-void PINMAMECALLBACK OnConsoleDataUpdated(void* p_data, int size, const void* p_userData)
+void PINMAMECALLBACK OnConsoleDataUpdated(void* p_data, int size, void* const p_userData)
 {
 	printf("OnConsoleDataUpdated: size=%d\n", size);
 }
 
-int PINMAMECALLBACK IsKeyPressed(PINMAME_KEYCODE keycode, const void* p_userData)
+int PINMAMECALLBACK IsKeyPressed(PINMAME_KEYCODE keycode, void* const p_userData)
 {
 	return 0;
 }
 
-void PINMAMECALLBACK OnLogMessage(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, const void* p_userData)
+void PINMAMECALLBACK OnLogMessage(PINMAME_LOG_LEVEL logLevel, const char* format, va_list args, void* const p_userData)
 {
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), format, args);
@@ -262,7 +262,7 @@ void PINMAMECALLBACK OnLogMessage(PINMAME_LOG_LEVEL logLevel, const char* format
 		printf("ERROR: %s\n", buffer);
 }
 
-void PINMAMECALLBACK OnSoundCommand(int boardNo, int cmd, const void* p_userData)
+void PINMAMECALLBACK OnSoundCommand(int boardNo, int cmd, void* const p_userData)
 {
 	printf("OnSoundCommand: boardNo=%d, cmd=%d\n", boardNo, cmd);
 }

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -1734,6 +1734,36 @@ STDMETHODIMP CController::put_TimeFence(double timeInS)
 }
 
 /****************************************************************************
+ * IController.get_StateBlock: returns a shared memory block name which holds
+ * a global state block prepended by the memory block size as an unsigned int
+ ****************************************************************************/
+STDMETHODIMP CController::get_StateBlock(/*[out, retval]*/ BSTR* pVal)
+{
+	if (!pVal)
+		return E_POINTER;
+	if (!Machine)
+		return E_FAIL;
+	if (core_getOutputState(PINMAME_STATE_REQMASK_ALL) == NULL)
+		return E_FAIL;
+	CComBSTR bsStateSharedMemName(TEXT("Local\\VPinMameStateBlock"));
+	*pVal = bsStateSharedMemName.Detach();
+	return S_OK;
+}
+
+/****************************************************************************
+ * IController.UpdateStateBlock: Update requested outputs of the global state
+ * block
+ ****************************************************************************/
+STDMETHODIMP CController::UpdateStateBlock(/*[in, defaultvalue(0x3F)]*/ unsigned int updateMask)
+{
+	if (!Machine)
+		return E_FAIL;
+	if (core_getOutputState(updateMask) == NULL)
+		return E_FAIL;
+	return S_OK;
+}
+
+/****************************************************************************
  * IController.Version (read-only): gets the program version of VPM
  ****************************************************************************/
 STDMETHODIMP CController::get_Version(BSTR *pVal)

--- a/src/win32com/Controller.h
+++ b/src/win32com/Controller.h
@@ -205,6 +205,9 @@ public:
 	STDMETHOD(put_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[in]*/ int newVal);
 
 	STDMETHOD(put_TimeFence)(/*[in]*/ double fenceIns);
+
+	STDMETHOD(get_StateBlock)(/*[out, retval]*/ BSTR* pVal);
+	STDMETHOD(UpdateStateBlock)(/*[in, defaultvalue(0x1F)]*/ unsigned int updateMask);
 };
 
 #endif // !defined(AFX_Controller_H__D2811491_40D6_4656_9AA7_8FF85FD63543__INCLUDED_)

--- a/src/win32com/ControllerDmdDevice.cpp
+++ b/src/win32com/ControllerDmdDevice.cpp
@@ -51,8 +51,8 @@ typedef void(*DmdDev_Render_16_Shades_t)(UINT16 width, UINT16 height, UINT8* fra
 typedef void(*DmdDev_Render_4_Shades_t)(UINT16 width, UINT16 height, UINT8* frame);
 typedef void(*DmdDev_Render_16_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8* frame, UINT32 noOfRawFrames, UINT8* rawbuffer);
 typedef void(*DmdDev_Render_4_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8* frame, UINT32 noOfRawFrames, UINT8* rawbuffer);
-typedef void(*DmdDev_Render_PM_Alphanumeric_Frame_t)(core_segOverallLayout_t layout, const UINT16* const seg_data, const UINT16* const seg_data2);
-typedef void(*DmdDev_Render_PM_Alphanumeric_Dim_Frame_t)(core_segOverallLayout_t layout, const UINT16* const seg_data, const char* const seg_dim, const UINT16* const seg_data2);
+typedef void(*DmdDev_Render_PM_Alphanumeric_Frame_t)(core_tSegOverallLayout layout, const UINT16* const seg_data, const UINT16* const seg_data2);
+typedef void(*DmdDev_Render_PM_Alphanumeric_Dim_Frame_t)(core_tSegOverallLayout layout, const UINT16* const seg_data, const char* const seg_dim, const UINT16* const seg_data2);
 typedef void(*DmdDev_Render_Lum_And_Raw_t)(UINT16 width, UINT16 height, UINT8* lumFrame, UINT8* rawFrame, UINT32 noOfRawFrames, UINT8* rawbuffer);
 
 typedef struct {
@@ -239,7 +239,7 @@ extern "C" void dmddeviceRenderDMDFrame(const int width, const int height, UINT8
 	}
 }
 
-extern "C" void dmddeviceRenderAlphanumericFrame(core_segOverallLayout_t layout, UINT16* seg_data, UINT16* seg_data2, char* seg_dim) {
+extern "C" void dmddeviceRenderAlphanumericFrame(core_tSegOverallLayout layout, UINT16* seg_data, UINT16* seg_data2, char* seg_dim) {
 	for (int i = 0; i < 2; i++)
 	{
 		if (dmdDevices[i].Render_PM_Alphanumeric_Dim_Frame)

--- a/src/win32com/VPinMAME.idl
+++ b/src/win32com/VPinMAME.idl
@@ -259,6 +259,8 @@ import "ocidl.idl";
 		[propget, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [out, retval] int *pVal);
 		[propput, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [in] int newVal);
 		[propput, id(89), helpstring("property TimeFence")] HRESULT TimeFence([in] double timeInS);
+		[propget, id(90), helpstring("property StateBlock")] HRESULT StateBlock([out, retval] BSTR* pVal);
+		[id(91), helpstring("method UpdateStateBlock")] HRESULT UpdateStateBlock([in, defaultvalue(0x3F)] unsigned int updateMask);
 	};
 
 	// WSHDlg and related interfaces

--- a/src/wpc/byvidpin.c
+++ b/src/wpc/byvidpin.c
@@ -459,6 +459,12 @@ static VIDEO_STOP(byVP) {
 
 static PINMAME_VIDEO_UPDATE(byVP_update) {
   TMS9928A_refresh((core_gameData->hw.display ? 2 : 1), bitmap, 1);
+  struct rectangle bounds;
+  bounds.min_x = 0;
+  bounds.min_y = 0;
+  bounds.max_x = 192;
+  bounds.max_y = 256;
+  core_display_video_update(bitmap, &bounds, layout, 1);
   return 0;
 }
 

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -10,6 +10,10 @@
 #include "gen.h"
 #include "sim.h"
 
+#include "drawgfx.h"
+
+#include "../libpinmame/pinmamedef.h"
+
 /*-- some convenience macros --*/
 #ifndef FALSE
   #define FALSE (0)
@@ -172,24 +176,24 @@
 /  Generic Display layout data
 /------------------------------*/
 /* The different kind of display units */
-#define CORE_SEG16    0 // 16 segments
-#define CORE_SEG16R   1 // 16 segments with comma and period reversed
-#define CORE_SEG10    2 // 9  segments and comma
-#define CORE_SEG9     3 // 9  segments
-#define CORE_SEG8     4 // 7  segments and comma
-#define CORE_SEG8D    5 // 7  segments and period
-#define CORE_SEG7     6 // 7  segments
-#define CORE_SEG87    7 // 7  segments, comma every three
-#define CORE_SEG87F   8 // 7  segments, forced comma every three
-#define CORE_SEG98    9 // 9  segments, comma every three
-#define CORE_SEG98F  10 // 9  segments, forced comma every three
-#define CORE_SEG7S   11 // 7  segments, small
-#define CORE_SEG7SC  12 // 7  segments, small, with comma
+#define CORE_SEG16    0 // 14 segments with comma and period
+#define CORE_SEG16R   1 // 14 segments with comma and period reversed
+#define CORE_SEG10    2 //  9 segments and comma
+#define CORE_SEG9     3 //  9 segments
+#define CORE_SEG8     4 //  7 segments and comma
+#define CORE_SEG8D    5 //  7 segments and period
+#define CORE_SEG7     6 //  7 segments
+#define CORE_SEG87    7 //  7 segments, comma every three
+#define CORE_SEG87F   8 //  7 segments, forced comma every three
+#define CORE_SEG98    9 //  9 segments, comma every three
+#define CORE_SEG98F  10 //  9 segments, forced comma every three
+#define CORE_SEG7S   11 //  7 segments, small
+#define CORE_SEG7SC  12 //  7 segments, small, with comma
 #define CORE_SEG16S  13 // 16 segments with split top and bottom line
 #define CORE_DMD     14 // DMD Display
 #define CORE_VIDEO   15 // VIDEO Display
-#define CORE_SEG16N  16 // 16 segments without commas
-#define CORE_SEG16D  17 // 16 segments with periods only
+#define CORE_SEG16N  16 // 14 segments (no dot nor comma)
+#define CORE_SEG16D  17 // 14 segments with period but no comma
 
 #define CORE_SEGALL   0x1f // maximum segment definition number
 #define CORE_IMPORT   0x20 // Link to another display layout
@@ -229,7 +233,7 @@ struct core_dispLayout {
 typedef struct core_dispLayout core_tLCDLayout, *core_ptLCDLayout;
 // Overall alphanumeric display layout. Used externally by VPinMame's dmddevice. Don't change order
 typedef enum {
-   CORE_SEGLAYOUT_None,
+   CORE_SEGLAYOUT_None = 0,
    CORE_SEGLAYOUT_2x16Alpha,
    CORE_SEGLAYOUT_2x20Alpha,
    CORE_SEGLAYOUT_2x7Alpha_2x7Num,
@@ -247,7 +251,7 @@ typedef enum {
    CORE_SEGLAYOUT_1x7Num_1x16Alpha_1x16Num,
    CORE_SEGLAYOUT_1x16Alpha_1x16Num_1x7Num_1x4Num,
    CORE_SEGLAYOUT_Invalid
-} core_segOverallLayout_t;
+} core_tSegOverallLayout;
 
 
 #define PINMAME_VIDEO_UPDATE(name) int (name)(struct mame_bitmap *bitmap, const struct rectangle *cliprect, const struct core_dispLayout *layout)
@@ -607,6 +611,9 @@ extern int core_getPulsedSol(int solNo);
 extern UINT64 core_getAllSol(void);
 extern void core_getAllPhysicSols(float* const state);
 
+/*-- full output state --*/
+extern pinmame_tMachineOutputState* core_getOutputState(const unsigned int updateMask);
+
 /*-- AC sync and PWM integration --*/
 extern void core_update_pwm_outputs(const int startIndex, const int count);
 INLINE void core_update_pwm_gis(void) { if (options.usemodsol & (CORE_MODOUT_FORCE_ON | CORE_MODOUT_ENABLE_PHYSOUT_GI)) core_update_pwm_outputs(CORE_MODOUT_GI0, coreGlobals.nGI); }
@@ -668,6 +675,8 @@ extern void core_dmd_pwm_exit(core_tDMDPWMState* dmd_state);
 extern void core_dmd_submit_frame(core_tDMDPWMState* dmd_state, const UINT8* frame, const int ntimes);
 extern void core_dmd_update_pwm(core_tDMDPWMState* dmd_state);
 extern void core_dmd_video_update(struct mame_bitmap *bitmap, const struct rectangle *cliprect, const struct core_dispLayout *layout, core_tDMDPWMState* dmd_state);
+
+extern void core_display_video_update(struct mame_bitmap* bitmap, const struct rectangle* cliprect, const struct core_dispLayout* layout, const int rotation);
 
 extern void core_sound_throttle_adj(int sIn, int *sOut, int buffersize, double samplerate);
 

--- a/src/wpc/sam.c
+++ b/src/wpc/sam.c
@@ -2252,7 +2252,9 @@ static PINMAME_VIDEO_UPDATE(samminidmd_update) {
             bits = (bits << 1) | (coreGlobals.dmdDotRaw[y * 5 + x] ? 1 : 0);
         coreGlobals.drawSeg[35 * dmd_y + 5 * dmd_x + x] = bits;
     }
+#ifndef VPINMAME
     if (!pmoptions.dmd_only)
+#endif
         core_dmd_video_update(bitmap, cliprect, layout, NULL);
     return 0;
 }
@@ -2274,8 +2276,10 @@ static PINMAME_VIDEO_UPDATE(samminidmd2_update) {
         bits = (bits<<1) | (coreGlobals.dmdDotRaw[kk * layout->length + ii] ? 1 : 0);
       coreGlobals.drawSeg[ii] = bits;
     }
-    if (!pmoptions.dmd_only)
-      core_dmd_video_update(bitmap, cliprect, layout, NULL);
+#ifndef VPINMAME
+	 if (!pmoptions.dmd_only)
+#endif
+		 core_dmd_video_update(bitmap, cliprect, layout, NULL);
     return 0;
 }
 

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -793,16 +793,14 @@ WRITE_HANDLER(wpc_w) {
       {
         //static double prev; printf("WPC_ALPHA2LO %8.5fms %02x %02x\n", timer_get_time() - prev, wpc_data[WPC_ALPHAPOS], data); prev = timer_get_time();
         wpclocals.alphaSeg[20+wpc_data[WPC_ALPHAPOS]].b.lo |= data;
-        if (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_ALPHASEGS | CORE_MODOUT_FORCE_ON))
-          core_write_pwm_output_8b(CORE_MODOUT_SEG0 + (20 + wpc_data[WPC_ALPHAPOS]) * 2 * 8, data);
+        core_write_pwm_output_8b(CORE_MODOUT_SEG0 + (20 + wpc_data[WPC_ALPHAPOS]) * 2 * 8, data);
       }
       break;
     case WPC_ALPHA2HI:
       if ((core_gameData->gen & GENWPC_HASDMD) == 0)
       {
         wpclocals.alphaSeg[20+wpc_data[WPC_ALPHAPOS]].b.hi |= data;
-        if (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_ALPHASEGS | CORE_MODOUT_FORCE_ON))
-          core_write_pwm_output_8b(CORE_MODOUT_SEG0 + ((20 + wpc_data[WPC_ALPHAPOS]) * 2 + 1) * 8, data);
+        core_write_pwm_output_8b(CORE_MODOUT_SEG0 + ((20 + wpc_data[WPC_ALPHAPOS]) * 2 + 1) * 8, data);
       }
       break;
     case WPC_LAMPROW: /* row and column can be written in any order */
@@ -869,17 +867,14 @@ WRITE_HANDLER(wpc_w) {
         // The delay between setting segments then blanking them is used to a rough PWM dimming
         // Overall timing is 1ms maximum per digit over a 16ms period
         //static double prev; printf("WPC_ALPHAPOS %8.5fms %02x\n", timer_get_time() - prev, data); prev = timer_get_time();
-        if (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_ALPHASEGS | CORE_MODOUT_FORCE_ON))
-        {
-          int prevIndex = CORE_MODOUT_SEG0 + wpc_data[WPC_ALPHAPOS] * 2 * 8;
-          int newIndex  = CORE_MODOUT_SEG0 +     data               * 2 * 8;
-          if (prevIndex != newIndex)
-            for (int i = 0; i < 4; i++)
-            {
-              int offst = i == 0 ? 0 : i == 1 ? 8 : i == 2 ? 320 : 328;
-              core_write_pwm_output_8b(newIndex  + offst, coreGlobals.binaryOutputState[(prevIndex + offst) >> 3]);
-              core_write_pwm_output_8b(prevIndex + offst, 0);
-            }
+        int prevIndex = CORE_MODOUT_SEG0 + wpc_data[WPC_ALPHAPOS] * 2 * 8;
+        int newIndex  = CORE_MODOUT_SEG0 +     data               * 2 * 8;
+        if (prevIndex != newIndex) {
+          for (int i = 0; i < 4; i++) {
+            int offst = i == 0 ? 0 : i == 1 ? 8 : i == 2 ? 320 : 328;
+            core_write_pwm_output_8b(newIndex  + offst, coreGlobals.binaryOutputState[(prevIndex + offst) >> 3]);
+            core_write_pwm_output_8b(prevIndex + offst, 0);
+          }
         }
       }
       break; /* just save position */
@@ -896,8 +891,7 @@ WRITE_HANDLER(wpc_w) {
       else if ((core_gameData->gen & GENWPC_HASDMD) == 0) // WPC_ALPHA1LO
       {
         wpclocals.alphaSeg[wpc_data[WPC_ALPHAPOS]].b.lo |= data;
-        if (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_ALPHASEGS | CORE_MODOUT_FORCE_ON))
-          core_write_pwm_output_8b(CORE_MODOUT_SEG0 + wpc_data[WPC_ALPHAPOS] * 2 * 8, data);
+        core_write_pwm_output_8b(CORE_MODOUT_SEG0 + wpc_data[WPC_ALPHAPOS] * 2 * 8, data);
       }
       break;
     case WPC_EXTBOARD3: /* WPC_ALPHA1HI */


### PR DESCRIPTION
This commits allows to share previously unshared data without overloading too much the API by adding a single data block for pulsed state, device state, modulated segments, multiple DMDs, raw DMD frames (for correct rendering and allow coloring) and video.

This commit contains the skeleton and base implementation to set up the ground for more testing on client side (VPX) when support will be more advanced there. It also gives a ground to implement in LibPinMame.

The aims of these changes are for VPX but could be useful for other client as well:
- allow VPX to perform correct DMD rendering (needs unprocessed DMD frames),
- allow VPX's plugin to perform coloring (needs unprocessed DMD frames),
- allow VPX to include a backglass renderer with support for fading lamps & flashers (could be done with existing interface but at the price of lots of data exchange and likely some API bloat),
- allow VPX to support modulated segments,
- allow VPX to add support for video output (MrGame machines, ...).

[Edit: multiple force-push to fix stupid build bugs (missing min/max, ...)]