### PR TITLE
GTS3 fix for DMD diag Led and 6845 CRTC addresses.

### DIFF
--- a/src/vidhrdw/crtc6845.c
+++ b/src/vidhrdw/crtc6845.c
@@ -85,49 +85,51 @@ READ_HANDLER( crtc6845_register_r )
 {
 	int retval=0;
 
+	// Most 6845 registers are write-only, except R14/R15 (cursor) and R16/R17 (lightpen).
+
 	switch(crtc6845[offset].address_latch)
 	{
 		case 0:
-			retval=crtc6845[offset].horiz_total;
+			// retval=crtc6845[offset].horiz_total;                  // write-only register
 			break;
 		case 1:
-			retval=crtc6845[offset].horiz_disp;
+			// retval=crtc6845[offset].horiz_disp;                   // write-only register
 			break;
 		case 2:
-			retval=crtc6845[offset].horiz_sync_pos;
+			// retval=crtc6845[offset].horiz_sync_pos;               // write-only register
 			break;
 		case 3:
-			retval=crtc6845[offset].sync_width;
+			// retval=crtc6845[offset].sync_width;                   // write-only register
 			break;
 		case 4:
-			retval=crtc6845[offset].vert_total;
+			// retval=crtc6845[offset].vert_total;                   // write-only register
 			break;
 		case 5:
-			retval=crtc6845[offset].vert_total_adj;
+			// retval=crtc6845[offset].vert_total_adj;               // write-only register
 			break;
 		case 6:
-			retval=crtc6845[offset].vert_disp;
+			// retval=crtc6845[offset].vert_disp;                    // write-only register
 			break;
 		case 7:
-			retval=crtc6845[offset].vert_sync_pos;
+			// retval=crtc6845[offset].vert_sync_pos;                // write-only register
 			break;
 		case 8:
-			retval=crtc6845[offset].intl_skew;
+			// retval=crtc6845[offset].intl_skew;                    // write-only register
 			break;
 		case 9:
-			retval=crtc6845[offset].max_ras_addr;
+			// retval=crtc6845[offset].max_ras_addr;                 // write-only register
 			break;
 		case 10:
-			retval=crtc6845[offset].cursor_start_ras;
+			// retval=crtc6845[offset].cursor_start_ras;             // write-only register
 			break;
 		case 11:
-			retval=crtc6845[offset].cursor_end_ras;
+			// retval=crtc6845[offset].cursor_end_ras;               // write-only register
 			break;
 		case 12:
-			retval=(crtc6845[offset].start_addr >> 8) & 0x003f;
+			// retval=(crtc6845[offset].start_addr >> 8) & 0x003f;   // write-only register
 			break;
 		case 13:
-			retval=crtc6845[offset].start_addr&0xff;
+			// retval=crtc6845[offset].start_addr&0xff;              // write-only register
 			break;
 		case 14:
 			retval=(crtc6845[offset].cursor >> 8) & 0x003f;
@@ -158,6 +160,9 @@ WRITE_HANDLER( crtc6845_address_w )
 WRITE_HANDLER( crtc6845_register_w )
 {
 	LOG(("%8.5f CRT #0 PC %04x: WRITE reg 0x%02x data 0x%02x\n",timer_get_time(),activecpu_get_pc(),crtc6845[offset].address_latch,data));
+
+	// Most 6845 registers can be written, except R16/R17 (lightpen) that are read-only.
+
 	switch(crtc6845[offset].address_latch)
 	{
 		case 0:
@@ -214,10 +219,10 @@ WRITE_HANDLER( crtc6845_register_w )
 			crtc6845[offset].cursor = (crtc6845[offset].cursor & 0xff00) | data;
 			break;
 		case 16:
-			crtc6845[offset].light_pen = ((data & 0x003f) << 8) | (crtc6845[offset].light_pen & 0x00ff);
+			// crtc6845[offset].light_pen = ((data & 0x003f) << 8) | (crtc6845[offset].light_pen & 0x00ff);  // read-only register
 			break;
 		case 17:
-			crtc6845[offset].light_pen = (crtc6845[offset].light_pen & 0xff00) | data;
+			// crtc6845[offset].light_pen = (crtc6845[offset].light_pen & 0xff00) | data;                    // read-only register
 			break;
 		default:
 			break;

--- a/src/wpc/gts3.c
+++ b/src/wpc/gts3.c
@@ -412,10 +412,10 @@ static INTERRUPT_GEN(GTS3_interface_update) {
 									(GTS3_dmdlocals[0].diagnosticLed << 1) |
 									(GTS3_dmdlocals[1].diagnosticLed << 2);
 	} else {
-		coreGlobals.diagnosticLed = (GTS3locals.diagnosticLed2<<3) |
-									(GTS3locals.diagnosticLed1<<2) |
-									(GTS3_dmdlocals[0].diagnosticLed<<1) |
-									GTS3locals.diagnosticLed;
+		coreGlobals.diagnosticLed = GTS3locals.diagnosticLed |
+			                        (GTS3_dmdlocals[0].diagnosticLed << 1) |
+			                        (GTS3locals.diagnosticLed1 << 2) |
+			                        (GTS3locals.diagnosticLed2 << 3);
 	}
   }
 
@@ -888,7 +888,7 @@ static WRITE_HANDLER(dmd_outport)
 	GTS3_dmdlocals[offset].a18=GTS3_dmdlocals[offset].q3;
 	GTS3_dmdlocals[offset].status1=(data>>5)&1;
 	GTS3_dmdlocals[offset].status2=(data>>6)&1;
-	GTS3_dmdlocals[offset].diagnosticLed = data>>7;
+	GTS3_dmdlocals[offset].diagnosticLed = 1 - (data>>7); // DMD LED polarity : negative
 	dmdswitchbank(offset);
 }
 
@@ -1043,40 +1043,40 @@ MEMORY_END
 /  Memory map for DMD CPU
 /----------------------------*/
 static MEMORY_READ_START(GTS3_dmdreadmem)
-{0x0000,0x1fff, MRA_RAM},
-{0x2000,0x2000, crtc6845_register_0_r},
-{0x3000,0x3000, dmdlatch_r}, /*Input Enable*/
-{0x4000,0x7fff, MRA_BANK1},
-{0x8000,0xffff, MRA_ROM},
+{0x0000,0x1fff, MRA_RAM},               /* DMD RAM         */
+{0x2801,0x2801, crtc6845_register_0_r}, /* CRTC index      */
+{0x3000,0x3000, dmdlatch_r},            /* Input Port      */
+{0x4000,0x7fff, MRA_BANK1},             /* Paginated ROM   */
+{0x8000,0xffff, MRA_ROM},               /* ROM             */
 MEMORY_END
 
 static MEMORY_WRITE_START(GTS3_dmdwritemem)
-{0x0000,0x0fff, MWA_RAM},
-{0x1000,0x1fff, MWA_RAM},    /*DMD Display RAM*/
-{0x2800,0x2800, crtc6845_address_0_w},
-{0x2801,0x2801, crtc6845_register_0_w},
-{0x3800,0x3800, dmdoport},   /*Output Enable*/
-{0x4000,0x7fff, MWA_BANK1},
-{0x8000,0xffff, MWA_ROM},
+{0x0000,0x0fff, MWA_RAM},               /* DMD RAM         */
+{0x1000,0x1fff, MWA_RAM},               /* DMD Display RAM */
+{0x2800,0x2800, crtc6845_address_0_w},  /* CRTC index      */
+{0x2801,0x2801, crtc6845_register_0_w}, /* CRTC registers  */
+{0x3800,0x3800, dmdoport},              /* Output Port     */
+{0x4000,0x7fff, MWA_BANK1},             /* Paginated ROM   */
+{0x8000,0xffff, MWA_ROM},               /* ROM             */
 MEMORY_END
 
 //NOTE: DMD #2 for Strikes N Spares - Identical to DMD #1 hardware & memory map
 static MEMORY_READ_START(GTS3_dmdreadmem2)
-{0x0000,0x1fff, MRA_RAM},
-{0x2000,0x2000, crtc6845_register_1_r},
-{0x3000,0x3000, dmdlatch2_r}, /*Input Enable*/
-{0x4000,0x7fff, MRA_BANK2},
-{0x8000,0xffff, MRA_ROM},
+{0x0000,0x1fff, MRA_RAM},               /* DMD RAM         */
+{0x2801,0x2801, crtc6845_register_1_r}, /* CRTC index      */
+{0x3000,0x3000, dmdlatch2_r},           /* Input Port      */
+{0x4000,0x7fff, MRA_BANK2},             /* Paginated ROM   */
+{0x8000,0xffff, MRA_ROM},               /* ROM             */
 MEMORY_END
 
 static MEMORY_WRITE_START(GTS3_dmdwritemem2)
-{0x0000,0x0fff, MWA_RAM},
-{0x1000,0x1fff, MWA_RAM},    /*DMD Display RAM*/
-{0x2800,0x2800, crtc6845_address_1_w},
-{0x2801,0x2801, crtc6845_register_1_w},
-{0x3800,0x3800, dmdoport2},  /*Output Enable*/
-{0x4000,0x7fff, MWA_BANK2},
-{0x8000,0xffff, MWA_ROM},
+{0x0000,0x0fff, MWA_RAM},               /* DMD RAM         */
+{0x1000,0x1fff, MWA_RAM},               /* DMD Display RAM */
+{0x2800,0x2800, crtc6845_address_1_w},  /* CRTC index      */
+{0x2801,0x2801, crtc6845_register_1_w}, /* CRTC registers  */
+{0x3800,0x3800, dmdoport2},             /* Output Port     */
+{0x4000,0x7fff, MWA_BANK2},             /* Paginated ROM   */
+{0x8000,0xffff, MWA_ROM},               /* ROM             */
 MEMORY_END
 
 MACHINE_DRIVER_START(gts3)


### PR DESCRIPTION
Hi, 
_First (direct) contribution to **pinmame** !_

While developping a personal test ROM for GT3 MA-1739 board (DMD board) and testing it with **pinmame**, I noticed some issues related to the 6845 chip and Gottlieb SYS-3 board.

- The diag LED of the MA-1739 board is inverted. This LED has <ins>negative</ins> polarity.
- Address to read 6845 registers is wrong. $2000 need to be replaced by <ins>$2801</ins> (decoded by the U8G GAL).
- Implementation of the 6845 is erronous, as most of registers are <ins>write-only</ins> but coded read-write.

Fun to see that thoses bugs had never been detected. The main reason is that the 6845 registers are never read in pinball/video games, as they don't use cursor or lightpen capabilities.

I've also check with others 6845 variants, like MC 6845-1, MOS 6545, HD 6345, HD 68B45 (aka HD 46505 used in Caveman video board) : and all have most of the registers write-only (except cursor and lightpen).




