### PR TITLE
startup: exit if ROM files are missing

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1226,7 +1226,7 @@ static int display_rom_load_results(struct rom_load_data *romdata)
 		if (romdata->errors)
 		{
 			strcat(romdata->errorbuf, "ERROR: required files are missing, the game cannot be run.");
-			// bailing = 1;
+			bailing = 1;
 		}
 		else
 			strcat(romdata->errorbuf, "WARNING: the game might not run correctly.");


### PR DESCRIPTION
This line was commented out 20 years ago in 4ec6b7c.

I'm not sure of the reasons behind the change, but I'm doing some automation with PinMAME and wanted to return to the previous behavior of automatically exiting for ROMs that don't exist.

Is there a reason to keep this line commented out?  Do users launch from batch files in Windows Explorer and therefore miss seeing error messages if there isn't a "Press any key to continue" prompt?  there are other instances of MAME code setting that flag (see `bail_and_print()` in mame.c), so maybe we don't need special treatment for missing ROMs?

Alternatively, I was looking for a way to set `options.gui_host` from the command line, but see that's only present in `Win32ui.c` and `VPinMAMEConfig.cpp`.