### PR TITLE
ci: remove upx compression to avoid virus false positives

### DIFF
--- a/.github/workflows/libpinmame.yml
+++ b/.github/workflows/libpinmame.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       revision: ${{ steps.version.outputs.revision }}
@@ -48,17 +48,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: windows-latest, platform: win, arch: x64 }
-          - { os: windows-latest, platform: win, arch: x86 }
-          - { os: windows-latest, platform: win, arch: arm64 }
-          - { os: macos-latest, platform: macos, arch: x64 }
-          - { os: macos-latest, platform: macos, arch: arm64 }
-          - { os: ubuntu-latest, platform: linux, arch: x64 }
+          - { os: windows-2025, platform: win, arch: x64 }
+          - { os: windows-2025, platform: win, arch: x86 }
+          - { os: windows-2025, platform: win, arch: arm64 }
+          - { os: macos-15, platform: macos, arch: x64 }
+          - { os: macos-15, platform: macos, arch: arm64 }
+          - { os: ubuntu-24.04, platform: linux, arch: x64 }
           - { os: ubuntu-24.04-arm, platform: linux, arch: aarch64 }
-          - { os: ubuntu-latest, platform: android, arch: arm64-v8a }
-          - { os: macos-latest, platform: ios, arch: arm64 }
-          - { os: macos-latest, platform: ios-simulator, arch: arm64 }
-          - { os: macos-latest, platform: tvos, arch: arm64 }
+          - { os: ubuntu-24.04, platform: android, arch: arm64-v8a }
+          - { os: macos-15, platform: ios, arch: arm64 }
+          - { os: macos-15, platform: ios-simulator, arch: arm64 }
+          - { os: macos-15, platform: tvos, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
       - name: Build libpinmame-${{ matrix.platform }}-${{ matrix.arch }}
@@ -66,11 +66,25 @@ jobs:
           cp cmake/libpinmame/CMakeLists.txt .
           if [[ "${{ matrix.platform }}" == "win" ]]; then
              if [[ "${{ matrix.arch }}" == "x64" ]]; then
-                cmake -G "Visual Studio 17 2022" -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }} -B build
+                cmake \
+                   -G "Visual Studio 17 2022" \
+                   -DPLATFORM=${{ matrix.platform }} \
+                   -DARCH=${{ matrix.arch }} \
+                   -B build
              elif [[ "${{ matrix.arch }}" == "x86" ]]; then
-                cmake -G "Visual Studio 17 2022" -A Win32 -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }} -B build
+                cmake \
+                   -G "Visual Studio 17 2022" \
+                   -A Win32 \
+                   -DPLATFORM=${{ matrix.platform }} \
+                   -DARCH=${{ matrix.arch }} \
+                   -B build
              elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
-                cmake -G "Visual Studio 17 2022" -A ARM64 -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }} -B build
+                cmake \
+                   -G "Visual Studio 17 2022" \
+                   -A ARM64 \
+                   -DPLATFORM=${{ matrix.platform }} \
+                   -DARCH=${{ matrix.arch }} \
+                   -B build
              fi
              cmake --build build --config Release
           else
@@ -79,7 +93,11 @@ jobs:
              else
                 NUM_PROCS=$(nproc)
              fi
-             cmake -DCMAKE_BUILD_TYPE=Release -DPLATFORM=${{ matrix.platform }} -DARCH=${{ matrix.arch }} -B build
+             cmake \
+                -DPLATFORM=${{ matrix.platform }} \
+                -DARCH=${{ matrix.arch }} \
+                -DCMAKE_BUILD_TYPE=Release \
+                -B build
              cmake --build build -- -j${NUM_PROCS}
           fi
       - name: Prepare artifacts
@@ -132,7 +150,7 @@ jobs:
           path: ${{ steps.artifacts.outputs.artifact_path }}
 
   post-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: [ version, build ]
     name: Build libpinmame-macos
     steps:

--- a/.github/workflows/pinmame.yml
+++ b/.github/workflows/pinmame.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   VERSION_START_SHA: 79345956d1807e3188f0e895379466c7c4caae72
-  UPX_ARTIFACT: 345209471
 
 defaults:
   run:
@@ -14,7 +13,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       revision: ${{ steps.version.outputs.revision }}
@@ -43,7 +42,7 @@ jobs:
 
   build:
     name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [ version ]
     strategy:
       fail-fast: false
@@ -64,22 +63,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/setup-nasm@v1
-#      - run: |
-#          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
-#          7z x upx.zip -oupx
-#          rm upx.zip
       - run: |
           perl -i -pe"s/0/${{ needs.version.outputs.revision }}/g" src/git_version.h
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha7 }}/g" src/git_version.h
-          curl -L https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-win64.zip -o upx.zip
-          7z e upx.zip -oupx
-          rm upx.zip
       - name: Build PinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
           cp cmake/pinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake ${{ matrix.extra-flags }} -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build
+          cmake \
+             -G "Visual Studio 17 2022" \
+             -A ${{ matrix.platform-name }} \
+             ${{ matrix.extra-flags }} \
+             -B build
           cmake --build build --config Release
-          ./upx/upx.exe --best --lzma build/Release/PinMAME.exe
       - run: |
           mkdir tmp
           cp build/Release/PinMAME.exe tmp

--- a/.github/workflows/pinmame32.yml
+++ b/.github/workflows/pinmame32.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   VERSION_START_SHA: 79345956d1807e3188f0e895379466c7c4caae72
-  UPX_ARTIFACT: 345209471
 
 defaults:
   run:
@@ -14,7 +13,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       revision: ${{ steps.version.outputs.revision }}
@@ -43,7 +42,7 @@ jobs:
 
   build:
     name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [ version ]
     strategy:
       fail-fast: false
@@ -72,22 +71,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/setup-nasm@v1
-#      - run: |
-#          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
-#          7z x upx.zip -oupx
-#          rm upx.zip
       - run: |
           perl -i -pe"s/0/${{ needs.version.outputs.revision }}/g" src/git_version.h
           perl -i -pe"s/unknown/${{ needs.version.outputs.sha7 }}/g" src/git_version.h
-          curl -L https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-win64.zip -o upx.zip
-          7z e upx.zip -oupx
-          rm upx.zip
       - name: Build PinMAME32${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
           cp cmake/pinmame32/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake ${{ matrix.extra-flags }} -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build
+          cmake \
+             -G "Visual Studio 17 2022" \
+             -A ${{ matrix.platform-name }} \
+             ${{ matrix.extra-flags }} \
+             -B build
           cmake --build build --config Release
-          ./upx/upx.exe --best --lzma build/Release/PinMAME32.exe
       - run: |
           mkdir tmp
           cp build/Release/PinMAME32.exe tmp

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
       tag: ${{ steps.version.outputs.tag }}
@@ -38,7 +38,7 @@ jobs:
           echo "tag=${VERSION}-${REVISION}-${{ steps.sha.outputs.sha7 }}" >> $GITHUB_OUTPUT
 
   prerelease:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ version ]
     steps:
       - id: download

--- a/.github/workflows/vpinmame.yml
+++ b/.github/workflows/vpinmame.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   VERSION_START_SHA: 79345956d1807e3188f0e895379466c7c4caae72
-#  UPX_ARTIFACT: 345209471
 
 defaults:
   run:
@@ -14,7 +13,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       revision: ${{ steps.version.outputs.revision }}
@@ -43,7 +42,7 @@ jobs:
 
   build:
     name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [ version ]
     strategy:
       fail-fast: false
@@ -76,14 +75,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/setup-nasm@v1
-#      - run: |
-#          curl -sL -H "Authorization: Token ${{ secrets.GH_PAT }}" https://api.github.com/repos/upx/upx/actions/artifacts/${{ env.UPX_ARTIFACT }}/zip -o upx.zip
-#          7z x upx.zip -oupx
-#          rm upx.zip
-#      - run: |
-#          curl -L https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-win64.zip -o upx.zip
-#          7z e upx.zip -oupx
-#          rm upx.zip
       - name: Update buildnumber
         run: |
           perl -i -pe"s/0/${{ needs.version.outputs.revision }}/g" src/git_version.h
@@ -95,11 +86,17 @@ jobs:
       - name: Build VPinMAME${{ matrix.artifact-suffix }}-${{ matrix.platform }}
         run: |
           cp cmake/vpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake ${{ matrix.extra-flags }} -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build/vpinmame
+          cmake \
+             -G "Visual Studio 17 2022" \
+             -A ${{ matrix.platform-name }} \
+             ${{ matrix.extra-flags }} \
+             -B build/vpinmame
           cmake --build build/vpinmame --config Release
-          # ./upx/upx.exe --best --lzma build/vpinmame/Release/${{ matrix.vpinmame }}
           cp cmake/instvpm/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build/instvpm
+          cmake \
+             -G "Visual Studio 17 2022" \
+             -A ${{ matrix.platform-name }} \
+             -B build/instvpm
           cmake --build build/instvpm --config Release
       - run: |
           mkdir tmp

--- a/.github/workflows/xpinmame.yml
+++ b/.github/workflows/xpinmame.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   version:
     name: Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       revision: ${{ steps.version.outputs.revision }}
@@ -48,25 +48,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             platform: osx-x64
             exe: xpinmame
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             platform: linux-x64
             exe: xpinmame
     steps:
       - uses: actions/checkout@v4
-      - if: matrix.os == 'macos-latest'
+      - if: matrix.os == 'macos-15'
         run: |
           brew install xquartz
 
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-24.04'
         run: |    
           sudo apt install libx11-dev libxv-dev libasound2-dev
       - name: Build xpinmame-${{ matrix.platform }}
         run: |
           cp cmake/xpinmame/CMakeLists_${{ matrix.platform }}.txt CMakeLists.txt
-          cmake -DCMAKE_BUILD_TYPE=Release -B build/Release
+          cmake \
+             -DCMAKE_BUILD_TYPE=Release \
+             -B build/Release
           cmake --build build/Release
       - run: |
           mkdir tmp

--- a/.github/workflows/xpinmame_lisy.yml
+++ b/.github/workflows/xpinmame_lisy.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.cpu_info }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR removes upx compression to address issues like https://github.com/vpinball/pinmame/issues/472

Also, the ci has been updated to have specific `runs-on` such as `windows-2025` instead of `windows-latest`, `macos-15` instead of `macos-latest`.

This way we will know exactly what we are building on as opposed to having github automatically switch and us not knowing it:

![Screenshot 2025-08-10 at 10 57 28 AM](https://github.com/user-attachments/assets/8055e8b6-96a9-46cd-8aaa-111a5bb2a20f)
