### PR TITLE
PWM: cleanup solenoid mapping

### DIFF
--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -18,7 +18,7 @@ Added PWM support to CFTBL backglass flashers
 Added PWM lamps & solenoids support to Bally 6803 games
 Added PWM lamps & solenoids support to Zaccaria games
 Added PWM support to Alvin G. games
-Fixed PWM GameOn and J11 outputs for WPC games
+Fixed PWM GameOn and J111 outputs for WPC games
 Improved sound for Metal Man, and a bit for Jolly Park and Verne's World (in general, slightly more authentic MSM5205 sound)
 Slightly improved YM262 sound for Sir Lancelot
 Fixed sound problems if a OKI6295 game is used after a OKI6376 game (e.g. GTS3 after Sleic)

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -515,11 +515,11 @@ typedef struct {
   volatile UINT32 pulsedSolState;                               /* Current pulse binary value of solenoids on driver board */
   volatile UINT32 solenoids;                                    /* Current integrated binary On/Off value of solenoids on driver board (not pulsed, averaged over a period depending on the driver) */
   volatile UINT32 solenoids2;                                   /* Current integrated binary On/Off value of additional solenoids, including flipper solenoids (not pulsed, averaged over a period depending on the driver) */
-  UINT64 flipperCoils;                                          /* Coil mapping of flipper power/hold coils => TODO move to core_gameData */
   /*-- GI --*/
   volatile int   gi[CORE_MAXGI];                                /* WPC, Whitestar and SAM GI strings state */
   /*-- Generalized outputs --*/
   int nSolenoids, nLamps, nGI, nAlphaSegs;                      /* Number of physical outputs the driver handles */
+  int hasModulatedFlippers;                                     /* Non 0 if flippers are implemented through modulated outputs instead of standard solenoids/solenoids2 bitmasks */
   double lastACZeroCrossTimeStamp;                              /* Last time AC did cross 0 as reported by the driver (should be 120Hz) */
   UINT8 binaryOutputState[CORE_MODOUT_MAX / 8];                 /* Pulsed binary state */
   core_tPhysicOutput physicOutputState[CORE_MODOUT_MAX];        /* Output state, taking in account the physical device wired to the binary output */


### PR DESCRIPTION
This fix a few issues with the way 'solenoid' output were mapped:
- removes the hacky flipper remapping (Capcom flipper states are no more duplicated from 8..11 to PinMAME mapping)
- cleanly implemented modulated flipper solenoid (Capcom & WPC as they are also used to drive modulated lamps)
- fix WPC conflict between J111 GPIO/GameOn/WPC 95 JPDC outputs

------------------------------------
Review of output writing, taking in account this commit:
- 'directly written to solenoids2' means not implementing PWM
- lists what is written to PWM outputs and expected remappings if any

S11: writes to 1..32, flippers are directly written to solenoids2

Bally 6803: writes to 1..20, flippers are directly written to solenoids2

Capcom: writes to 1..32, flippers are written to sol 9..12 (not PinMAME flippers slots 33..36/45..48) as they are sometimes used to control modulated lights

GTS3: writes to 1..32, flippers are directly written to solenoids2

GTS80: writes to 1..9, flippers are directly written to solenoids2 

S11: writes 1..16, switched sol to 17..22, 23 is GameOn, muxed sol to 24..32, ext sol to 41..49, flippers are directly written to solenoids2

SE: writes 1..32 except 15/16 which are flipper solenoids written directly to solenoids2, write to 15 with FastFlip state

SAM/SPA: writes to 1..32 & writes to 51..64 with up to 14 aux solenoids (actually 12 with 2 unused slots)

WPC:
- Writes to 1..28
- Writes to 29..32 with GameOn and J111 GPIO, conflicting with previous write
- Writes to 33..36 with ROM controlled upper flipper coils (which can also be used as flasher driver)
- Writes to 37..40 with aux solenoids
- Writes to 31..44 with a mirror of aux solenoids
- Writes to 45..48 with ROM controlled lower flipper coils (which can also be used as flasher driver)
- Writes to 51..58 with aux board output (see Demolition man for example, not that they are referenced 37..44 in manuals)

ZAC: writes to 1..32, flippers are directly written to solenoids2