### PR TITLE
Add new COM Version method including build number as double

### DIFF
--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -1757,6 +1757,24 @@ STDMETHODIMP CController::get_Version(BSTR *pVal)
 }
 
 /****************************************************************************
+ * IController.Version (read-only): gets the program version of VPM as double
+ ****************************************************************************/
+ STDMETHODIMP CController::get_PMBuildVersion(double *pVal)
+ {
+	 if ( !pVal )
+		 return S_FALSE;
+
+	
+	 int nVersionNo0, nVersionNo1, nVersionNo2, nVersionNo3;
+	 GetProductVersion(&nVersionNo0, &nVersionNo1, &nVersionNo2, &nVersionNo3);
+	
+	 *pVal = nVersionNo0 * 1000 + nVersionNo1 * 100 + nVersionNo2 + nVersionNo3 / 10000.0;
+	 //Should output the version number as 30600 with build number as decimal
+ 
+	 return S_OK;
+ }
+ 
+/****************************************************************************
  * IController.Games (read-only): hands out a pointer to a games-objects
  ****************************************************************************/
 STDMETHODIMP CController::get_Games(IGames* *pVal)

--- a/src/win32com/Controller.h
+++ b/src/win32com/Controller.h
@@ -205,6 +205,7 @@ public:
 	STDMETHOD(put_ModOutputType)(/*[in]*/ int output, /*[in]*/ int no, /*[in]*/ int newVal);
 
 	STDMETHOD(put_TimeFence)(/*[in]*/ double fenceIns);
+	STDMETHOD(get_PMBuildVersion)(/*[out, retval]*/ double *pVal);
 };
 
 #endif // !defined(AFX_Controller_H__D2811491_40D6_4656_9AA7_8FF85FD63543__INCLUDED_)

--- a/src/win32com/VPinMAME.idl
+++ b/src/win32com/VPinMAME.idl
@@ -259,6 +259,7 @@ import "ocidl.idl";
 		[propget, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [out, retval] int *pVal);
 		[propput, id(88), helpstring("property ModOutputType")] HRESULT ModOutputType([in] int output, [in] int no, [in] int newVal);
 		[propput, id(89), helpstring("property TimeFence")] HRESULT TimeFence([in] double timeInS);
+		[propget, id(90), helpstring("property PMBuildVersion")] HRESULT PMBuildVersion([out, retval] double *pVal);
 	};
 
 	// WSHDlg and related interfaces


### PR DESCRIPTION
This adds a PMBuildVersion COM method to VPM similar to VPBuildVersion and B2SBuildVersion which includes the build number as decimal.

-> 3700,0012

To use this version number in Tables, there will be a method in B2S forwarding this value.