### PR TITLE
ci: fix VPinMAME build failures

### DIFF
--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -43,7 +43,7 @@ jobs:
 
   build:
     name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ version ]
     strategy:
       fail-fast: false
@@ -95,11 +95,11 @@ jobs:
       - name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
           cp cmake/vpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake ${{ matrix.extra-flags }} -T v141_xp -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build/vpinmame
+          cmake ${{ matrix.extra-flags }} -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build/vpinmame
           cmake --build build/vpinmame --config Release
           # ./upx/upx.exe --best --lzma build/vpinmame/Release/${{ matrix.vpinmame }}
           cp cmake/instvpm/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake -T v141_xp -G "Visual Studio 16 2019" -A ${{ matrix.platform-name }} -B build/instvpm
+          cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build/instvpm
           cmake --build build/instvpm --config Release
       - run: |
           mkdir tmp


### PR DESCRIPTION
The `windows-2019` runner image was deprecated.  I bumped up to 2022, and had to update the Visual Studio version.  After doing that, I needed to remove the forced toolset of `v141_xp` in order to complete the build.

I'm not sure if the build is actually good or not, but at least it passes the build process.

Others with more CI/CMake/Visual Studio experience might want to weigh in before you merge this.

Here's the [successful workflow](https://github.com/tomlogic/pinmame/actions/runs/16328977039) on my fork.