### PR TITLE
Add new COM Version method including build number as double **new format**

### DIFF
--- a/installguide/Interface.html
+++ b/installguide/Interface.html
@@ -29,8 +29,8 @@ interface, with details below.</TD></TR>
             <TR><TD WIDTH="50%">ShowTitle</TD><TD WIDTH="50%">HandleKeyboard</TD></TR>
             <TR><TD WIDTH="50%">ShowDMDOnly</TD><TD WIDTH="50%">SampleRate</TD></TR>
             <TR><TD WIDTH="50%">Antialias</TD><TD WIDTH="50%">LockDisplay</TD></TR>
-            <TR><TD WIDTH="50%">Version</TD><TD WIDTH="50%">ChangedLEDs</TD></TR>
-            <TR><TD WIDTH="50%">Hidden</TD><TD WIDTH="50%">&nbsp;</TD></TR>
+            <TR><TD WIDTH="50%">Version</TD><TD WIDTH="50%">PMBuildVersion</TD></TR>
+            <TR><TD WIDTH="50%">Hidden</TD><TD WIDTH="50%">ChangedLEDs</TD></TR>
             </TABLE>
         </TD>
         <TD VALIGN=top><TABLE WIDTH="100%" BORDER=0>
@@ -99,14 +99,31 @@ interface, with details below.</TD></TR>
         <TD WIDTH="50%" ALIGN="right">Read Only</TH></TD>
     <TR><TD VALIGN=top COLSPAN=2>
             <p>Returns the version number of Visual PinMAME as an 8-digit string
-            "vvmmbbrr":<BR><BR>
+            "vvmmrr00":<BR><BR>
         vv = Major version<BR>
-        mm = Minor version<BR>
         bb = Beta version<BR>
         rr = Revision<BR><BR>
   	Example:<BR>
-  		A result of "00990201" signifies "Version 0.99 Beta 2 Rev A<BR><BR>
+  		A result of "03070000" signifies "Version 3.7.0<BR><BR>
   		If (Controller.Version&lt;"00990201") Then MsgBox "You need a newer
+version of VPinMAME." : Exit Sub
+        </TD>
+    </TR>
+    </TABLE>
+
+    <TABLE WIDTH="100%" BORDER = 1>
+    <TR><TD WIDTH="50%"><B>PMBuildVersion</B></TH>
+        <TD WIDTH="50%" ALIGN="right">Read Only</TH></TD>
+    <TR><TD VALIGN=top COLSPAN=2>
+            <p>Returns the version number of Visual PinMAME as an double value
+            vvmmbbrr.xxxx:<BR><BR>
+        vv = Major version<BR>
+        mm = Minor version<BR>
+        rr = Revision<BR><BR>
+        xx = Build Number<BR><BR>
+  	Example:<BR>
+  		A result of 30700.0012 signifies "Version 3.7.0 Build 12<BR><BR>
+  		If (Controller.PMBuildVersion&lt;30700.0012) Then MsgBox "You need a newer
 version of VPinMAME." : Exit Sub
         </TD>
     </TR>

--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -6,6 +6,8 @@ What's new in PinMAME:
 Version 3.7 (XX XXth, 2025) - ""
 ------------------------------------------------------------------------------
 
+Add windows COM method PMBuildVersion returning 30700.4711 with build number as decimal.
+
 *** ROM SUPPORT *** Thanks to Tom Collins
 Clones:
 Victory (1.1 multiplayer MOD)

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -1768,8 +1768,8 @@ STDMETHODIMP CController::get_Version(BSTR *pVal)
 	 int nVersionNo0, nVersionNo1, nVersionNo2, nVersionNo3;
 	 GetProductVersion(&nVersionNo0, &nVersionNo1, &nVersionNo2, &nVersionNo3);
 	
-	 *pVal = nVersionNo0 * 1000 + nVersionNo1 * 100 + nVersionNo2 + nVersionNo3 / 10000.0;
-	 //Should output the version number as 30600 with build number as decimal
+	 *pVal = nVersionNo0 * 10000 + nVersionNo1 * 100 + nVersionNo2 + nVersionNo3 / 10000.0;
+	 //Should output the version number as 30600.4711 with build number as decimal
  
 	 return S_OK;
  }


### PR DESCRIPTION
Changed output format 3700.4711 -> 30700.4711 leaving for more minor version numbers and keeping the output similar to Visual Pinball
Added documentation to the html file and to readme.txt