### PR TITLE
DMD: fix backward compatibility (VPX renderer, colorization plugins) and clean ups

### DIFF
--- a/src/wpc/capcom.c
+++ b/src/wpc/capcom.c
@@ -951,8 +951,8 @@ PINMAME_VIDEO_UPDATE(cc_dmd128x32) {
 
   UINT32 offset = locals.visible_page ? 0x800 * locals.visible_page - 0x10 : 0;
   RAM = ramptr+offset;
-  for (ii = 0; ii <= 32; ii++) {
-    UINT8 *line = &coreGlobals.dotCol[ii][0];
+  for (ii = 0; ii < 32; ii++) {
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii*layout->length];
     for (kk = 0; kk < 16; kk++) {
       UINT16 intens1 = RAM[0];
       for(jj=0;jj<8;jj++) {
@@ -977,9 +977,9 @@ PINMAME_VIDEO_UPDATE(cc_dmd256x64) {
 
   UINT32 offset = locals.visible_page ? 0x800 * locals.visible_page - 0x20 : 0;
   RAM = ramptr+offset;
-  for (ii = 0; ii <= 64; ii++) {
-    UINT8 *linel = &coreGlobals.dotCol[ii][0];
-    UINT8 *liner = &coreGlobals.dotCol[ii][128];
+  for (ii = 0; ii < 64; ii++) {
+    UINT8 *linel = &coreGlobals.dmdDotRaw[ii * layout->length];
+    UINT8 *liner = &coreGlobals.dmdDotRaw[ii * layout->length + 128];
     for (kk = 0; kk < 16; kk++) {
       UINT16 intensl = RAM[0];
       UINT16 intensr = RAM[0x10];

--- a/src/wpc/dmddevice.h
+++ b/src/wpc/dmddevice.h
@@ -35,8 +35,8 @@ extern "C"
 
 int pindmdInit(const char* GameName, UINT64 HardwareGeneration, const tPMoptions *Options);
 void pindmdDeInit(void);
-void renderDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *currbuffer, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
-void render2ndDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *currbuffer, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
+void renderDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
+void render2ndDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
 layout_t layoutAlphanumericFrame(UINT64 gen, UINT16* seg_data, UINT16* seg_data_2, UINT8 total_disp, UINT8* disp_num_segs, const char* GameName);
 void renderAlphanumericFrame(UINT64 gen, UINT16 *seg_data, char *seg_dim, UINT8 total_disp, UINT8 *disp_num_segs, const char* GameName);
 void FwdConsoleData(UINT8 data);

--- a/src/wpc/gts3.c
+++ b/src/wpc/gts3.c
@@ -591,7 +591,8 @@ static void gts3dmd_init(void) {
   crtc6845_set_vsync(0, 3579545. / 2., dmd_vblank);
 
   // Setup PWM shading
-  core_dmd_pwm_init(&GTS3_dmdlocals[0].pwm_state, 128, 32, CORE_DMD_PWM_FILTER_GTS3);
+  core_dmd_pwm_init(&GTS3_dmdlocals[0].pwm_state, 128, 32, CORE_DMD_PWM_FILTER_GTS3, 
+	  (strncasecmp(Machine->gamedrv->name, "smb", 3) == 0) || (strncasecmp(Machine->gamedrv->name, "cueball", 7) == 0) ? CORE_DMD_PWM_COMBINER_LUM_16 : CORE_DMD_PWM_COMBINER_LUM_4);
 
   /*DMD*/
   /*copy last 32K of ROM into last 32K of CPU region*/
@@ -732,7 +733,7 @@ static MACHINE_INIT(gts3dmd2) {
   crtc6845_set_vsync(1, 3579545. / 2., dmd_vblank);
 
   // Setup PWM shading
-  core_dmd_pwm_init(&GTS3_dmdlocals[1].pwm_state, 128, 32, CORE_DMD_PWM_FILTER_GTS3);
+  core_dmd_pwm_init(&GTS3_dmdlocals[1].pwm_state, 128, 32, CORE_DMD_PWM_FILTER_GTS3, CORE_DMD_PWM_COMBINER_LUM_16);
 
   /*copy last 32K of DMD ROM into last 32K of CPU region*/
   if (memory_region(GTS3_MEMREG_DCPU2)) {
@@ -960,7 +961,7 @@ static WRITE_HANDLER(dmd_aux) {
 static void dmd_vblank(int which) {
 	const UINT8* RAM = memory_region(which ? GTS3_MEMREG_DCPU2 : GTS3_MEMREG_DCPU1) + 0x1000 + (crtc6845_start_address_r(which) >> 2);
 	//static double prev; printf("DMD VBlank %6.2fHz: %02x %02x %02x %02x\n", 1. / (timer_get_time() - prev), RAM[20 * 16 + 2], RAM[20 * 16 + 6], RAM[20 * 16 + 10], RAM[20 * 16 + 14]); prev = timer_get_time();
-	core_dmd_submit_frame(&GTS3_dmdlocals[which].pwm_state, RAM);
+	core_dmd_submit_frame(&GTS3_dmdlocals[which].pwm_state, RAM, 1);
 	cpu_set_nmi_line(which ? GTS3_DCPUNO2 : GTS3_DCPUNO, PULSE_LINE);
 }
 

--- a/src/wpc/gts3dmd.c
+++ b/src/wpc/gts3dmd.c
@@ -15,7 +15,7 @@ extern GTS3_DMDlocals GTS3_dmdlocals[2];
 // This was needed because each game had a different (somewhat wrong) VSync frequency.
 // This lead to better performance since less frames were accumulated but had 2 side effects:
 // - there were some occasional residual flickers,
-// - DMD luminance was not fully coherent between GTS3 games (some 4 shades, some other 5 shades).
+// - DMD luminance was not fully coherent between GTS3 games.
 int gts3_dmd128x32(int which, struct mame_bitmap* bitmap, const struct rectangle* cliprect, const struct core_dispLayout* layout)
 {
   core_dmd_update_pwm(&GTS3_dmdlocals[which].pwm_state);

--- a/src/wpc/se.c
+++ b/src/wpc/se.c
@@ -879,7 +879,7 @@ PINMAME_VIDEO_UPDATE(seminidmd1_update) {
   UINT16 *seg = coreGlobals.drawSeg;
 
   for (ii = 0, bits = 0x40; ii < 7; ii++, bits >>= 1) {
-    UINT8 *line = &coreGlobals.dotCol[ii+1][0];
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii * layout->length];
     int jj,kk;
     for (jj = 2; jj >= 0; jj--)
       for (kk = 0; kk < 5; kk++) {
@@ -891,7 +891,7 @@ PINMAME_VIDEO_UPDATE(seminidmd1_update) {
     int jj;
     bits = 0;
     for (jj = 0; jj < 7; jj++)
-      bits = (bits<<2) | coreGlobals.dotCol[jj+1][ii];
+      bits = (bits<<2) | coreGlobals.dmdDotRaw[jj * layout->length + ii];
     *seg++ = bits;
   }
   if (!pmoptions.dmd_only)
@@ -905,7 +905,7 @@ PINMAME_VIDEO_UPDATE(seminidmd1s_update) {
   UINT16 *seg = &coreGlobals.drawSeg[5*(2-jj)];
 
   for (ii = 0, bits = 0x40; ii < 7; ii++, bits >>= 1) {
-    UINT8 *line = &coreGlobals.dotCol[ii+1][0];
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii * layout->length];
     int kk;
     for (kk = 0; kk < 5; kk++)
       *line++ = ((selocals.minidmd[0][jj][kk] & bits) + (selocals.minidmd[1][jj][kk] & bits) +
@@ -915,7 +915,7 @@ PINMAME_VIDEO_UPDATE(seminidmd1s_update) {
     int kk;
     bits = 0;
     for (kk = 0; kk < 7; kk++)
-      bits = (bits<<2) | coreGlobals.dotCol[kk+1][ii];
+      bits = (bits<<2) | coreGlobals.dmdDotRaw[kk * layout->length + ii];
     *seg++ = bits;
   }
   if (!pmoptions.dmd_only)
@@ -928,7 +928,7 @@ PINMAME_VIDEO_UPDATE(seminidmd2_update) {
   UINT16 *seg = coreGlobals.drawSeg;
 
   for (ii = 0, bits = 0x01; ii < 7; ii++, bits <<= 1) {
-    UINT8 *line = &coreGlobals.dotCol[ii+1][0];
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii * layout->length];
     int jj,kk;
     for (jj = 0; jj < 3; jj++)
       for (kk = 4; kk >= 0; kk--)
@@ -939,7 +939,7 @@ PINMAME_VIDEO_UPDATE(seminidmd2_update) {
     int jj;
     bits = 0;
     for (jj = 0; jj < 7; jj++)
-      bits = (bits<<2) | coreGlobals.dotCol[jj+1][ii];
+      bits = (bits<<2) | coreGlobals.dmdDotRaw[jj * layout->length + ii];
     *seg++ = bits;
   }
   if (!pmoptions.dmd_only)
@@ -951,9 +951,9 @@ PINMAME_VIDEO_UPDATE(seminidmd3_update) {
   int ii,kk;
   UINT16 *seg = coreGlobals.drawSeg;
 
-  memset(coreGlobals.dotCol,0,sizeof(coreGlobals.dotCol));
+  memset(coreGlobals.dmdDotRaw,0,sizeof(coreGlobals.dmdDotRaw));
   for (kk = 0; kk < 5; kk++) {
-    UINT8 *line = &coreGlobals.dotCol[kk+1][0];
+    UINT8 *line = &coreGlobals.dmdDotRaw[kk * layout->length];
     int jj,bits;
     for (jj = 0; jj < 3; jj++)
       for (ii = 0, bits = 0x01; ii < 7; ii++, bits <<= 1)
@@ -964,7 +964,7 @@ PINMAME_VIDEO_UPDATE(seminidmd3_update) {
     int bits = 0;
     int jj;
     for (jj = 0; jj < 5; jj++)
-      bits = (bits<<2) | coreGlobals.dotCol[jj+1][ii];
+      bits = (bits<<2) | coreGlobals.dmdDotRaw[jj * layout->length + ii];
     *seg++ = bits;
   }
   if (!pmoptions.dmd_only)
@@ -988,12 +988,12 @@ PINMAME_VIDEO_UPDATE(seminidmd4_update) {
       int isRed = (selocals.minidmd[0][ii/7][ii%7] & bits) > 0;
       int isGrn = (selocals.minidmd[1][ii/7][ii%7] & bits) > 0;
       bits1 = (bits1 << 2) | (isGrn << 1) | isRed;
-      line = &coreGlobals.dotCol[ii+1][kk];
+      line = &coreGlobals.dmdDotRaw[ii * layout->length + kk];
       *line = color[isRed][isGrn];
       isRed = (selocals.minidmd[2][ii/7][ii%7] & bits) > 0;
       isGrn = (selocals.minidmd[3][ii/7][ii%7] & bits) > 0;
       bits2 = (bits2 << 2) | (isGrn << 1) | isRed;
-      line = &coreGlobals.dotCol[ii+1][7+kk];
+      line = &coreGlobals.dmdDotRaw[ii * layout->length + 7+kk];
       *line = color[isRed][isGrn];
     }
     *seg++ = bits1;

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -304,8 +304,8 @@ PINMAME_VIDEO_UPDATE(sleic_dmd_update) {
   UINT16 *RAM;
 
   RAM = (void *)(memory_region(SLEIC_MEMREG_CPU) + 0x60410);
-  for (ii = 1; ii <= 32; ii++) {
-    UINT8 *line = &coreGlobals.dotCol[ii][0];
+  for (ii = 0; ii < 32; ii++) {
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii * layout->length];
     for (jj = 0; jj < 16; jj++) {
       for (kk = 7; kk >= 0; kk--) {
         *line++ = (RAM[0]>>kk) & 1 ? 3 : 0;

--- a/src/wpc/spinb.c
+++ b/src/wpc/spinb.c
@@ -1438,7 +1438,7 @@ PINMAME_VIDEO_UPDATE(SPINBdmd_update) {
 
 #ifdef MAME_DEBUG
   core_textOutf(50,20,1,"offset=%08x", offset);
-  memset(coreGlobals.dotCol,0,sizeof(coreGlobals.dotCol));
+  memset(coreGlobals.dmdDotRaw,0,sizeof(coreGlobals.dmdDotRaw));
 
   if(!debugger_focus) {
   if(keyboard_pressed_memory_repeat(KEYCODE_C,2))
@@ -1464,8 +1464,8 @@ PINMAME_VIDEO_UPDATE(SPINBdmd_update) {
   RAM2 += offset;
 #endif
 
-  for (ii = 1; ii <= 32; ii++) {
-    UINT8 *line = &coreGlobals.dotCol[ii][0];
+  for (ii = 0; ii < 32; ii++) {
+    UINT8 *line = &coreGlobals.dmdDotRaw[ii * layout->length];
     for (jj = 0; jj < (128/8); jj++) {
 	  UINT8 intens1, intens2, dot1, dot2;
 	  dot1 = core_revbyte(RAM[0]);
@@ -1505,10 +1505,10 @@ PINMAME_VIDEO_UPDATE(SPINBdmd_update) {
   UINT8   *line;
   UINT8   d1,d2,d3;
 
-  memset(coreGlobals.dotCol, 0, sizeof(coreGlobals.dotCol));
+  memset(coreGlobals.dmdDotRaw, 0, sizeof(coreGlobals.dmdDotRaw));
   for (row=0; row < 32; row++)
   {
-    line = &coreGlobals.dotCol[row+1][0];
+    line = &coreGlobals.dmdDotRaw[row * layout->length];
     for (col=0; col < 16; col++)
     {
       d1=dmd32RAM[0][row][col];

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -1189,7 +1189,7 @@ static MACHINE_INIT(wpc) {
   // Init DMD PWM shading
   if (core_gameData->gen & (GEN_WPCDMD | GEN_WPCFLIPTRON | GEN_WPCDCS | GEN_WPCSECURITY | GEN_WPC95DCS | GEN_WPC95))
   {
-    core_dmd_pwm_init(&dmdlocals.pwm_state, 128, (core_gameData->hw.gameSpecific2 == WPC_PH) ? 64 : 32, CORE_DMD_PWM_FILTER_WPC);
+    core_dmd_pwm_init(&dmdlocals.pwm_state, 128, (core_gameData->hw.gameSpecific2 == WPC_PH) ? 64 : 32, CORE_DMD_PWM_FILTER_WPC, CORE_DMD_PWM_COMBINER_SUM_3);
     dmdlocals.pwm_state.revByte = 1;
   }
 
@@ -1593,20 +1593,20 @@ static void wpc_dmd_hsync(int param) {
         UINT8 full_frame[0x400]; // Somewhat overkill (2 copies)
         memcpy(full_frame, memory_region(WPC_DMDREGION) + (dmdlocals.visiblePage & 0x0f) * 0x200 + (dmdlocals.visiblePage % 2) * 0x200, 0x200);
         memset(&full_frame[0x200], 0, 0x200);
-        core_dmd_submit_frame(&dmdlocals.pwm_state, full_frame);
+        core_dmd_submit_frame(&dmdlocals.pwm_state, full_frame, 1);
         #ifdef PROC_SUPPORT
           if (coreGlobals.p_rocEn) // PH: reasonable guess on how to handle two frames only
             procFillDMDSubFrame(dmd_state->frame_index % 3, full_frame, 0x400);
         #endif
       } else { // full page
-        core_dmd_submit_frame(&dmdlocals.pwm_state, memory_region(WPC_DMDREGION) + dmdlocals.visiblePage * 0x400);
+        core_dmd_submit_frame(&dmdlocals.pwm_state, memory_region(WPC_DMDREGION) + dmdlocals.visiblePage * 0x400, 1);
         #ifdef PROC_SUPPORT
           if (coreGlobals.p_rocEn) // PH: reasonable guess on how to handle two frames only
             procFillDMDSubFrame(dmd_state->frame_index % 3, memory_region(WPC_DMDREGION) + dmdlocals.visiblePage * 0x400, 0x400);
         #endif
       }
     } else {
-      core_dmd_submit_frame(&dmdlocals.pwm_state, memory_region(WPC_DMDREGION) + (dmdlocals.visiblePage & 0x0f) * 0x200);
+      core_dmd_submit_frame(&dmdlocals.pwm_state, memory_region(WPC_DMDREGION) + (dmdlocals.visiblePage & 0x0f) * 0x200, 1);
       #ifdef PROC_SUPPORT
         if (coreGlobals.p_rocEn) /* looks like P-ROC uses the last 3 subframes sent rather than the first 3 */
           procFillDMDSubFrame(dmd_state->frame_index % 3, memory_region(WPC_DMDREGION) + (dmdlocals.visiblePage & 0x0f) * 0x200, 0x200);


### PR DESCRIPTION
- change dmd buffers to be linear and 0 based
- compute both luminance and bitplane DMD frames for PWM enabled drivers
- overall cleanups