### PR TITLE
unix: build ALSA and SDL sound drivers on the Linux targets

### DIFF
--- a/makefile.unix
+++ b/makefile.unix
@@ -600,7 +600,7 @@ ARCH  = linux
 # Choose any additonal sound drivers you want to include, besides the 
 # native sound driver for your system.
 # SOUND_ESOUND = 1
-# SOUND_ALSA = 1
+SOUND_ALSA = 1
 # SOUND_ARTS_TEIRA = 1
 # SOUND_ARTS_SMOTEK = 1
 # SOUND_SDL = 1

--- a/makefile.unixsdl
+++ b/makefile.unixsdl
@@ -600,10 +600,10 @@ ARCH  = linux
 # Choose any additonal sound drivers you want to include, besides the 
 # native sound driver for your system.
 # SOUND_ESOUND = 1
-# SOUND_ALSA = 1
+SOUND_ALSA = 1
 # SOUND_ARTS_TEIRA = 1
 # SOUND_ARTS_SMOTEK = 1
-# SOUND_SDL = 1
+SOUND_SDL = 1
 # SOUND_WAVEOUT = 1
 
 

--- a/makefile.unixsdl_debug
+++ b/makefile.unixsdl_debug
@@ -600,10 +600,10 @@ ARCH  = linux
 # Choose any additonal sound drivers you want to include, besides the 
 # native sound driver for your system.
 # SOUND_ESOUND = 1
-# SOUND_ALSA = 1
+SOUND_ALSA = 1
 # SOUND_ARTS_TEIRA = 1
 # SOUND_ARTS_SMOTEK = 1
-# SOUND_SDL = 1
+SOUND_SDL = 1
 # SOUND_WAVEOUT = 1
 
 

--- a/src/unix/unix.mak
+++ b/src/unix/unix.mak
@@ -255,7 +255,15 @@ MY_LIBS += `esd-config --libs`
 endif
 
 ifdef SOUND_ALSA
-CONFIG  += -DSYSDEP_DSP_ALSA 
+# Verify the ALSA development headers are installed before adding -lasound, so a
+# missing dev package fails with a clear, distro-neutral message instead of a
+# cryptic "cannot find -lasound" at link time. The probe uses the compiler's own
+# include path (-include, no literal '#'), so it works wherever the header lives.
+ALSA_AVAILABLE := $(shell $(CC) -x c -E -include alsa/asoundlib.h /dev/null >/dev/null 2>&1 && echo yes)
+ifneq ($(ALSA_AVAILABLE),yes)
+$(error SOUND_ALSA=1 but the ALSA development library/headers were not found. Install the ALSA dev package and rebuild: Debian/Ubuntu/Kali -> libasound2-dev; Fedora/RHEL/CentOS -> alsa-lib-devel; openSUSE -> alsa-devel; Arch -> alsa-lib; Gentoo -> media-libs/alsa-lib. Or comment out SOUND_ALSA in the makefile.)
+endif
+CONFIG  += -DSYSDEP_DSP_ALSA
 MY_LIBS += -lasound
 endif
 


### PR DESCRIPTION
The unix builds only compile the platform's native sound driver, which on Linux is OSS (/dev/dsp). Modern Linux no longer provides a usable /dev/dsp: the in-kernel OSS layer has been removed for years, and PipeWire/PulseAudio desktops do not emulate it. As a result the stock build has no working audio output and can even block when the device is opened. ALSA is the right default nowadays -- it is the kernel's native sound API and the most portable choice, since PipeWire, PulseAudio and bare ALSA all expose an ALSA interface.

Enable SOUND_ALSA on every Linux target (makefile.unix, makefile.unixsdl, makefile.unixsdl_debug). The ALSA DSP plugin has the highest priority of all sysdep_dsp plugins (4 vs OSS 3), so once it is compiled in the plugin manager selects it automatically while OSS remains as a fallback -- no runtime flag is needed.

Also enable SOUND_SDL on the two SDL builds (makefile.unixsdl and makefile.unixsdl_debug). Those already link libSDL for video, so the SDL audio driver costs no extra dependency and provides a sound-server-friendly alternative: it routes through PipeWire/PulseAudio rather than grabbing the device, and is selectable at runtime with -dp sdl. makefile.unix is left SDL-free on purpose. This mirrors makefile.lisy, which already enables both.

Finally, guard the ALSA dependency in src/unix/unix.mak: probe for <alsa/asoundlib.h> through the compiler's own include path and fail at parse time with a clear, distro-neutral message that names the dev package per distribution (Debian/Ubuntu libasound2-dev, Fedora/RHEL alsa-lib-devel, openSUSE alsa-devel, Arch alsa-lib, Gentoo media-libs/alsa-lib) instead of a cryptic "cannot find -lasound" link error.