### PR TITLE
build: fix xpinmame_lisy builds

### DIFF
--- a/src/unix/unix.mak
+++ b/src/unix/unix.mak
@@ -314,6 +314,8 @@ ifdef EFENCE
 MY_LIBS += -lefence
 endif
 
+OBJS += $(COREOBJS) $(DRVLIBS) $(OBJ)/unix.$(DISPLAY_METHOD)/osdepend.a
+
 MY_OBJDIRS = $(CORE_OBJDIRS) $(sort $(OBJDIRS))
 
 ##############################################################################


### PR DESCRIPTION
This fixes the xpinmame_lisy builds as `osdepend.a` was removed in https://github.com/vpinball/pinmame/commit/12a41061#diff-1434ea00f069d9a84c5ee012c478f6e0916c580e4aa054899d491f845b0b9af0L320 