### PR TITLE
dw: use full name for game

### DIFF
--- a/src/wpc/sims/wpc/prelim/dw.c
+++ b/src/wpc/sims/wpc/prelim/dw.c
@@ -337,12 +337,12 @@ WPC_ROMEND
 /*--------------
 /  Game drivers
 /---------------*/
-CORE_GAMEDEF(dw,l2,"Dr. Who (L-2)",1992, "Bally",wpc_mFliptronS,0)
-CORE_CLONEDEF(dw,d2,l2,"Dr. Who (D-2 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
-CORE_CLONEDEF(dw,l1,l2,"Dr. Who (L-1)",1992, "Bally",wpc_mFliptronS,0)
-CORE_CLONEDEF(dw,d1,l2,"Dr. Who (D-1 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
-CORE_CLONEDEF(dw,p5,l2,"Dr. Who (P-5 Prototype)",1992, "Bally",wpc_mFliptronS,0)
-CORE_CLONEDEF(dw,p6,l2,"Dr. Who (P-6 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
+CORE_GAMEDEF(dw,l2,"Doctor Who (L-2)",1992, "Bally",wpc_mFliptronS,0)
+CORE_CLONEDEF(dw,d2,l2,"Doctor Who (D-2 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
+CORE_CLONEDEF(dw,l1,l2,"Doctor Who (L-1)",1992, "Bally",wpc_mFliptronS,0)
+CORE_CLONEDEF(dw,d1,l2,"Doctor Who (D-1 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
+CORE_CLONEDEF(dw,p5,l2,"Doctor Who (P-5 Prototype)",1992, "Bally",wpc_mFliptronS,0)
+CORE_CLONEDEF(dw,p6,l2,"Doctor Who (P-6 LED Ghost Fix)",1992, "Bally",wpc_mFliptronS,0)
 
 /*-----------------------
 / Simulation Definitions

--- a/src/wpc/wpc.h
+++ b/src/wpc/wpc.h
@@ -152,7 +152,7 @@ extern const core_tLCDLayout wpc_dispDMD[];
 / SHIFTBIT2 works in the same way but the address is unaffected
 /   SHIFTBIT2 = 1<<(SHIFTBIT2 & 7)
 /
-/ Dr. Who is the only game testing the shifter.
+/ Doctor Who is the only game testing the shifter.
 /------------------------------------------------------------------------------
 / A = Alpha, M = ?, F = Fliptronics, D = DCS, S = Security, 9 = WPC95
 /------------------------------------------------AMFDS9-------------------------*/


### PR DESCRIPTION
The game is called Doctor Who, abbreviated to DW, but not Dr. Who.

I've been spending time with the WPC-era games, and notice that most use the full name of the game.  The abbreviation to "Dr. Who" seems unnecessary.