### PR TITLE
WPC: remove (again) snd FIRQ as it is not wired

### DIFF
--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -1144,7 +1144,7 @@ static SWITCH_UPDATE(wpc) {
 #endif
 }
 
-static WRITE_HANDLER(snd_data_cb) { // Pre DCS sound board A-12738 generates FIRQ on data ready
+static WRITE_HANDLER(snd_data_cb) { // Pre DCS sound board A-12738 may generate FIRQ on data ready if W1 jumper is soldered
   if (wpclocals.sndFIRQ != 1) {
     wpclocals.sndFIRQ = 1;
     update_firq();
@@ -1173,7 +1173,11 @@ static MACHINE_INIT(wpc) {
     case GEN_WPCALPHA_2:
     case GEN_WPCDMD:
     case GEN_WPCFLIPTRON:
-      sndbrd_0_init(SNDBRD_WPCS, 1, memory_region(WPCS_ROMREGION), snd_data_cb, NULL);
+      // Pre DCS sound board A-12738 may generate FIRQ on data ready if W1 jumper is soldered but so far, I didn't find any game with W1 soldered
+      // and inspected gamecode only managed FIRQ coming from WPC or DMD. Moreover, if enabling, this would break the DMD timing as the gamecode
+      // would mistakenly consider sound FIRQ as a DMD FIRQ, breaking display during score in lots of games.
+      // sndbrd_0_init(SNDBRD_WPCS, 1, memory_region(WPCS_ROMREGION), snd_data_cb, NULL);
+      sndbrd_0_init(SNDBRD_DCS, 1, memory_region(DCS_ROMREGION), NULL, NULL);
       break;
     case GEN_WPCDCS:
     case GEN_WPCSECURITY:


### PR DESCRIPTION
Fix https://github.com/vpinball/pinmame/issues/382