### PR TITLE
Data East 128x16 DMD shade correction.

### DIFF
--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -3730,8 +3730,8 @@ UINT8* core_dmd_update_identify(const core_tLCDLayout* layout, unsigned int * ra
         frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
       }
       else { //if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_1_2) { // double length frame are the 2 last ones, single length frame is the one before (Data East 128x16)
-        frame0 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 2)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
-        frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
+        frame0 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
+        frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 3)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
       }
       for (int kk = 0; kk < dmd_state->rawFrameSize; kk++) {
         unsigned int intens1;
@@ -3739,7 +3739,7 @@ UINT8* core_dmd_update_identify(const core_tLCDLayout* layout, unsigned int * ra
         if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_2_1) {
           intens1 = 2*(frame0[kk] & 0x55) + (frame1[kk] & 0x55);   // 0x55 = 01010101 binary mask
           intens2 =   (frame0[kk] & 0xaa) + (frame1[kk] & 0xaa)/2; // 0xaa = 10101010 binary mask
-        } else { //if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_1_2)
+        } else { //if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_1_2), need to make sure frame1 is multiplied here (see else above)
           intens1 =   (frame0[kk] & 0x55) + 2*(frame1[kk] & 0x55); // 0x55 = 01010101 binary mask
           intens2 =   (frame0[kk] & 0xaa)/2 + (frame1[kk] & 0xaa); // 0xaa = 10101010 binary mask
         }

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -3730,12 +3730,19 @@ UINT8* core_dmd_update_identify(const core_tLCDLayout* layout, unsigned int * ra
         frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
       }
       else { //if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_1_2) { // double length frame are the 2 last ones, single length frame is the one before (Data East 128x16)
-        frame0 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
-        frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 3)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
+        frame0 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 2)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
+        frame1 = dmd_state->rawFrames + ((dmd_state->nextFrame + (dmd_state->nFrames - 1)) % dmd_state->nFrames) * dmd_state->rawFrameSize;
       }
       for (int kk = 0; kk < dmd_state->rawFrameSize; kk++) {
-        const unsigned int intens1 = 2*(frame0[kk] & 0x55) + (frame1[kk] & 0x55);   // 0x55 = 01010101 binary mask
-        const unsigned int intens2 =   (frame0[kk] & 0xaa) + (frame1[kk] & 0xaa)/2; // 0xaa = 10101010 binary mask
+        unsigned int intens1;
+        unsigned int intens2;
+        if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_2_1) {
+          intens1 = 2*(frame0[kk] & 0x55) + (frame1[kk] & 0x55);   // 0x55 = 01010101 binary mask
+          intens2 =   (frame0[kk] & 0xaa) + (frame1[kk] & 0xaa)/2; // 0xaa = 10101010 binary mask
+        } else { //if (dmd_state->raw_combiner == CORE_DMD_PWM_COMBINER_SUM_1_2)
+          intens1 =   (frame0[kk] & 0x55) + 2*(frame1[kk] & 0x55); // 0x55 = 01010101 binary mask
+          intens2 =   (frame0[kk] & 0xaa)/2 + (frame1[kk] & 0xaa); // 0xaa = 10101010 binary mask
+        }
         *rawData++ = (intens2 >> 6) & 0x03;
         *rawData++ = (intens1 >> 6) & 0x03;
         *rawData++ = (intens2 >> 4) & 0x03;


### PR DESCRIPTION
I've done research into this and came to the realization PinMAME incorrectly handles 128x16 shades. 
Looking at the code, it's odd that DE x16 does have its own case called SUM_1_2, though this isn't being correctly followed up. 