### PR TITLE
Validate m2sw/sw2m & m2lamp/lamp2m

### DIFF
--- a/src/wpc/alvg.c
+++ b/src/wpc/alvg.c
@@ -57,7 +57,7 @@
    #2) Manually calling the NMI		(VIA BUG?)
    #3) Clearing the Lamp Matrix at the appropriate time
    #4) Lamp and Switch Column handling needs to be improved (use core functions)
-   #5) Not sure if I did the sw2m and m2sw functions properly
+   #5) Not sure if I did the sw2m and m2sw functions properly [Edit VB 2026/07/13 made m2sw symmetric with sw2m]
    #6) Solenoid handling needs to be cleaned up (ie, remove unnecessary code)
    #7) Sound board (gen #2) FIRQ freq. is set by a jumper (don't know which is used) nor what the value of E is.
    #8) There's probably more I can't think of at the moment
@@ -583,7 +583,7 @@ static int alvg_sw2m(int no) {
 }
 
 static int alvg_m2sw(int col, int row) {
-	return col*8 + row - 9;
+	return col*8 + row - 7;
 }
 
 //Send data to the DMD CPU

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -2454,6 +2454,30 @@ static MACHINE_INIT(core) {
     /*-- init switch matrix --*/
     memcpy((void*)coreGlobals.invSw, (void*)core_gameData->wpc.invSw, sizeof(core_gameData->wpc.invSw));
     memcpy((void*)coreGlobals.swMatrix, (void*)coreGlobals.invSw, sizeof(coreGlobals.invSw));
+    /*-- validate switch & lamp matrices --*/
+    if (coreData->m2sw) {
+      assert(coreData->sw2m);
+      for (int col = 0; col < CORE_STDSWCOLS + core_gameData->hw.swCol; col++) {
+        for (int row = 0; row < 8; row++) {
+          const int n = col * 8 + row;
+          const int m2sw = coreData->m2sw(col, row);
+          const int sw2m = coreData->sw2m(m2sw);
+          assert(sw2m == n);
+        }
+      }
+    }
+    if (coreData->m2lamp) {
+       assert(coreData->lamp2m);
+       for (int col = 0; col < core_gameData->hw.lampCol; col++) {
+          for (int row = 0; row < 8; row++) {
+             const int n = col * 8 + row;
+             const int m2lamp = coreData->m2lamp(col, row);
+             const int lamp2m = coreData->lamp2m(m2lamp);
+             assert(lamp2m == n);
+          }
+       }
+    }
+
 #ifdef PROC_SUPPORT
     /*-- P-ROC operation requires a YAML.  Disable P-ROC operation
      * if no YAML is specified. --*/

--- a/src/wpc/gts80.c
+++ b/src/wpc/gts80.c
@@ -116,9 +116,12 @@ static int GTS80_sw2m(int no) {
 }
 
 static int GTS80_m2sw(int col, int row) {
-  if (col > 9 || (col == 9 && row >= 6)) return col*8+row;
-  else if (col < 1)                      return -9 + row;
-  else                                   return row*10+col-1;
+  if (col == 0 && row == 0)
+    return -8;                    // matches sw2m(-8) == 0
+  else if (col <= 9)
+    return row * 10 + col - 1;    // inverse of the 0<=no<96 branch
+  else
+    return col * 10 + row + 1;    // inverse of the no>=96 branch
 }
 static int GTS80_lamp2m(int no)           { return no+8; }
 static int GTS80_m2lamp(int col, int row) { return (col-1)*8+row; }

--- a/src/wpc/play.c
+++ b/src/wpc/play.c
@@ -447,7 +447,12 @@ static MEMORY_WRITE_START(PLAYMATIC_writemem3)
 MEMORY_END
 
 static int play_sw2m(int no) { return 8+(no/10)*8+(no%10-1); }
-static int play_m2sw(int col, int row) { return (col-1)*10+row+1; }
+static int play_m2sw(int col, int row) {
+   if (col == 0)
+      return row - 7;
+   else
+      return (col - 1) * 10 + (row + 1);
+}
 
 MACHINE_DRIVER_START(PLAYMATIC1)
   MDRV_IMPORT_FROM(PinMAME)


### PR DESCRIPTION
Assert linear to matrix and opposite functions are symmetric (m2sw was not used anywhere, some implementations did not fullfill the contract) Fix incorrect mappings for:
- GTS80
- AlvinG
- Playmatic