### PR TITLE
fixed flickering of segment displays rendered as synthetic DMD

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -533,11 +533,10 @@ extern "C" void OnStateChange(const int state)
 			if (displayCount <= layout->index)
 				displayCount = layout->index + 1;
 		}
-		const int syntheticDmdIndex = displayCount;
-		if (hasDMDOrVideo)
-			displayCount++;
-		else
-			displayCount = syntheticDmdIndex + 1;
+		// Reserve one extra slot unconditionally.
+		// Using hasDMDOrVideo as the gate is wrong here: segment-only games also create an extra
+		// synthetic 128x32 DMD below, so they need one additional display slot as well.
+		displayCount++;
 		_displays.resize(displayCount);
 
 		for (const struct core_dispLayout* layout = core_gameData->lcdLayout, * parent_layout = nullptr; layout->length || (parent_layout && parent_layout->length); layout += 1) {
@@ -596,9 +595,9 @@ extern "C" void OnStateChange(const int state)
 			pDisplay->size = pDisplay->layout.width * pDisplay->layout.height;
 			pDisplay->pData = malloc(pDisplay->size);
 			memset(pDisplay->pData, 0, pDisplay->size);
-			_displays[syntheticDmdIndex] = pDisplay;
+			_displays[displayCount - 1] = pDisplay;
 			if (_p_Config->cb_OnDisplayAvailable)
-				(*(_p_Config->cb_OnDisplayAvailable))(syntheticDmdIndex, displayCount, &pDisplay->layout, _p_userData);
+				(*(_p_Config->cb_OnDisplayAvailable))(displayCount - 1, displayCount, &pDisplay->layout, _p_userData);
 		}
 	}
 }

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -533,8 +533,11 @@ extern "C" void OnStateChange(const int state)
 			if (displayCount <= layout->index)
 				displayCount = layout->index + 1;
 		}
+		const int syntheticDmdIndex = displayCount;
 		if (hasDMDOrVideo)
 			displayCount++;
+		else
+			displayCount = syntheticDmdIndex + 1;
 		_displays.resize(displayCount);
 
 		for (const struct core_dispLayout* layout = core_gameData->lcdLayout, * parent_layout = nullptr; layout->length || (parent_layout && parent_layout->length); layout += 1) {
@@ -593,9 +596,9 @@ extern "C" void OnStateChange(const int state)
 			pDisplay->size = pDisplay->layout.width * pDisplay->layout.height;
 			pDisplay->pData = malloc(pDisplay->size);
 			memset(pDisplay->pData, 0, pDisplay->size);
-			_displays[displayCount - 1] = pDisplay;
+			_displays[syntheticDmdIndex] = pDisplay;
 			if (_p_Config->cb_OnDisplayAvailable)
-				(*(_p_Config->cb_OnDisplayAvailable))(displayCount - 1, displayCount, &pDisplay->layout, _p_userData);
+				(*(_p_Config->cb_OnDisplayAvailable))(syntheticDmdIndex, displayCount, &pDisplay->layout, _p_userData);
 		}
 	}
 }


### PR DESCRIPTION
I didn't update pinmame since August 2025 in PPUC. Now I did it and adopted the libpinmame changes. But I noticed that Williams Sys3 and Sys6 games are now flickering, like a permanent on/off per segment.
I added some debug code in PPUC and saw that the top right corner that should show a stable `0`in attract mode toggles (cornerChecksum):
```
OnDisplayUpdated(): index=5, type=14, top=0, left=0, width=128, height=32, depth=2, length=0
SyntheticDMD: index=5 blank=0 lit=59 min=0 max=128 checksum=a2ca78d9 cornerLit=0 cornerChecksum=4a2bb865 hw=20000
OnDisplayUpdated(): index=5, type=14, top=0, left=0, width=128, height=32, depth=2, length=0
SyntheticDMD: index=5 blank=0 lit=687 min=0 max=3 checksum=f435a51a cornerLit=57 cornerChecksum=ed057750 hw=20000
OnDisplayUpdated(): index=5, type=14, top=0, left=0, width=128, height=32, depth=2, length=0
SyntheticDMD: index=5 blank=0 lit=59 min=0 max=128 checksum=a2ca78d9 cornerLit=0 cornerChecksum=4a2bb865 hw=20000
OnDisplayUpdated(): index=5, type=14, top=0, left=0, width=128, height=32, depth=2, length=0
SyntheticDMD: index=5 blank=0 lit=687 min=0 max=3 checksum=f435a51a cornerLit=57 cornerChecksum=ed057750 hw=20000
```

For segment-only games, libpinmame created an extra synthetic 128x32 DMD but stored it in the same display slot as the last segment display.

So updates alternated between:
- real synthetic DMD frame data
- segment-display data misread as DMD data

That caused the visible flicker. I gave the synthetic DMD its own dedicated display index and now it is working for PPUC. But you have to judge if that is the correct fix.

Using this fix, I also get way less display updates which is very important.