### PR TITLE
DMD: better backward compatibility for dmddevice.dll

### DIFF
--- a/docs/dmd.md
+++ b/docs/dmd.md
@@ -3,7 +3,7 @@
 Emulating the DMD pursues the following purposes:
 - providing emulators (PinMame, VPX,...) with informations allowing rendering of a virtual DMD as accurately as possible,
 - driving modern DMD hardware which implements their own shading capabilities,
-- providing frames that can be uniquely identified to perform colorization.
+- providing frames that can be uniquely identified to perform colorization or trigger events (f.e. PinUp display events).
 
 These aims lead the DMD emulation to evaluate 2 different things:
 - luminance frames, which are suited for accurate rendering, but may vary as the luminance model improves,
@@ -31,12 +31,12 @@ The table below gives the main information (PWM FPS / Display FPS / PWM pattern)
 
 | Name                                                        | PWM FPS / Disp.FPS     | PWM pattern | Emulation comments                                             |
 |-------------------------------------------------------------|------------------------|-------------|----------------------------------------------------------------|
-|[WPC](#wpc)                                                  | **122.1** / 40.7       | 2/3 frames  |                                                                |
+|[WPC](#wpc)                                                  | **122.1** / 61.1-40.7  | 2/3 frames  |                                                                |
 |[WPC Phantom Haus](#wpc)                                     | 61.05 / 30.1           | 2 frames    |                                                                |
 |[Data East 128x16](#data-east-128x16)                        | 177.5 / **59.2**       | 2u row      |                                                                |
 |[Data East 128x32](#data-east-128x32-segastern-whitestar)    | 234.2 / **78.1**       | 2u row      |                                                                |
 |Sega 192x64                                                  | 224.2 / 74.73          | 2u row      |                                                                |
-|Gottlieb GTS3                                                | **375.9** / 125.3-37.6 | 3/6/8/10    |                                                                |
+|Gottlieb GTS3                                                | **375.9** / 125.3-37.6 | 3/6/8/10 frames |                                                            |
 |[Alvin G. 1](#alvin-g)                                       | 332.4 / 83.1           | 4 row       |Still a little flicker on the title screen                      |
 |[Alvin G. 2](#alvin-g)                                       | 298.6 / **74.6**       | 4 row       |                                                                |
 |[Sega/Stern Whitestar](#data-east-128x32-segastern-whitestar)| 233.3 / **77.8**       | 2u row      |                                                                |
@@ -44,12 +44,12 @@ The table below gives the main information (PWM FPS / Display FPS / PWM pattern)
 |Sleic                                                        | ?                      | ?           |Review in progress                                              |
 |Spinball                                                     | **132.9**              | ?           |Review in progress                                              |
 |Capcom                                                       | **508.6** / 127.2 ?    | 4 ?         |Review in progress                                              |
-|[Stern SAM](#stern-sam)                                      | 751.2 / **62.6**       | 4u row      |Needs interframe emulation, shade validation, fix back/front mix|            
-|[Stern Spike 1](#stern-spike-1)                              | 952.4 / **63.5**       | 4u          |Unsupported hardware |            
+|[Stern SAM](#stern-sam)                                      | 751.2 / **62.6**       | 4u row      |Needs overall emulation timing fixes, interframe emulation, shade validation, back/front mix validation|
+|[Stern Spike 1](#stern-spike-1)                              | 952.4 / **63.5**       | 4u frames   |Unsupported hardware                                            |            
 
 - 'u' stands for 'unbalanced': each row/frame has a different display length.
 - All FPS are expressed in Hz (same as frame per second), the one in **bold** have been verified on real hardware.
-- PWM can be performed per row or per frame (PWM FPS is computed considering equivalent per frame FPS).
+- PWM can be performed per row or per frame (PWM FPS is computed considering equivalent per frame FPS). When done per frame, the game code may dynamically change the PWM pattern length.
 
 
 ## WPC

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -3126,21 +3126,12 @@ void core_dmd_render_lpm(const int width, const int height, const UINT8* const d
 }
 #endif
 
-// Send main DMD bitplane frame to dmddevice plugins
+// Send main DMD to dmddevice plugins
 #ifdef VPINMAME
-void core_dmd_render_dmddevice(const int width, const int height, const UINT8* const dmdDotRaw, const int isDMD2) {
+void core_dmd_render_dmddevice(const int width, const int height, const UINT8* const dmdDotLum, const UINT8* const dmdDotRaw, const int isDMD2) {
   if (g_fShowPinDMD) {
     const int isStrikeNSpares = strncasecmp(Machine->gamedrv->name, "snspare", 7) == 0;
-    if (isStrikeNSpares) {
-      if (isDMD2)
-        renderDMDFrame(core_gameData->gen, width, height, dmdDotRaw, g_fDumpFrames, Machine->gamedrv->name, raw_dmd_frame_count, raw_dmd_frames);
-      else
-        render2ndDMDFrame(core_gameData->gen, width, height, dmdDotRaw, g_fDumpFrames, Machine->gamedrv->name, raw_dmd_frame_count, raw_dmd_frames);
-    }
-    else {
-      renderDMDFrame(core_gameData->gen, width, height, dmdDotRaw, g_fDumpFrames, Machine->gamedrv->name, raw_dmd_frame_count, raw_dmd_frames);
-      render2ndDMDFrame(core_gameData->gen, width, height, dmdDotRaw, g_fDumpFrames, Machine->gamedrv->name, raw_dmd_frame_count, raw_dmd_frames);
-    }
+    renderDMDFrame(width, height, dmdDotLum, dmdDotRaw, raw_dmd_frame_count, raw_dmd_frames, isStrikeNSpares ? (isDMD2 ? 2 : 1) : 3);
   }
 }
 #endif
@@ -3245,7 +3236,7 @@ void core_dmd_video_update(struct mame_bitmap *bitmap, const struct rectangle *c
     core_dmd_render_internal(bitmap, layout->left, layout->top, layout->length, layout->start, dmdDotLum, pmoptions.dmd_antialias && !(layout->type & CORE_DMDNOAA));
     if (isMainDMD) {
       core_dmd_render_vpm(layout->length, layout->start, dmdDotLum);
-      core_dmd_render_dmddevice(layout->length, layout->start, dmdDotRaw, layout->top != 0);
+      core_dmd_render_dmddevice(layout->length, layout->start, dmdDotLum, dmdDotRaw, layout->top != 0);
       core_dmd_capture_frame(layout->length, layout->start, dmdDotRaw, raw_dmd_frame_count ,raw_dmd_frames);
       has_DMD_Video = 1;
     }

--- a/src/wpc/dmddevice.cpp
+++ b/src/wpc/dmddevice.cpp
@@ -1,325 +1,19 @@
-#ifndef WIN32
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-#include "driver.h"
 #include "gen.h"
+#include "driver.h"
 #include "core.h"
 #include "dmddevice.h"
 
-static UINT16  seg_data2[CORE_SEGCOUNT] = {};
-
-#else
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef _WIN32_WINNT
-#if _MSC_VER >= 1800
- // Windows XP _WIN32_WINNT_WINXP
- #define _WIN32_WINNT 0x0501
-#elif _MSC_VER < 1600
- #define _WIN32_WINNT 0x0400
-#else
- #define _WIN32_WINNT 0x0403
-#endif
-#define WINVER _WIN32_WINNT
-#endif
-#include <windows.h>
-#include "driver.h"
-#include "gen.h"
-#include "core.h"
-#include "cpu/at91/at91.h"
-#include "dmddevice.h"
-
-#ifndef LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
- #define LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR    0x00000100
-#endif
-
-#ifndef LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
- #define LOAD_LIBRARY_SEARCH_DEFAULT_DIRS    0x00001000
+#ifdef __cplusplus
+}
 #endif
 
 static UINT16  seg_data2[CORE_SEGCOUNT] = {};
-static UINT16  dmd_width = 128;
-static UINT16  dmd_height = 32;
-static bool    dmd_hasDMD = false;
 
-static HMODULE DmdDev_hModule;
-static HMODULE DmdScr_hModule;
-
-typedef int(*DmdDev_Open_t)();
-typedef bool(*DmdDev_Close_t)();
-typedef void(*DmdDev_PM_GameSettings_t)(const char* GameName, UINT64 HardwareGeneration, const tPMoptions &Options);
-typedef void(*DmdDev_Set_4_Colors_Palette_t)(rgb24 color0, rgb24 color33, rgb24 color66, rgb24 color100);
-typedef void(*DmdDev_Console_Data_t)(UINT8 data);
-typedef int(*DmdDev_Console_Input_t)(UINT8 *buf, int size);
-typedef int(*DmdDev_Console_Input_Ptr_t)(DmdDev_Console_Input_t ptr);
-typedef void(*DmdDev_Render_16_Shades_t)(UINT16 width, UINT16 height, UINT8 *frame);
-typedef void(*DmdDev_Render_4_Shades_t)(UINT16 width, UINT16 height, UINT8 *frame);
-typedef void(*DmdDev_Render_16_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8 *frame, UINT32 noOfRawFrames, UINT8 *rawbuffer);
-typedef void(*DmdDev_Render_4_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8 *frame, UINT32 noOfRawFrames, UINT8 *rawbuffer);
-typedef void(*DmdDev_render_PM_Alphanumeric_Frame_t)(layout_t layout, const UINT16 *const seg_data, const UINT16 *const seg_data2);
-typedef void(*DmdDev_render_PM_Alphanumeric_Dim_Frame_t)(layout_t layout, const UINT16 *const seg_data, const char *const seg_dim, const UINT16 *const seg_data2);
-
-static DmdDev_Open_t DmdDev_Open;
-static DmdDev_Close_t DmdDev_Close;
-static DmdDev_PM_GameSettings_t DmdDev_PM_GameSettings;
-static DmdDev_Set_4_Colors_Palette_t DmdDev_Set_4_Colors_Palette;
-static DmdDev_Console_Data_t DmdDev_Console_Data;
-static DmdDev_Console_Input_Ptr_t DmdDev_Console_Input_Ptr;
-static DmdDev_Render_16_Shades_t DmdDev_Render_16_Shades;
-static DmdDev_Render_4_Shades_t DmdDev_Render_4_Shades;
-static DmdDev_Render_16_Shades_with_Raw_t DmdDev_Render_16_Shades_with_Raw;
-static DmdDev_Render_4_Shades_with_Raw_t DmdDev_Render_4_Shades_with_Raw;
-static DmdDev_render_PM_Alphanumeric_Frame_t DmdDev_render_PM_Alphanumeric_Frame;
-static DmdDev_render_PM_Alphanumeric_Dim_Frame_t DmdDev_render_PM_Alphanumeric_Dim_Frame;
-
-static DmdDev_Open_t DmdScr_Open;
-static DmdDev_Close_t DmdScr_Close;
-static DmdDev_PM_GameSettings_t DmdScr_PM_GameSettings;
-static DmdDev_Set_4_Colors_Palette_t DmdScr_Set_4_Colors_Palette;
-static DmdDev_Console_Data_t DmdScr_Console_Data;
-static DmdDev_Console_Input_Ptr_t DmdScr_Console_Input_Ptr;
-static DmdDev_Render_16_Shades_t DmdScr_Render_16_Shades;
-static DmdDev_Render_4_Shades_t DmdScr_Render_4_Shades;
-static DmdDev_Render_16_Shades_with_Raw_t DmdScr_Render_16_Shades_with_Raw;
-static DmdDev_Render_4_Shades_with_Raw_t DmdScr_Render_4_Shades_with_Raw;
-static DmdDev_render_PM_Alphanumeric_Frame_t DmdScr_render_PM_Alphanumeric_Frame;
-static DmdDev_render_PM_Alphanumeric_Dim_Frame_t DmdScr_render_PM_Alphanumeric_Dim_Frame;
-
-void FwdConsoleData(UINT8 data) {
-	if (DmdDev_Console_Data)
-		DmdDev_Console_Data(data);
-
-	if (DmdScr_Console_Data)
-		DmdScr_Console_Data(data);
-}
-
-extern "C" {
-	int at91_receive_serial(int usartno, data8_t *buf, int size);
-}
-
-int RcvConsoleInput(UINT8 *buf, int size)
-{
-	const int ret = at91_receive_serial(1, buf, size);
-	return ret;
-}
-
-static HMODULE GetCurrentModule()
-{
-	HMODULE hModule = NULL;
-	GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,	(LPCTSTR)GetCurrentModule, &hModule);
-	return hModule;
-}
-
-int pindmdInit(const char* GameName, UINT64 HardwareGeneration, const tPMoptions *Options) {
-
-	// look for the DmdDevice(64).dll and DmdScreen(64).dll in the path of vpinmame.dll/libpinmame-X.X.dll
-	char DmdDev_filename[MAX_PATH];
-	char DmdScr_filename[MAX_PATH];
-	bool DmdScr = false;
-	bool DmdDev = false;
-
-	GetModuleFileName(GetCurrentModule(),DmdDev_filename,MAX_PATH);
-	strcpy(DmdScr_filename,DmdDev_filename);
-	char *ptr  = strrchr(DmdDev_filename,'\\');
-	char *ptr2 = strrchr(DmdScr_filename,'\\');
-
-#ifdef _WIN64
-	strcpy(ptr+1,"DmdDevice64.dll");
-#else
-	strcpy(ptr+1,"DmdDevice.dll");
-#endif
-
-#ifdef _WIN64
-	strcpy(ptr2+1,"DmdScreen64.dll");
-#else
-	strcpy(ptr2+1,"DmdScreen.dll");
-#endif
-
-	DmdDev_hModule = LoadLibraryEx(DmdDev_filename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-
-	if ( !DmdDev_hModule ) {
-#ifdef _WIN64
-		DmdDev_hModule = LoadLibrary("DmdDevice64.dll");
-#else
-		DmdDev_hModule = LoadLibrary("DmdDevice.dll");
-#endif
-	}
-
-	DmdScr_hModule = LoadLibraryEx(DmdScr_filename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-
-	if (!DmdScr_hModule) {
-#ifdef _WIN64
-		DmdScr_hModule = LoadLibrary("DmdScreen64.dll");
-#else
-		DmdScr_hModule = LoadLibrary("DmdScreen.dll");
-#endif
-	}
-
-	if (DmdDev_hModule) {
-		DmdDev_Open = (DmdDev_Open_t)GetProcAddress(DmdDev_hModule, "Open");
-		DmdDev_PM_GameSettings = (DmdDev_PM_GameSettings_t)GetProcAddress(DmdDev_hModule, "PM_GameSettings");
-		DmdDev_Close = (DmdDev_Close_t)GetProcAddress(DmdDev_hModule, "Close");
-		DmdDev_Render_4_Shades = (DmdDev_Render_4_Shades_t)GetProcAddress(DmdDev_hModule, "Render_4_Shades");
-		DmdDev_Render_16_Shades = (DmdDev_Render_16_Shades_t)GetProcAddress(DmdDev_hModule, "Render_16_Shades");
-		DmdDev_Render_4_Shades_with_Raw = (DmdDev_Render_4_Shades_with_Raw_t)GetProcAddress(DmdDev_hModule, "Render_4_Shades_with_Raw");
-		DmdDev_Render_16_Shades_with_Raw = (DmdDev_Render_16_Shades_with_Raw_t)GetProcAddress(DmdDev_hModule, "Render_16_Shades_with_Raw");
-		DmdDev_render_PM_Alphanumeric_Frame = (DmdDev_render_PM_Alphanumeric_Frame_t)GetProcAddress(DmdDev_hModule, "Render_PM_Alphanumeric_Frame");
-		DmdDev_render_PM_Alphanumeric_Dim_Frame = (DmdDev_render_PM_Alphanumeric_Dim_Frame_t)GetProcAddress(DmdDev_hModule, "Render_PM_Alphanumeric_Dim_Frame");
-		DmdDev_Set_4_Colors_Palette = (DmdDev_Set_4_Colors_Palette_t)GetProcAddress(DmdDev_hModule, "Set_4_Colors_Palette");
-		DmdDev_Console_Data = (DmdDev_Console_Data_t)GetProcAddress(DmdDev_hModule, "Console_Data");
-		DmdDev_Console_Input_Ptr = (DmdDev_Console_Input_Ptr_t)GetProcAddress(DmdDev_hModule, "Console_Input_Ptr");
-
-		if (!DmdDev_Open || !DmdDev_Close || !DmdDev_PM_GameSettings || !DmdDev_Render_4_Shades || !DmdDev_Render_16_Shades || !DmdDev_render_PM_Alphanumeric_Frame) {
-			DmdDev = false;
-		}
-		else {
-			DmdDev = true;
-		}
-	}
-
-	if (DmdScr_hModule) {
-		DmdScr_Open = (DmdDev_Open_t)GetProcAddress(DmdScr_hModule, "Open");
-		DmdScr_PM_GameSettings = (DmdDev_PM_GameSettings_t)GetProcAddress(DmdScr_hModule, "PM_GameSettings");
-		DmdScr_Close = (DmdDev_Close_t)GetProcAddress(DmdScr_hModule, "Close");
-		DmdScr_Render_4_Shades = (DmdDev_Render_4_Shades_t)GetProcAddress(DmdScr_hModule, "Render_4_Shades");
-		DmdScr_Render_16_Shades = (DmdDev_Render_16_Shades_t)GetProcAddress(DmdScr_hModule, "Render_16_Shades");
-		DmdScr_Render_4_Shades_with_Raw = (DmdDev_Render_4_Shades_with_Raw_t)GetProcAddress(DmdScr_hModule, "Render_4_Shades_with_Raw");
-		DmdScr_Render_16_Shades_with_Raw = (DmdDev_Render_16_Shades_with_Raw_t)GetProcAddress(DmdScr_hModule, "Render_16_Shades_with_Raw");
-		DmdScr_render_PM_Alphanumeric_Frame = (DmdDev_render_PM_Alphanumeric_Frame_t)GetProcAddress(DmdScr_hModule, "Render_PM_Alphanumeric_Frame");
-		DmdScr_render_PM_Alphanumeric_Dim_Frame = (DmdDev_render_PM_Alphanumeric_Dim_Frame_t)GetProcAddress(DmdScr_hModule, "Render_PM_Alphanumeric_Dim_Frame");
-		DmdScr_Set_4_Colors_Palette = (DmdDev_Set_4_Colors_Palette_t)GetProcAddress(DmdScr_hModule, "Set_4_Colors_Palette");
-		DmdScr_Console_Data = (DmdDev_Console_Data_t)GetProcAddress(DmdScr_hModule, "Console_Data");
-		DmdScr_Console_Input_Ptr = (DmdDev_Console_Input_Ptr_t)GetProcAddress(DmdScr_hModule, "Console_Input_Ptr");
-
-		if (!DmdScr_Open || !DmdScr_Close || !DmdScr_PM_GameSettings || !DmdScr_Render_4_Shades || !DmdScr_Render_16_Shades || !DmdScr_render_PM_Alphanumeric_Frame) {
-			DmdScr = false;
-		}
-		else {
-			DmdScr = true;
-		}
-	}
-
-	dmd_width = 128; // set default DMD size
-	dmd_height = 32;
-	dmd_hasDMD = false;
-	memset(seg_data2, 0, sizeof(seg_data2));
-
-	rgb24 color0, color33, color66, color100;
-
-	if (Options->dmd_colorize) {
-		color0.red = Options->dmd_red0;
-		color0.green = Options->dmd_green0;
-		color0.blue = Options->dmd_blue0;
-		color33.red = Options->dmd_red33;
-		color33.green = Options->dmd_green33;
-		color33.blue = Options->dmd_blue33;
-		color66.red = Options->dmd_red66;
-		color66.green = Options->dmd_green66;
-		color66.blue = Options->dmd_blue66;
-		color100.red = Options->dmd_red;
-		color100.green = Options->dmd_green;
-		color100.blue = Options->dmd_blue;
-	}
-
-	if (DmdDev) {
-		DmdDev_Open();
-
-		if (DmdDev_Console_Input_Ptr)
-			DmdDev_Console_Input_Ptr(RcvConsoleInput);
-
-		if (DmdDev_Set_4_Colors_Palette && Options->dmd_colorize) {
-			DmdDev_Set_4_Colors_Palette(color0,color33,color66,color100);
-		}
-		DmdDev_PM_GameSettings(GameName, HardwareGeneration, *Options);
-	}
-
-	if (DmdScr) {
-		DmdScr_Open();
-
-		if (DmdScr_Console_Input_Ptr)
-			DmdScr_Console_Input_Ptr(RcvConsoleInput);
-
-		if (DmdScr_Set_4_Colors_Palette && Options->dmd_colorize) {
-			DmdScr_Set_4_Colors_Palette(color0, color33, color66, color100);
-		}
-		DmdScr_PM_GameSettings(GameName, HardwareGeneration, *Options);
-	}
-
-	if (!DmdScr && !DmdDev){
-		MessageBox(NULL, "No external DMD driver found or DMD driver functions not found", "Visual PinMame Error", MB_ICONERROR);
-		return 0;
-	}
-	else
-		return 1;
-
-}
-
-void pindmdDeInit() {
-
-	UINT8 *tmpbuffer = (UINT8 *)malloc(dmd_width*dmd_height);
-	memset(tmpbuffer, 0x00, dmd_width*dmd_height);
-
-	if (DmdDev_Render_4_Shades) 
-		DmdDev_Render_4_Shades(dmd_width, dmd_height, tmpbuffer); //clear screen
-
-	if (DmdDev_Close) {
-		DmdDev_Close();
-		FreeLibrary(DmdDev_hModule);
-	}
-
-	if (DmdScr_Render_4_Shades)
-		DmdScr_Render_4_Shades(dmd_width, dmd_height, tmpbuffer); //clear screen
-
-	if (DmdScr_Close){
-		DmdScr_Close();
-		FreeLibrary(DmdScr_hModule);
-	}
-
-	free(tmpbuffer);
-}
-
-void renderDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer) {
-	dmd_width = width; // store for DeInit
-	dmd_height = height;
-	dmd_hasDMD = true;
-	// 16 shades based on hardware generation and extended to some GTS3 games using long PWM pattern (SMB, SMBMW and CBW)
-	if ((gen & (GEN_SAM | GEN_SPA | GEN_ALVG_DMD2)) || (strncasecmp(GameName, "smb", 3) == 0) || (strncasecmp(GameName, "cueball", 7) == 0)) {
-		if ((noOfRawFrames != 0) && DmdDev_Render_16_Shades_with_Raw)
-			DmdDev_Render_16_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
-		else if (DmdDev_Render_16_Shades)
-			DmdDev_Render_16_Shades(width, height, frame);
-	}
-	else {
-		if ((noOfRawFrames != 0) && DmdDev_Render_4_Shades_with_Raw)
-			DmdDev_Render_4_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
-		else if (DmdDev_Render_4_Shades)
-			DmdDev_Render_4_Shades(width, height, frame);
-	}
-}
-
-void render2ndDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8* frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8* rawbuffer) {
-	dmd_width = width; // store for DeInit
-	dmd_height = height;
-	dmd_hasDMD = true;
-	// 16 shades based on hardware generation and extended to some GTS3 games using long PWM pattern (SMB, SMBMW and CBW)
-	if ((gen & (GEN_SAM | GEN_SPA | GEN_ALVG_DMD2)) || (strncasecmp(GameName, "smb", 3) == 0) || (strncasecmp(GameName, "cueball", 7) == 0)) {
-		if ((noOfRawFrames != 0) && DmdScr_Render_16_Shades_with_Raw)
-			DmdScr_Render_16_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
-		else if (DmdScr_Render_16_Shades)
-			DmdScr_Render_16_Shades(width, height, frame);
-	}
-	else {
-		if ((noOfRawFrames != 0) && DmdScr_Render_4_Shades_with_Raw)
-			DmdScr_Render_4_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
-		else if (DmdScr_Render_4_Shades)
-			DmdScr_Render_4_Shades(width, height, frame);
-	}
-}
-
-#endif
-
-// this one can be called without having to do an init/de-init, so its pure
 layout_t layoutAlphanumericFrame(UINT64 gen, UINT16* seg_data, UINT16* seg_data_2, UINT8 total_disp, UINT8 *disp_num_segs, const char* GameName) {
 
 	// Medusa fix
@@ -477,7 +171,329 @@ layout_t layoutAlphanumericFrame(UINT64 gen, UINT16* seg_data, UINT16* seg_data_
 	return layout;
 }
 
-#ifdef WIN32
+
+
+
+
+#ifdef VPINMAME
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef _WIN32_WINNT
+#if _MSC_VER >= 1800
+ // Windows XP _WIN32_WINNT_WINXP
+ #define _WIN32_WINNT 0x0501
+#elif _MSC_VER < 1600
+ #define _WIN32_WINNT 0x0400
+#else
+ #define _WIN32_WINNT 0x0403
+#endif
+#define WINVER _WIN32_WINNT
+#endif
+#include <windows.h>
+
+#ifndef LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+ #define LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR    0x00000100
+#endif
+
+#ifndef LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
+ #define LOAD_LIBRARY_SEARCH_DEFAULT_DIRS    0x00001000
+#endif
+
+static UINT16  dmd_width = 0; // Only valid if dmd_hasDMD is set
+static UINT16  dmd_height = 0; // Only valid if dmd_hasDMD is set
+static bool    dmd_hasDMD = false;
+
+static HMODULE DmdDev_hModule;
+static HMODULE DmdScr_hModule;
+
+typedef int(*DmdDev_Open_t)();
+typedef bool(*DmdDev_Close_t)();
+typedef void(*DmdDev_PM_GameSettings_t)(const char* GameName, UINT64 HardwareGeneration, const tPMoptions &Options);
+typedef void(*DmdDev_Set_4_Colors_Palette_t)(rgb24 color0, rgb24 color33, rgb24 color66, rgb24 color100);
+typedef void(*DmdDev_Console_Data_t)(UINT8 data);
+typedef int(*DmdDev_Console_Input_t)(UINT8 *buf, int size);
+typedef int(*DmdDev_Console_Input_Ptr_t)(DmdDev_Console_Input_t ptr);
+typedef void(*DmdDev_Render_16_Shades_t)(UINT16 width, UINT16 height, UINT8 *frame);
+typedef void(*DmdDev_Render_4_Shades_t)(UINT16 width, UINT16 height, UINT8 *frame);
+typedef void(*DmdDev_Render_16_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8 *frame, UINT32 noOfRawFrames, UINT8 *rawbuffer);
+typedef void(*DmdDev_Render_4_Shades_with_Raw_t)(UINT16 width, UINT16 height, UINT8 *frame, UINT32 noOfRawFrames, UINT8 *rawbuffer);
+typedef void(*DmdDev_Render_PM_Alphanumeric_Frame_t)(layout_t layout, const UINT16 *const seg_data, const UINT16 *const seg_data2);
+typedef void(*DmdDev_Render_PM_Alphanumeric_Dim_Frame_t)(layout_t layout, const UINT16 *const seg_data, const char *const seg_dim, const UINT16 *const seg_data2);
+typedef void(*DmdDev_Render_Lum_And_Raw_t)(UINT16 width, UINT16 height, UINT8* lumFrame, UINT8* rawFrame, UINT32 noOfRawFrames, UINT8* rawbuffer);
+
+
+static DmdDev_Open_t DmdDev_Open;
+static DmdDev_Close_t DmdDev_Close;
+static DmdDev_PM_GameSettings_t DmdDev_PM_GameSettings;
+static DmdDev_Set_4_Colors_Palette_t DmdDev_Set_4_Colors_Palette;
+static DmdDev_Console_Data_t DmdDev_Console_Data;
+static DmdDev_Console_Input_Ptr_t DmdDev_Console_Input_Ptr;
+static DmdDev_Render_16_Shades_t DmdDev_Render_16_Shades;
+static DmdDev_Render_4_Shades_t DmdDev_Render_4_Shades;
+static DmdDev_Render_16_Shades_with_Raw_t DmdDev_Render_16_Shades_with_Raw;
+static DmdDev_Render_4_Shades_with_Raw_t DmdDev_Render_4_Shades_with_Raw;
+static DmdDev_Render_PM_Alphanumeric_Frame_t DmdDev_Render_PM_Alphanumeric_Frame;
+static DmdDev_Render_PM_Alphanumeric_Dim_Frame_t DmdDev_Render_PM_Alphanumeric_Dim_Frame;
+static DmdDev_Render_Lum_And_Raw_t DmdDev_Render_Lum_And_Raw;
+
+static DmdDev_Open_t DmdScr_Open;
+static DmdDev_Close_t DmdScr_Close;
+static DmdDev_PM_GameSettings_t DmdScr_PM_GameSettings;
+static DmdDev_Set_4_Colors_Palette_t DmdScr_Set_4_Colors_Palette;
+static DmdDev_Console_Data_t DmdScr_Console_Data;
+static DmdDev_Console_Input_Ptr_t DmdScr_Console_Input_Ptr;
+static DmdDev_Render_16_Shades_t DmdScr_Render_16_Shades;
+static DmdDev_Render_4_Shades_t DmdScr_Render_4_Shades;
+static DmdDev_Render_16_Shades_with_Raw_t DmdScr_Render_16_Shades_with_Raw;
+static DmdDev_Render_4_Shades_with_Raw_t DmdScr_Render_4_Shades_with_Raw;
+static DmdDev_Render_PM_Alphanumeric_Frame_t DmdScr_Render_PM_Alphanumeric_Frame;
+static DmdDev_Render_PM_Alphanumeric_Dim_Frame_t DmdScr_Render_PM_Alphanumeric_Dim_Frame;
+static DmdDev_Render_Lum_And_Raw_t DmdScr_Render_Lum_And_Raw;
+
+
+extern "C"
+{
+#include "cpu/at91/at91.h"
+	int at91_receive_serial(int usartno, data8_t* buf, int size);
+}
+
+void FwdConsoleData(UINT8 data) {
+	if (DmdDev_Console_Data)
+		DmdDev_Console_Data(data);
+
+	if (DmdScr_Console_Data)
+		DmdScr_Console_Data(data);
+}
+
+int RcvConsoleInput(UINT8 *buf, int size)
+{
+	const int ret = at91_receive_serial(1, buf, size);
+	return ret;
+}
+
+static HMODULE GetCurrentModule()
+{
+	HMODULE hModule = NULL;
+	GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,	(LPCTSTR)GetCurrentModule, &hModule);
+	return hModule;
+}
+
+int pindmdInit(const char* GameName, UINT64 HardwareGeneration, const tPMoptions *Options) {
+
+	// look for the DmdDevice(64).dll and DmdScreen(64).dll in the path of vpinmame.dll/libpinmame-X.X.dll
+	char DmdDev_filename[MAX_PATH];
+	char DmdScr_filename[MAX_PATH];
+	bool DmdScr = false;
+	bool DmdDev = false;
+
+	GetModuleFileName(GetCurrentModule(),DmdDev_filename,MAX_PATH);
+	strcpy(DmdScr_filename,DmdDev_filename);
+	char *ptr  = strrchr(DmdDev_filename,'\\');
+	char *ptr2 = strrchr(DmdScr_filename,'\\');
+
+#ifdef _WIN64
+	strcpy(ptr+1,"DmdDevice64.dll");
+#else
+	strcpy(ptr+1,"DmdDevice.dll");
+#endif
+
+#ifdef _WIN64
+	strcpy(ptr2+1,"DmdScreen64.dll");
+#else
+	strcpy(ptr2+1,"DmdScreen.dll");
+#endif
+
+	DmdDev_hModule = LoadLibraryEx(DmdDev_filename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+
+	if ( !DmdDev_hModule ) {
+#ifdef _WIN64
+		DmdDev_hModule = LoadLibrary("DmdDevice64.dll");
+#else
+		DmdDev_hModule = LoadLibrary("DmdDevice.dll");
+#endif
+	}
+
+	DmdScr_hModule = LoadLibraryEx(DmdScr_filename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+
+	if (!DmdScr_hModule) {
+#ifdef _WIN64
+		DmdScr_hModule = LoadLibrary("DmdScreen64.dll");
+#else
+		DmdScr_hModule = LoadLibrary("DmdScreen.dll");
+#endif
+	}
+
+	if (DmdDev_hModule) {
+		DmdDev_Open = (DmdDev_Open_t)GetProcAddress(DmdDev_hModule, "Open");
+		DmdDev_PM_GameSettings = (DmdDev_PM_GameSettings_t)GetProcAddress(DmdDev_hModule, "PM_GameSettings");
+		DmdDev_Close = (DmdDev_Close_t)GetProcAddress(DmdDev_hModule, "Close");
+		DmdDev_Render_4_Shades = (DmdDev_Render_4_Shades_t)GetProcAddress(DmdDev_hModule, "Render_4_Shades");
+		DmdDev_Render_16_Shades = (DmdDev_Render_16_Shades_t)GetProcAddress(DmdDev_hModule, "Render_16_Shades");
+		DmdDev_Render_4_Shades_with_Raw = (DmdDev_Render_4_Shades_with_Raw_t)GetProcAddress(DmdDev_hModule, "Render_4_Shades_with_Raw");
+		DmdDev_Render_16_Shades_with_Raw = (DmdDev_Render_16_Shades_with_Raw_t)GetProcAddress(DmdDev_hModule, "Render_16_Shades_with_Raw");
+		DmdDev_Render_Lum_And_Raw = (DmdDev_Render_Lum_And_Raw_t)GetProcAddress(DmdDev_hModule, "Render_Lum_And_Raw");
+		DmdDev_Render_PM_Alphanumeric_Frame = (DmdDev_Render_PM_Alphanumeric_Frame_t)GetProcAddress(DmdDev_hModule, "Render_PM_Alphanumeric_Frame");
+		DmdDev_Render_PM_Alphanumeric_Dim_Frame = (DmdDev_Render_PM_Alphanumeric_Dim_Frame_t)GetProcAddress(DmdDev_hModule, "Render_PM_Alphanumeric_Dim_Frame");
+		DmdDev_Set_4_Colors_Palette = (DmdDev_Set_4_Colors_Palette_t)GetProcAddress(DmdDev_hModule, "Set_4_Colors_Palette");
+		DmdDev_Console_Data = (DmdDev_Console_Data_t)GetProcAddress(DmdDev_hModule, "Console_Data");
+		DmdDev_Console_Input_Ptr = (DmdDev_Console_Input_Ptr_t)GetProcAddress(DmdDev_hModule, "Console_Input_Ptr");
+
+		if (!DmdDev_Open || !DmdDev_Close || !DmdDev_PM_GameSettings || !DmdDev_Render_4_Shades || !DmdDev_Render_16_Shades || !DmdDev_Render_PM_Alphanumeric_Frame) {
+			DmdDev = false;
+		}
+		else {
+			DmdDev = true;
+		}
+	}
+
+	if (DmdScr_hModule) {
+		DmdScr_Open = (DmdDev_Open_t)GetProcAddress(DmdScr_hModule, "Open");
+		DmdScr_PM_GameSettings = (DmdDev_PM_GameSettings_t)GetProcAddress(DmdScr_hModule, "PM_GameSettings");
+		DmdScr_Close = (DmdDev_Close_t)GetProcAddress(DmdScr_hModule, "Close");
+		DmdScr_Render_4_Shades = (DmdDev_Render_4_Shades_t)GetProcAddress(DmdScr_hModule, "Render_4_Shades");
+		DmdScr_Render_16_Shades = (DmdDev_Render_16_Shades_t)GetProcAddress(DmdScr_hModule, "Render_16_Shades");
+		DmdScr_Render_4_Shades_with_Raw = (DmdDev_Render_4_Shades_with_Raw_t)GetProcAddress(DmdScr_hModule, "Render_4_Shades_with_Raw");
+		DmdScr_Render_16_Shades_with_Raw = (DmdDev_Render_16_Shades_with_Raw_t)GetProcAddress(DmdScr_hModule, "Render_16_Shades_with_Raw");
+		DmdScr_Render_Lum_And_Raw = (DmdDev_Render_Lum_And_Raw_t)GetProcAddress(DmdScr_hModule, "Render_Lum_And_Raw");
+		DmdScr_Render_PM_Alphanumeric_Frame = (DmdDev_Render_PM_Alphanumeric_Frame_t)GetProcAddress(DmdScr_hModule, "Render_PM_Alphanumeric_Frame");
+		DmdScr_Render_PM_Alphanumeric_Dim_Frame = (DmdDev_Render_PM_Alphanumeric_Dim_Frame_t)GetProcAddress(DmdScr_hModule, "Render_PM_Alphanumeric_Dim_Frame");
+		DmdScr_Set_4_Colors_Palette = (DmdDev_Set_4_Colors_Palette_t)GetProcAddress(DmdScr_hModule, "Set_4_Colors_Palette");
+		DmdScr_Console_Data = (DmdDev_Console_Data_t)GetProcAddress(DmdScr_hModule, "Console_Data");
+		DmdScr_Console_Input_Ptr = (DmdDev_Console_Input_Ptr_t)GetProcAddress(DmdScr_hModule, "Console_Input_Ptr");
+
+		if (!DmdScr_Open || !DmdScr_Close || !DmdScr_PM_GameSettings || !DmdScr_Render_4_Shades || !DmdScr_Render_16_Shades || !DmdScr_Render_PM_Alphanumeric_Frame) {
+			DmdScr = false;
+		}
+		else {
+			DmdScr = true;
+		}
+	}
+
+	dmd_hasDMD = false;
+	memset(seg_data2, 0, sizeof(seg_data2));
+
+	rgb24 color0, color33, color66, color100;
+
+	if (Options->dmd_colorize) {
+		color0.red = Options->dmd_red0;
+		color0.green = Options->dmd_green0;
+		color0.blue = Options->dmd_blue0;
+		color33.red = Options->dmd_red33;
+		color33.green = Options->dmd_green33;
+		color33.blue = Options->dmd_blue33;
+		color66.red = Options->dmd_red66;
+		color66.green = Options->dmd_green66;
+		color66.blue = Options->dmd_blue66;
+		color100.red = Options->dmd_red;
+		color100.green = Options->dmd_green;
+		color100.blue = Options->dmd_blue;
+	}
+
+	if (DmdDev) {
+		DmdDev_Open();
+
+		if (DmdDev_Console_Input_Ptr)
+			DmdDev_Console_Input_Ptr(RcvConsoleInput);
+
+		if (DmdDev_Set_4_Colors_Palette && Options->dmd_colorize) {
+			DmdDev_Set_4_Colors_Palette(color0,color33,color66,color100);
+		}
+		DmdDev_PM_GameSettings(GameName, HardwareGeneration, *Options);
+	}
+
+	if (DmdScr) {
+		DmdScr_Open();
+
+		if (DmdScr_Console_Input_Ptr)
+			DmdScr_Console_Input_Ptr(RcvConsoleInput);
+
+		if (DmdScr_Set_4_Colors_Palette && Options->dmd_colorize) {
+			DmdScr_Set_4_Colors_Palette(color0, color33, color66, color100);
+		}
+		DmdScr_PM_GameSettings(GameName, HardwareGeneration, *Options);
+	}
+
+	if (!DmdScr && !DmdDev){
+		MessageBox(NULL, "No external DMD driver found or DMD driver functions not found", "Visual PinMame Error", MB_ICONERROR);
+		return 0;
+	}
+	else
+		return 1;
+
+}
+
+void pindmdDeInit() {
+	if (dmd_hasDMD) {
+		UINT8* tmpbuffer = (UINT8*)malloc(dmd_width * dmd_height);
+		memset(tmpbuffer, 0x00, dmd_width * dmd_height);
+		if (DmdDev_Render_4_Shades)
+			DmdDev_Render_4_Shades(dmd_width, dmd_height, tmpbuffer); //clear screen
+		if (DmdScr_Render_4_Shades)
+			DmdScr_Render_4_Shades(dmd_width, dmd_height, tmpbuffer); //clear screen
+		free(tmpbuffer);
+	}
+
+	if (DmdDev_Close) {
+		DmdDev_Close();
+		FreeLibrary(DmdDev_hModule);
+	}
+	if (DmdScr_Close){
+		DmdScr_Close();
+		FreeLibrary(DmdScr_hModule);
+	}
+}
+
+void renderDMDFrame(const int width, const int height, UINT8* dmdDotLum, UINT8* dmdDotRaw, UINT32 noOfRawFrames, UINT8 *rawbuffer, const int isDMD2) {
+	dmd_width = width; // store for DeInit
+	dmd_height = height;
+	dmd_hasDMD = true;
+
+	// New implementation that sends both luminance information for rendering, and combined bitplanes as well as raw frames for frame identification for colorization & triggering events
+	if (((isDMD2 & 1) != 0) && DmdDev_Render_Lum_And_Raw)
+		DmdDev_Render_Lum_And_Raw(width, height, dmdDotLum, dmdDotRaw, noOfRawFrames, rawbuffer);
+	if (((isDMD2 & 2) != 0) && DmdScr_Render_Lum_And_Raw)
+		DmdScr_Render_Lum_And_Raw(width, height, dmdDotLum, dmdDotRaw, noOfRawFrames, rawbuffer);
+
+	// Legacy implementation uses a single stream for both frame identification and rendering.
+	// To ensure some backward compatibility with existing coloriation/rendering implementation:
+	// - for GTS3: send luminance information adapted to legacy 2/4 bit format (breaks frame identification, but would break frame rendering otherwise)
+	// - for others: send identification frames
+	// This is somewhat hacky but needed until all external dmddevice.dll are updated to the new implementation
+	UINT8* frame = dmdDotRaw;
+	// 16 shades based on hardware generation and extended to some GTS3 games using long PWM pattern (SMB, SMBMW and CBW)
+	const int is16Shades = (core_gameData->gen & (GEN_SAM | GEN_SPA | GEN_ALVG_DMD2)) || (strncasecmp(Machine->gamedrv->name, "smb", 3) == 0) || (strncasecmp(Machine->gamedrv->name, "cueball", 7) == 0);
+	if (core_gameData->gen & GEN_GTS3) {
+		const int shift = is16Shades ? 4 : 6;
+		frame = (UINT8*)malloc(width * height);
+		for (int i = 0; i < width * height; i++)
+			frame[i] = dmdDotLum[i] >> shift;
+	}
+	if (is16Shades) {
+		if (((isDMD2 & 1) != 0) && (noOfRawFrames != 0) && DmdDev_Render_16_Shades_with_Raw)
+			DmdDev_Render_16_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
+		else if (((isDMD2 & 1) != 0) && DmdDev_Render_16_Shades)
+			DmdDev_Render_16_Shades(width, height, frame);
+		if (((isDMD2 & 2) != 0) && (noOfRawFrames != 0) && DmdScr_Render_16_Shades_with_Raw)
+			DmdScr_Render_16_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
+		else if (((isDMD2 & 2) != 0) && DmdScr_Render_16_Shades)
+			DmdScr_Render_16_Shades(width, height, frame);
+	}
+	else {
+		if (((isDMD2 & 1) != 0) && (noOfRawFrames != 0) && DmdDev_Render_4_Shades_with_Raw)
+			DmdDev_Render_4_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
+		else if (((isDMD2 & 1) != 0) && DmdDev_Render_4_Shades)
+			DmdDev_Render_4_Shades(width, height, frame);
+		if (((isDMD2 & 2) != 0) && (noOfRawFrames != 0) && DmdScr_Render_4_Shades_with_Raw)
+			DmdScr_Render_4_Shades_with_Raw(width, height, frame, noOfRawFrames, rawbuffer);
+		else if (((isDMD2 & 2) != 0) && DmdScr_Render_4_Shades)
+			DmdScr_Render_4_Shades(width, height, frame);
+	}
+	if (core_gameData->gen & GEN_GTS3) {
+		free(frame);
+	}
+}
 
 void renderAlphanumericFrame(UINT64 gen, UINT16 *seg_data, char *seg_dim, UINT8 total_disp, UINT8 *disp_num_segs, const char* GameName) {
 
@@ -491,15 +507,15 @@ void renderAlphanumericFrame(UINT64 gen, UINT16 *seg_data, char *seg_dim, UINT8 
 	if (layout == __Invalid)
 		return;
 
-	if (DmdDev_render_PM_Alphanumeric_Dim_Frame)
-		DmdDev_render_PM_Alphanumeric_Dim_Frame(layout, seg_data, seg_dim, seg_data2);
-	else if (DmdDev_render_PM_Alphanumeric_Frame) // older interface without dimming
-		DmdDev_render_PM_Alphanumeric_Frame(layout, seg_data, seg_data2);
+	if (DmdDev_Render_PM_Alphanumeric_Dim_Frame)
+		DmdDev_Render_PM_Alphanumeric_Dim_Frame(layout, seg_data, seg_dim, seg_data2);
+	else if (DmdDev_Render_PM_Alphanumeric_Frame) // older interface without dimming
+		DmdDev_Render_PM_Alphanumeric_Frame(layout, seg_data, seg_data2);
 
-	if (DmdScr_render_PM_Alphanumeric_Dim_Frame)
-		DmdScr_render_PM_Alphanumeric_Dim_Frame(layout, seg_data, seg_dim, seg_data2);
-	else if (DmdScr_render_PM_Alphanumeric_Frame) // older interface without dimming
-		DmdScr_render_PM_Alphanumeric_Frame(layout, seg_data, seg_data2);
+	if (DmdScr_Render_PM_Alphanumeric_Dim_Frame)
+		DmdScr_Render_PM_Alphanumeric_Dim_Frame(layout, seg_data, seg_dim, seg_data2);
+	else if (DmdScr_Render_PM_Alphanumeric_Frame) // older interface without dimming
+		DmdScr_Render_PM_Alphanumeric_Frame(layout, seg_data, seg_data2);
 }
 
 #endif

--- a/src/wpc/dmddevice.h
+++ b/src/wpc/dmddevice.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Utility function to help rendering an alphanumeric display on a standard 128x32 DMD display
+
 typedef struct rgb24 {
 	UINT8 red;
 	UINT8 green;
@@ -27,19 +29,24 @@ typedef enum {
 	__Invalid
 } layout_t;
 
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-int pindmdInit(const char* GameName, UINT64 HardwareGeneration, const tPMoptions *Options);
-void pindmdDeInit(void);
-void renderDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
-void render2ndDMDFrame(UINT64 gen, UINT16 width, UINT16 height, UINT8 *frame, UINT8 doDumpFrame, const char* GameName, UINT32 noOfRawFrames, UINT8 *rawbuffer);
+
 layout_t layoutAlphanumericFrame(UINT64 gen, UINT16* seg_data, UINT16* seg_data_2, UINT8 total_disp, UINT8* disp_num_segs, const char* GameName);
-void renderAlphanumericFrame(UINT64 gen, UINT16 *seg_data, char *seg_dim, UINT8 total_disp, UINT8 *disp_num_segs, const char* GameName);
+
+// VPinMame function to send DMD/Alphanumeric information to an external dmddevice/dmdscreen.dll plugin
+// Note that this part of the header is not used externally of VPinMame (move it to something like core_dmdevice.h/core_dmddevice.c ?)
+#ifdef VPINMAME
+int pindmdInit(const char* GameName, UINT64 HardwareGeneration, const tPMoptions* Options);
+void renderDMDFrame(const int width, const int height, UINT8* dmdDotLum, UINT8* dmdDotRaw, UINT32 noOfRawFrames, UINT8* rawbuffer, const int isDMD2);
+void renderAlphanumericFrame(UINT64 gen, UINT16* seg_data, char* seg_dim, UINT8 total_disp, UINT8* disp_num_segs, const char* GameName);
 void FwdConsoleData(UINT8 data);
+void pindmdDeInit(void);
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/src/wpc/sam.c
+++ b/src/wpc/sam.c
@@ -37,10 +37,11 @@
 #include "video.h"
 #include "cpu/at91/at91.h"
 #include "sndbrd.h"
-#include "dmddevice.h"
 #include "mech.h"
 
-#ifdef LIBPINMAME
+#if defined(VPINMAME)
+#include "dmddevice.h"
+#elif defined(LIBPINMAME)
 extern void libpinmame_forward_console_data(void* data, int size);
 #endif
 
@@ -1654,12 +1655,11 @@ static void sam_transmit_serial(int usartno, data8_t *data, int size)
 	while (size > 0)
 	{
 		if (usartno == 1) {
-#ifdef VPINMAME
 			//console messages
+#if defined(VPINMAME)
 			while(size--)
 				FwdConsoleData((*(data++)));
-#endif
-#ifdef LIBPINMAME
+#elif defined(LIBPINMAME)
 			libpinmame_forward_console_data(data, size);
 #endif
 			return;


### PR DESCRIPTION
I limited the change to what is described in the issue #344 (it fixes #344) but I think, there is some more room for cleanup since after reviewing the codebase, there seems to be some legacy left over for dmddevice.h/dmddevice.cpp

dmddevice.h/.cpp in ext/dmddevice contains the interface for dmd device drivers: some struct definitions and some function definitions

dmddevice.h/.cpp in PinMame source contains:
- a copy of `rgb24` and `layout_t` struct from ext/dmddevice/dmddevice.h (but not the rest of it)
- an helper to get a layout to render alphanumeric on a 4:1 DMD, the implementation to actually render is in usbalphanumeric.h inside ext/dmddevice folder imported inside PinMame as well as used by ext/dmddevice drivers
- a VPinMame only definition/implementation to exchange data through dmddevice.dll, only used inside VPinMame

To be more clean, I would propose to:
- avoid name conflicts, so rename PinMame dmddevice.h/.cpp to something else,
- keep the definition in only one place, so import `ext/dmddevice/dmddevice.h` instead of copy/pasting it
- split the alphanumeric layout/rendering from the other VPinMame only part (add it to core.h/.c),
- move the VPinMame only part to VPinMame folder in its own file,
- compile the PinMame part as C, and the VPinMame part as C++ (as a consequence of steps above).

To be even more clean, the device drivers could be in their own Github repo if they have one (since there are now quite a bunch of hardware drivers: PinDMD1, PinDMD2, PinDMD3, ZeDMD, RGB DMD, Pin2DMD, Freezy's DMD,...).

If you wish, I can do these.