### PR TITLE
Add an optional HTTP remote debugger (`src/remote_debug`, off by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ build/
 /.vs/
 /obj/
 /release/
+
+# Remote debugger (src/remote_debug): generated header + test/run artifacts
+/src/remote_debug/ui_html.h
+/src/remote_debug/*.bin
+/src/remote_debug/suite_log.txt
+/src/remote_debug/test_log.txt
+/src/remote_debug/sse_log.txt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ info on using MAME related functions.
 All standard MAME "functions" do work the same way in PinMAME (profiler, debugger, cheats,
 record/playback, command line switches etc.).
 
+This fork includes an **Advanced Remote Debugger** module, providing a thread-safe REST API and a high-fidelity web dashboard for headless or remote analysis. Features include real-time DMD/Alphanumeric rendering, hardware breakpoints, memory pattern search, and interactive matrix visualization. See [src/remote_debug/README.md](src/remote_debug/README.md) for full documentation and API reference.
+
 In addition, there is special compile time support for the [P-ROC](http://www.pinballcontrollers.com),
 to drive (at least) real WPC machines with PinMAME/P-ROC, [PPUC](https://github.com/PPUC) and LISY
 (Linux for Gottlieb System1 & System80, Bally, Atari, Williams and 'HOme' Pinballs, to drive real pinball machines via
@@ -155,3 +157,45 @@ For more information, please refer to [simulation.txt](release/simulation.txt) f
 # Note from the PinMAME Development team
 
 We're working hard to improve this great emulator, and welcome your feedback!! Please do not hesitate to contact us with questions, bug reports, suggestions, code patches, whatever!
+
+## Remote Debugger & Headless Mode
+
+This version of PinMAME includes a powerful **Remote Debugger** extension designed for deep hardware reversing and headless operation (e.g., in Docker or CI environments).
+
+### Key Features
+- **Headless Execution**: Run PinMAME without X11/SDL windows using the `-headless` flag.
+- **REST API**: Control every aspect of the emulator via a thread-safe HTTP interface.
+- **Web Dashboard**: Modern, low-latency UI for live DMD rendering, memory editing, and disassembling.
+- **WPC Specialization**: Real-time visualization of Lamp, Switch, and Solenoid matrices, including WPC ROM banking.
+- **Classic CLI**: Support for MAME-style debugger commands (`BP`, `WP`, `G`, `S`, etc.) via the web console.
+
+### Building
+To build with the Remote Debugger extension:
+```bash
+make -f makefile.unix REMOTE_DEBUG=1
+```
+
+### Usage
+Start PinMAME in headless mode with the debugger active:
+```bash
+./xpinmamed.x11 -headless -startpaused -httpport 8935 taf_l7
+```
+- `-headless`: Disables video/input windows.
+- `-startpaused`: Halts the CPU at the first instruction.
+- `-httpport <port>`: Sets the API/UI port (default: 8935).
+
+### Advanced Features
+- **Memory Search**: High-speed hex pattern matching via the UI or `GET /api/debugger/memory/find`.
+- **Cabinet & Service Panel**: Interactive buttons for COIN, START, and Service functions (+, -, ESC, ENT) with real-time feedback.
+- **Immediate Execution Halt**: Breakpoints and watchpoints now trigger an instant CPU abort for precise instruction-level debugging.
+- **WPC Matrix Visualizer**: Live 8x8 grids for Lamps and Switches, plus 32-bit Solenoid tracking.
+
+### Verification
+A comprehensive test suite is included to verify all API and core debugger features. To run the tests:
+```bash
+cd src/remote_debug
+./test_suite.sh
+```
+
+### Usage
+See src/remote/debug/README.md

--- a/makefile.unix
+++ b/makefile.unix
@@ -76,8 +76,13 @@ TARGET = pinmame
 # this will also select 'vid_lisy' as DISPLAY_METHOD
 # LISY_X_FAKE_VIDEO = 1
 
+# uncomment next line to include the HTTP remote debugger (src/remote_debug).
+# Its disassembly endpoint also needs the built-in MAME debugger, so enable
+# DEBUG as well, e.g.:  make -f makefile.unix REMOTE_DEBUG=1 DEBUG=1
+# REMOTE_DEBUG = 1
+
 ###########################################################################
-# Development environment options 
+# Development environment options
 ###########################################################################
 
 # GNU make is MANDATORY!!!
@@ -784,6 +789,10 @@ ifdef LISY_X_FAKE_VIDEO
 CFLAGS += -DLISY_VIDEO
 endif
 
+
+ifdef REMOTE_DEBUG
+CFLAGS += -DREMOTE_DEBUG
+endif
 
 ###########################################################################
 # All done.  Type make -f makefile.unix and enjoy xmame/xmess.  ;)

--- a/src/cpu/m6809/6809ops.c
+++ b/src/cpu/m6809/6809ops.c
@@ -204,6 +204,7 @@ INLINE void lbra( void )
 INLINE void lbsr( void )
 {
 	IMMWORD(ea);
+	DEBUG_PUSH_CALL(PPC, PC + EA);
 	PUSHWORD(pPC);
 	PC += EA;
 	CHANGE_PC;
@@ -621,7 +622,7 @@ INLINE void puls( void )
 	if( t&0x10 ) { PULLWORD(XD); m6809_ICount -= 2; }
 	if( t&0x20 ) { PULLWORD(YD); m6809_ICount -= 2; }
 	if( t&0x40 ) { PULLWORD(UD); m6809_ICount -= 2; }
-	if( t&0x80 ) { PULLWORD(PCD); CHANGE_PC; m6809_ICount -= 2; }
+	if( t&0x80 ) { DEBUG_POP_CALL(); PULLWORD(PCD); CHANGE_PC; m6809_ICount -= 2; }
 
 	/* HJB 990225: moved check after all PULLs */
 	if( t&0x01 ) { CHECK_IRQ_LINES; }
@@ -654,7 +655,7 @@ INLINE void pulu( void )
 	if( t&0x10 ) { PULUWORD(XD); m6809_ICount -= 2; }
 	if( t&0x20 ) { PULUWORD(YD); m6809_ICount -= 2; }
 	if( t&0x40 ) { PULUWORD(SD); m6809_ICount -= 2; }
-	if( t&0x80 ) { PULUWORD(PCD); CHANGE_PC; m6809_ICount -= 2; }
+	if( t&0x80 ) { DEBUG_POP_CALL(); PULUWORD(PCD); CHANGE_PC; m6809_ICount -= 2; }
 
 	/* HJB 990225: moved check after all PULLs */
 	if( t&0x01 ) { CHECK_IRQ_LINES; }
@@ -665,6 +666,7 @@ INLINE void pulu( void )
 /* $39 RTS inherent ----- */
 INLINE void rts( void )
 {
+	DEBUG_POP_CALL();
 	PULLWORD(PCD);
 	CHANGE_PC;
 }
@@ -679,6 +681,7 @@ INLINE void abx( void )
 INLINE void rti( void )
 {
 	UINT8 t;
+	DEBUG_POP_CALL();
 	PULLBYTE(CC);
 	t = CC & CC_E;		/* HJB 990225: entire state saved? */
 	if(t)
@@ -737,6 +740,7 @@ INLINE void mul( void )
 /* $3F SWI (SWI2 SWI3) absolute indirect ----- */
 INLINE void swi( void )
 {
+	DEBUG_PUSH_CALL(PPC, RM16(0xfffa));
 	CC |= CC_E; 			/* HJB 980225: save entire state */
 	PUSHWORD(pPC);
 	PUSHWORD(pU);
@@ -754,6 +758,7 @@ INLINE void swi( void )
 /* $103F SWI2 absolute indirect ----- */
 INLINE void swi2( void )
 {
+	DEBUG_PUSH_CALL(PPC, RM16(0xfff4));
 	CC |= CC_E; 			/* HJB 980225: save entire state */
 	PUSHWORD(pPC);
 	PUSHWORD(pU);
@@ -770,6 +775,7 @@ INLINE void swi2( void )
 /* $113F SWI3 absolute indirect ----- */
 INLINE void swi3( void )
 {
+	DEBUG_PUSH_CALL(PPC, RM16(0xfff2));
 	CC |= CC_E; 			/* HJB 980225: save entire state */
 	PUSHWORD(pPC);
 	PUSHWORD(pU);
@@ -1452,6 +1458,7 @@ INLINE void bsr( void )
 {
 	UINT8 t;
 	IMMBYTE(t);
+	DEBUG_PUSH_CALL(PPC, PC + SIGNED(t));
 	PUSHWORD(pPC);
 	PC += SIGNED(t);
 	CHANGE_PC;
@@ -1683,6 +1690,7 @@ INLINE void cmps_di( void )
 INLINE void jsr_di( void )
 {
 	DIRECT;
+	DEBUG_PUSH_CALL(PPC, EAD);
 	PUSHWORD(pPC);
 	PCD = EAD;
 	CHANGE_PC;
@@ -1920,6 +1928,7 @@ INLINE void cmps_ix( void )
 INLINE void jsr_ix( void )
 {
 	fetch_effective_address();
+	DEBUG_PUSH_CALL(PPC, EAD);
     PUSHWORD(pPC);
 	PCD = EAD;
 	CHANGE_PC;
@@ -2150,6 +2159,7 @@ INLINE void cmps_ex( void )
 INLINE void jsr_ex( void )
 {
 	EXTENDED;
+	DEBUG_PUSH_CALL(PPC, EA);
 	PUSHWORD(pPC);
 	PCD = EAD;
 	CHANGE_PC;

--- a/src/cpu/m6809/m6809.c
+++ b/src/cpu/m6809/m6809.c
@@ -204,6 +204,7 @@ static PAIR ea;         /* effective address */
 			m6809.extra_cycles += 10;	/* subtract +10 cycles */		\
 		}																\
 		CC |= CC_IF | CC_II;			/* inhibit FIRQ and IRQ */		\
+		DEBUG_PUSH_CALL(PC, RM16(0xfff6));								\
 		PCD=RM16(0xfff6);												\
 		CHANGE_PC;														\
 		(void)(*m6809.irq_callback)(M6809_FIRQ_LINE);					\
@@ -232,6 +233,7 @@ static PAIR ea;         /* effective address */
 			m6809.extra_cycles += 19;	 /* subtract +19 cycles */		\
 		}																\
 		CC |= CC_II;					/* inhibit IRQ */				\
+		DEBUG_PUSH_CALL(PC, RM16(0xfff8));								\
 		PCD=RM16(0xfff8);												\
 		CHANGE_PC;														\
 		(void)(*m6809.irq_callback)(M6809_IRQ_LINE);					\
@@ -482,7 +484,14 @@ void m6809_set_reg(int regnum, unsigned val)
 	switch( regnum )
 	{
 		case REG_PC:
-		case M6809_PC: PC = val; CHANGE_PC; break;
+		case M6809_PC:
+			PC = val;
+			CHANGE_PC;
+#ifdef REMOTE_DEBUG
+			/* Wake up CPU from SYNC/CWAI wait states so debugger can force execution from new PC */
+			m6809.int_state &= ~(M6809_CWAI | M6809_SYNC);
+#endif
+			break;
 		case REG_SP:
 		case M6809_S: S = val; break;
 		case M6809_CC: CC = val; CHECK_IRQ_LINES; break;
@@ -530,6 +539,7 @@ void m6809_init(void)
 
 void m6809_reset(void *param)
 {
+	DEBUG_RESET_CALLSTACK();
 	m6809.int_state = 0;
 	m6809.nmi_state = CLEAR_LINE;
 	m6809.irq_state[0] = CLEAR_LINE;
@@ -585,6 +595,7 @@ void m6809_set_irq_line(int irqline, int state)
 			PUSHBYTE(CC);
 			m6809.extra_cycles += 19;	/* subtract +19 cycles next time */
 		}
+		DEBUG_PUSH_CALL(PC, RM16(0xfffc));
 		CC |= CC_IF | CC_II;			/* inhibit FIRQ and IRQ */
 		PCD = RM16(0xfffc);
 		CHANGE_PC;

--- a/src/cpu/m6809/m6809.h
+++ b/src/cpu/m6809/m6809.h
@@ -12,6 +12,17 @@ enum {
 #define M6809_IRQ_LINE	0	/* IRQ line number */
 #define M6809_FIRQ_LINE 1   /* FIRQ line number */
 
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#define DEBUG_PUSH_CALL(caller, receiver) remote_debug_push_call(caller, receiver)
+#define DEBUG_POP_CALL() remote_debug_pop_call()
+#define DEBUG_RESET_CALLSTACK() remote_debug_reset_callstack()
+#else
+#define DEBUG_PUSH_CALL(caller, receiver)
+#define DEBUG_POP_CALL()
+#define DEBUG_RESET_CALLSTACK()
+#endif
+
 /* PUBLIC GLOBALS */
 extern int  m6809_ICount;
 

--- a/src/cpuexec.c
+++ b/src/cpuexec.c
@@ -8,6 +8,7 @@
 
 #include <math.h>
 #include <assert.h>
+#include <unistd.h>
 
 #include "driver.h"
 #include "timer.h"
@@ -15,6 +16,10 @@
 #include "video.h"
 #include "mamedbg.h"
 #include "hiscore.h"
+
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#endif
 
 #if (HAS_M68000 || HAS_M68010 || HAS_M68020 || HAS_M68EC020)
 #include "cpu/m68000/m68000.h"
@@ -424,12 +429,23 @@ void cpu_run(void)
 		{
 			profiler_mark(PROFILER_EXTRA);
 
+#ifdef REMOTE_DEBUG
+			/* Tiny gap to allow HTTP thread to grab the lock */
+			usleep(1); 
+#endif
+
 			/* if we have a load/save scheduled, handle it */
 			if (loadsave_schedule != LOADSAVE_NONE)
 				handle_loadsave();
 			
 			/* execute CPUs */
+#ifdef REMOTE_DEBUG
+			remote_debug_lock();
+#endif
 			cpu_timeslice();
+#ifdef REMOTE_DEBUG
+			remote_debug_unlock();
+#endif
 
 #if defined(LIBPINMAME)
          extern int libpinmame_time_to_quit(void);
@@ -977,6 +993,25 @@ void time_fence_exit()
 
 static void cpu_timeslice(void)
 {
+#ifdef REMOTE_DEBUG
+	if (remote_debug_should_quit()) {
+		time_to_quit = 1;
+		return;
+	}
+	if (remote_debug_is_paused())
+	{
+		/* Yield while paused to allow HTTP thread to work */
+		remote_debug_unlock();
+		while (remote_debug_is_paused() && !remote_debug_should_quit()) {
+			usleep(10000);
+		}
+		remote_debug_lock();
+		if (remote_debug_should_quit()) {
+			time_to_quit = 1;
+			return;
+		}
+	}
+#endif
 #if defined(VPINMAME)
 	// Continuously pump message loop, otherwise it creates stutters between COM server and client (VPinMAME locks VPX scripts until message are processed)
 	// It also causes a deadlock if using a TimeFence since messages are normally processed by a CPU callback that may not happen depending on the TimeFence.

--- a/src/driver.h
+++ b/src/driver.h
@@ -95,6 +95,11 @@ typedef struct {
 #ifdef PINMAME_HOST_UART
   char *serial_device;         /* COM or /dev/tty mapped to WPC95 UART */
 #endif
+#ifdef REMOTE_DEBUG
+  int headless;                /* Run without display */
+  int http_port;               /* HTTP server port */
+  int start_paused;            /* Start emulator in paused state */
+#endif
 } tPMoptions;
 extern tPMoptions pmoptions;
 struct pinMachine {

--- a/src/mame.c
+++ b/src/mame.c
@@ -118,6 +118,9 @@
 #if defined(PINMAME) && defined(PROC_SUPPORT)
 #include "p-roc/p-roc.h"
 #endif /* PINMAME && PROC_SUPPORT */
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#endif
 #if defined(PINMAME) && defined(LISY_SUPPORT)
  #include "lisy/utils.h"
 #endif /* PINMAME && LISY_SUPPORT */
@@ -330,6 +333,9 @@ int run_game(int game)
 			bail_and_print("Unable to initialize machine emulation");
 		else
 		{
+#ifdef REMOTE_DEBUG
+			remote_debug_init();
+#endif
 			/* then run it */
 			if (run_machine())
 				bail_and_print("Unable to start machine emulation");
@@ -587,6 +593,10 @@ void run_machine_core(void)
 
 				/* run the emulation! */
 				cpu_run();
+
+#ifdef REMOTE_DEBUG
+				remote_debug_exit();
+#endif
 
 				/* save the NVRAM */
 				if (Machine->drv->nvram_handler)
@@ -1156,6 +1166,9 @@ void draw_screen(void)
 
 void update_video_and_audio(void)
 {
+#ifdef REMOTE_DEBUG
+	if (remote_debug_should_quit()) return;
+#endif
 	int skipped_it = osd_skip_this_frame();
 
 #ifdef MAME_DEBUG
@@ -1254,6 +1267,10 @@ static void recompute_fps(int skipped_it)
 
 int updatescreen(void)
 {
+#ifdef REMOTE_DEBUG
+	if (remote_debug_should_quit())
+		return 1;
+#endif
 	/* update sound */
 	sound_update();
 

--- a/src/mamedbg.h
+++ b/src/mamedbg.h
@@ -109,7 +109,14 @@ extern int debug_trace_delay;	/* set to 0 to force a screen update */
  * if MAME_DEBUG is not specified, so a CPU core can simply add
  * CALL_MAME_DEBUG; before executing an instruction
  ***************************************************************************/
-#define CALL_MAME_DEBUG if( mame_debug ) MAME_Debug()
+#ifdef REMOTE_DEBUG
+extern void remote_debug_breakpoint_hook(void);
+#define REMOTE_DEBUG_HOOK remote_debug_breakpoint_hook()
+#else
+#define REMOTE_DEBUG_HOOK
+#endif
+
+#define CALL_MAME_DEBUG { REMOTE_DEBUG_HOOK; if( mame_debug ) MAME_Debug(); }
 
 #ifndef DECL_SPEC
 #define DECL_SPEC
@@ -137,7 +144,12 @@ void dbg_put_screen_char (int ch, int attr, int x, int y);
 
 #else	/* MAME_DEBUG */
 
+#ifdef REMOTE_DEBUG
+extern void remote_debug_breakpoint_hook(void);
+#define CALL_MAME_DEBUG remote_debug_breakpoint_hook()
+#else
 #define CALL_MAME_DEBUG
+#endif
 #define debugger_idle 0
 
 #endif  /* !MAME_DEBUG */

--- a/src/memory.c
+++ b/src/memory.c
@@ -1811,6 +1811,12 @@ extern void bpr_memref(UINT32 adr, int length);
 #define bpr_memref(a,l)
 #endif
 
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#else
+#define remote_debug_memref(a,l,w)
+#endif
+
 #define READBYTE8(name,abits,lookup,handlist,mask)										\
 data8_t name(offs_t address)															\
 {																						\
@@ -1818,7 +1824,7 @@ data8_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,0)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,0)];							\
@@ -1844,7 +1850,7 @@ data8_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -1871,7 +1877,7 @@ data8_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -1898,7 +1904,7 @@ data8_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -1925,7 +1931,7 @@ data8_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -1958,7 +1964,7 @@ data16_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -1984,7 +1990,7 @@ data16_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2011,7 +2017,7 @@ data16_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2044,7 +2050,7 @@ data32_t name(offs_t address)															\
 	MEMREADSTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~3;bpr_memref(address,4);																	\
+	address &= mask & ~3;bpr_memref(address,4);remote_debug_memref(address,4,0);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2075,7 +2081,7 @@ void name(offs_t address, data8_t data)													\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,0)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,0)];							\
@@ -2100,7 +2106,7 @@ void name(offs_t address, data8_t data)													\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -2126,7 +2132,7 @@ void name(offs_t address, data8_t data)													\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -2152,7 +2158,7 @@ void name(offs_t address, data8_t data)													\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2178,7 +2184,7 @@ void name(offs_t address, data8_t data)													\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask;bpr_memref(address,1);																	\
+	address &= mask;bpr_memref(address,1);remote_debug_memref(address,1,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2210,7 +2216,7 @@ void name(offs_t address, data16_t data)												\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,1)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,1)];							\
@@ -2235,7 +2241,7 @@ void name(offs_t address, data16_t data)												\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2261,7 +2267,7 @@ void name(offs_t address, data16_t data)												\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~1;bpr_memref(address,2);																	\
+	address &= mask & ~1;bpr_memref(address,2);remote_debug_memref(address,2,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\
@@ -2293,7 +2299,7 @@ void name(offs_t address, data32_t data)												\
 	MEMWRITESTART																		\
 																						\
 	/* perform lookup */																\
-	address &= mask & ~3;bpr_memref(address,4);																	\
+	address &= mask & ~3;bpr_memref(address,4);remote_debug_memref(address,4,1);																	\
 	entry = lookup[LEVEL1_INDEX(address,abits,2)];										\
 	if (entry >= SUBTABLE_BASE)															\
 		entry = lookup[LEVEL2_INDEX(entry,address,abits,2)];							\

--- a/src/pinmame.mak
+++ b/src/pinmame.mak
@@ -23,6 +23,19 @@ DRVLIBS += $(PINOBJ)/sndbrd.o $(PINOBJ)/bulb.o
 DRVLIBS += $(OBJ)/machine/4094.o
 DRVLIBS += $(OBJ)/sound/wavwrite.o
 
+ifdef REMOTE_DEBUG
+DRVLIBS += $(OBJ)/remote_debug/remote_debug.o $(OBJ)/remote_debug/http_server.o $(OBJ)/remote_debug/api_handler.o
+
+# The remote debugger sources must compile without warnings; enforce this
+# for these objects only. Project include dirs are turned into system
+# include dirs so that legacy core headers do not trigger warnings here.
+REMOTE_DEBUG_CFLAGS = -std=gnu99 -Wall -Wextra -Wunused -pedantic
+
+$(OBJ)/remote_debug/%.o: src/remote_debug/%.c
+	$(CC_COMMENT) @echo 'Compiling $< (strict) ...'
+	$(CC_COMPILE) $(CC) $(patsubst -I%,-isystem%,$(MY_CFLAGS)) $(REMOTE_DEBUG_CFLAGS) -o $@ -c $<
+endif
+
 COREOBJS += $(PINOBJ)/driver.o $(OBJ)/cheat.o $(PINOBJ)/mech.o
 
 # taken from MESS

--- a/src/remote_debug/README.md
+++ b/src/remote_debug/README.md
@@ -1,0 +1,528 @@
+# PinMAME Remote Debugger
+
+A thread-safe remote debugging extension for PinMAME with a web-based
+dashboard and REST API. Designed to be minimally invasive: all changes to
+existing PinMAME sources are guarded by `#ifdef REMOTE_DEBUG`; without that
+define the build is identical to upstream.
+
+Developed and tested against **Williams WPC**, but most features are
+platform-generic and work across PinMAME's other pinball systems to varying
+degrees — see [Platform Support](#platform-support).
+
+## Features
+- **Headless Operation**: run without X11 via `-headless` (server/CI/reverse
+  engineering setups); the debugger is the only frontend.
+- **Thread Safety**: the emulator thread holds a recursive lock for each CPU
+  timeslice; the HTTP thread takes the same lock around all machine access.
+- **REST API** with proper HTTP status codes (400/404/500/503 on errors) and
+  a self-describing reference at `/api/doc`.
+- **Push events (SSE)**: `GET /api/events` streams halt/resume/step/message
+  events; the web UI uses it and falls back to polling automatically.
+- **High-Fidelity Rendering**:
+  - Full DMD support (128x32 raw frame capture).
+  - Hardware-accurate Williams 16-segment alphanumeric starburst rendering.
+- **Matrix Visualizer**: live lamps, switches, solenoids, dedicated inputs.
+- **Interactive Inputs**: pulse cabinet buttons and toggle matrix switches.
+- **Advanced Debugging**:
+  - Bank-aware disassembler incl. **backwards disassembly** (`before=N`).
+  - Callstack tracking with full register context and ROM bank.
+  - Banked, **conditional** breakpoints (`cond=A==FF`) with hit/ignore counts.
+  - Watchpoints covering a **byte range** (R/W/RW), optionally with a
+    **value condition** (halt only when the byte reaches a value).
+  - Step Into / **Step Over** / **Step Out** / Run-To.
+  - Memory hex editor, pattern search, block fill, **block write**
+    (`data=DEADBEEF`). Debugger writes bypass the WPC RAM write protection.
+  - **Memory access trace**: log every access to selected addresses.
+  - **Code instrumentation**: count how often execution passes marked
+    addresses (bank-aware PC hit counting).
+  - **Execution trace**: ring buffer of the last N executed instructions
+    (PC/bank/regs) — "how did I get here" after a halt.
+  - **Code coverage**: record which addresses executed (per bank); the web
+    UI can highlight covered lines in the disassembler.
+  - **Tracepoints**: log a register snapshot every time PC hits an address
+    and keep running (non-intrusive tracing).
+  - **Value scan**: cheat-engine style variable search (snapshot + filter
+    changed/unchanged/inc/dec/equals).
+  - **Save states**: lightweight in-memory checkpoints of WPC RAM + main
+    CPU registers (save/load reliably, also while paused).
+  - **DMD recorder**: capture a sequence of DMD frames and replay them.
+  - NVRAM management (dump/clear).
+- **Playfield objects**:
+  - Named switch / lamp / solenoid enumeration (`/api/switches`,
+    `/api/lamps`, `/api/solenoids`) using the WPC switch numbering
+    (`col*10 + row + 1`) plus standard dedicated names.
+  - Timed switch **pulses** (hold for N ms, wall clock).
+  - **Object monitoring**: watch selected lamps/solenoids/switches and
+    retrieve a timestamped action log of their state changes, optionally
+    **halting** the emulator when a watched object changes.
+
+## Setup & Build
+1. `REMOTE_DEBUG = 1` is set near the top of `makefile.unix` (fork default).
+   `DEBUG = 1` stays enabled as well: the disassembler endpoint needs
+   `MAME_DEBUG` for real 6809 disassembly (without it only byte dumps are
+   returned) and it names the binary `xpinmamed.*`.
+2. Build: `make -f makefile.unix`.
+3. Run: `./xpinmamed.x11 -headless -startpaused -httpport 8926 -nosound -rompath <dir> <romname>`
+4. Open the dashboard: `http://localhost:8926/ui`.
+
+Command line options added by the debugger (see `src/unix/config.c`):
+`-headless`/`-hl`, `-httpport <port>`/`-hp` (default 8080), `-startpaused`/`-sp`.
+
+### Code quality
+The `src/remote_debug` objects are compiled with
+`-std=gnu99 -Wall -Wextra -Wunused -pedantic -Werror` (see `src/pinmame.mak`);
+the build fails on any warning in this directory. Core PinMAME headers are
+included as system headers for these objects so legacy-code warnings do not
+leak in.
+
+## Usage Examples
+
+All examples assume the emulator is running headless on port 8926:
+
+```sh
+./xpinmamed.x11 -headless -startpaused -httpport 8926 -nosound \
+    -rompath ~/.pinmame taf_l7 &
+BASE=http://localhost:8926
+```
+
+**Inspect and step the CPU while halted**
+```sh
+curl -s "$BASE/api/debugger/control?cmd=pause"
+curl -s "$BASE/api/debugger/state"                     # registers of all CPUs
+curl -s "$BASE/api/debugger/dasm?addr=8000&lines=8&before=2"
+curl -s "$BASE/api/debugger/control?cmd=step"          # step, then re-read state
+curl -s "$BASE/api/debugger/state/write?reg=A&val=7F"  # poke accumulator A
+```
+
+**Break on an address (bank-aware) and watch for the hit via SSE**
+```sh
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=8CC1"      # any bank
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=6000&bank=3E"  # bank 3E only
+curl -s "$BASE/api/debugger/control?cmd=resume"
+curl -sN "$BASE/api/events"      # streams {"event":"halt","reason":"bp",...}
+```
+
+**Conditional breakpoint (halt only when X > 0x1000, after 5 hits)**
+```sh
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=9000&cond=X>1000&ignore=5"
+```
+
+**Find a variable in RAM (value-scan / cheat-engine workflow)**
+```sh
+curl -s "$BASE/api/debugger/scan?cmd=new&addr=0000&size=8192"   # snapshot RAM
+# ... do something in game that changes the value ...
+curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed"         # keep changed bytes
+# ... change it again ...
+curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed"         # narrow further
+curl -s "$BASE/api/debugger/scan"                               # remaining candidates
+```
+
+**Count how often a routine runs (code instrumentation)**
+```sh
+curl -s "$BASE/api/debugger/instrument?cmd=add&addr=A2F0"
+curl -s "$BASE/api/debugger/control?cmd=resume"; sleep 5
+curl -s "$BASE/api/debugger/instrument"        # [{"addr":41712,"bank":-1,"count":137}]
+```
+
+**Monitor objects and read the action log**
+```sh
+curl -s "$BASE/api/monitor?cmd=add&type=lamp&id=11"    # watch lamp 11
+curl -s "$BASE/api/monitor?cmd=add&type=sol&id=5"      # watch solenoid 5
+curl -s "$BASE/api/monitor/log"    # [{"type":"lamp","id":11,"val":1,"t":48213}, ...]
+```
+
+**Inject switches (pulse a coin, toggle a target)**
+```sh
+curl -s "$BASE/api/switches"                       # list with numbers + names
+curl -s "$BASE/api/input?sw=1&val=1&pulse=150"     # pulse Coin 1 for 150 ms
+curl -s "$BASE/api/input?sw=57&val=1"              # hold switch 57 on
+```
+
+**Checkpoint the game state, poke around, restore it**
+```sh
+curl -s "$BASE/api/debugger/savestate?cmd=save&slot=before"
+curl -s "$BASE/api/debugger/memory/write?addr=0500&data=00000000"
+curl -s "$BASE/api/debugger/savestate?cmd=load&slot=before"   # RAM + CPU restored
+```
+
+**Record and download DMD frames**
+```sh
+curl -s "$BASE/api/debugger/dmdrec?cmd=start"
+curl -s "$BASE/api/debugger/control?cmd=resume"; sleep 3
+curl -s "$BASE/api/debugger/dmdrec?cmd=stop"          # {"count":180,...}
+curl -s "$BASE/api/debugger/dmdrec/data" -o dmd.bin   # packed binary frames
+```
+
+**Dump / clear NVRAM (WPC)**
+```sh
+curl -s "$BASE/api/debugger/nvram/dump" -o nvram.bin
+curl -s "$BASE/api/debugger/nvram?cmd=clear"
+```
+
+See `test_suite.sh` for an end-to-end script exercising every endpoint, and
+`find_nvram_coins.sh` for a complete reverse-engineering example (locating
+the coin/credit counters in CMOS with the value scan — insert coins and
+alternate `inc`/`unchanged` filters to drop the RTC noise).
+
+## API Reference
+
+Everything is `GET`. Parameter conventions:
+
+| Parameters | Base |
+|------------|------|
+| `addr`, `val`, `bank`, `pattern`, `data`, `cond` values | hexadecimal, `0x`/`$` prefix optional |
+| `size`, `lines`, `before`, `cpu`, `sw`, `idx`, `len`, `mode`, `ignore` | decimal |
+
+The live reference is served at `GET /api/doc`.
+
+### ROM banking and the `bank` parameter
+
+WPC memory is laid out as:
+
+| CPU address range | Contents | Banked? |
+|---|---|---|
+| `0x0000`-`0x3FFF` | RAM / ASIC I/O | no |
+| `0x4000`-`0x7FFF` | paged ROM (16 KB window) | **yes** |
+| `0x8000`-`0xFFFF` | fixed "prime" ROM | no |
+
+Only the `0x4000`-`0x7FFF` window is bank-switched, so the `bank` parameter
+is only meaningful for addresses in that range. For RAM/ASIC (`0x0000`-
+`0x3FFF`) and prime ROM (`0x8000`-`0xFFFF`) you do **not** pass a bank; if
+you do, it is ignored (those addresses are the same in every bank).
+
+`bank` is always **hexadecimal** (e.g. `bank=1E`, `bank=0x20`). Omitting it
+(or passing `-1`) means "current bank" for reads, and "any bank" for
+break/watch/trace points (they match regardless of which bank is paged in
+when the address is hit).
+
+Address-based endpoints and their `bank` support:
+
+| Endpoint | `bank`? | Meaning |
+|---|---|---|
+| `breakpoints` (add) | yes | halt at addr only when this bank is paged in |
+| `watchpoints` (add) | yes | trigger only when this bank is paged in |
+| `control/runto` | yes | temporary breakpoint honoring the bank |
+| `instrument` (add) | yes | count only hits in this bank |
+| `trace` (add) | yes | log accesses only in this bank |
+| `dasm` | yes | disassemble that bank mapped into the window |
+| `memory` (read) | yes | read the window from that ROM bank (side-effect free) |
+| `memory/find` | yes | search within that ROM bank |
+| `memory/write`, `memory/fill` | no | writes target RAM/ASIC, which is unbanked |
+| `scan` | no | value search operates on RAM, which is unbanked |
+
+Example — set a breakpoint at `0x5120` only while ROM bank `0x20` is active
+(vs. an all-banks breakpoint):
+
+```sh
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=5120&bank=20"   # bank 0x20 only
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=5120"           # any bank
+```
+
+On non-WPC platforms there is no banking; the `bank` parameter is accepted
+but ignored (reads always go through the current memory map).
+
+### System Info & Captures
+- `GET /api/info`: JSON with game status, lamps, switches, segments, solenoids.
+- `GET /api/events`: Server-Sent-Events stream. Each event is a JSON object:
+  `{"event": "halt"|"resume"|"step"|"message"|"quit", ...}` with context
+  fields (`reason`, `pc`, `bank`, `text`) where applicable.
+- `GET /ui`: serves the web dashboard (HTML).
+
+#### DMD
+- `GET /api/dmd/info`: `{width, height}`.
+- `GET /api/dmd/raw`: raw frame, 1 luminance byte per pixel.
+- `GET /api/dmd/pnm`: PGM (P5) image.
+
+#### Screenshot
+- `GET /api/screenshot/info`: `{width, height}`.
+- `GET /api/screenshot/raw`: raw RGB24.
+- `GET /api/screenshot/pnm` (alias `/api/screenshot`): PPM (P6) image.
+
+### Debugger Control
+- `GET /api/debugger/control?cmd=[pause|resume|step|stepover|stepout|exit]`
+- `GET /api/debugger/control/runto?addr=HEX[&bank=HEX]`
+- `GET /api/debugger/state`: registers/flags of all CPUs.
+- `GET /api/debugger/state/write?reg=[NAME|ID]&val=HEX[&cpu=N]`:
+  set a register. M6809 names (PC,S/SP,CC,A,B,U,X,Y,DP) and ADSP2100 names
+  (PC,AX0..,MR0..,CNTR,ASTAT,...) are resolved per CPU type.
+- `GET /api/debugger/dasm?addr=HEX[&lines=N][&before=N][&cpu=N][&bank=HEX]`:
+  JSON disassembly. `before=N` prepends up to N instructions *before* `addr`
+  (heuristic backtracking). `bank` temporarily maps that WPC ROM bank.
+- `GET /api/debugger/messages`: message log.
+- `GET /api/debugger/callstack`: list of `{caller, receiver, bank, pc(=return
+  address), u, s, x, y, a, b, dp, cc}`.
+
+### Points (Breakpoints & Watchpoints)
+- `GET /api/debugger/points`: JSON list of all BPs and WPs, including
+  `cond`, `hits`, `ignore`, `temp` (BP) and `len` (WP).
+- `GET /api/debugger/points?cmd=[toggle|delete]&type=[bp|wp]&idx=N`
+- `GET /api/debugger/breakpoints?cmd=add&addr=HEX[&bank=HEX][&cond=EXPR][&ignore=N]`:
+  `EXPR` compares an M6809 register with a hex constant using
+  `==`, `!=`, `<`, `>`, `<=`, `>=` (e.g. `cond=A==7F`, `cond=X>1000`).
+  `ignore=N` skips the first N (condition-true) hits.
+- `GET /api/debugger/breakpoints?cmd=clear`
+- `GET /api/debugger/watchpoints?cmd=add&addr=HEX[&len=N][&mode=1|2|3][&bank=HEX][&cond=eq|ne|lt|gt|le|ge&val=HEX]`:
+  watch `len` bytes (default 1); mode 1=read, 2=write, 3=both;
+  `bank` restricts to that ROM bank (0x4000-0x7FFF only). With `cond`+`val`
+  the watchpoint only halts when the byte at `addr` satisfies the comparison
+  (e.g. `mode=2&cond=eq&val=05` = "break on the write that sets it to 5").
+  Note: debugger writes go straight to RAM and do not trigger watchpoints —
+  only the emulated CPU's own accesses do.
+- `GET /api/debugger/watchpoints?cmd=clear`
+
+### Memory, Trace & NVRAM
+- `GET /api/debugger/memory?addr=HEX[&size=N][&cpu=N][&bank=HEX]`: read
+  (max 2048 bytes); `bank` reads the 0x4000-0x7FFF window from that ROM bank.
+- `GET /api/debugger/memory/write?addr=HEX&val=HEX[&cpu=N]`: write one byte.
+- `GET /api/debugger/memory/write?addr=HEX&data=HEXBYTES[&cpu=N]`: block write
+  (e.g. `data=DEADBEEF`, max 256 bytes).
+- `GET /api/debugger/memory/fill?addr=HEX&size=N&val=HEX[&cpu=N]`
+- `memory/write` and `memory/fill` take **no** `bank` — their targets are
+  RAM/ASIC (`0x0000`-`0x3FFF`), which is unbanked, and the banked window is
+  read-only ROM.
+- `GET /api/debugger/memory/find?pattern=HEXBYTES[&addr=HEX][&size=N][&cpu=N][&bank=HEX]`
+  (`bank` searches within that ROM bank)
+- Note: debugger writes into the WPC RAM range go directly to RAM and are
+  **not** blocked by the WPC memory protection hardware simulation.
+- `GET /api/debugger/trace?cmd=add&addr=HEX[&bank=HEX]`: trace accesses to an
+  address (`bank` restricts to that ROM bank).
+- `GET /api/debugger/trace?cmd=clear` / `GET /api/debugger/trace`: clear /
+  list `{watched: [{addr, bank}, ...], logs: [{cpu, pc, adr, len, write, bank}, ...]}`.
+- `GET /api/debugger/nvram/dump`: raw 8KB WPC CMOS dump.
+- `GET /api/debugger/nvram?cmd=clear`: wipe NVRAM (machine reset required to
+  reinitialize).
+
+### Playfield Objects
+Switches, lamps and solenoids use the WPC number `col*10 + row + 1`
+(matrix 11-88; coin-door column 1-8; flipper column 111-118).
+- `GET /api/switches`: all switches as `{num, col, row, active, name}`.
+  Names are the WPC standard dedicated/cabinet names where known.
+- `GET /api/lamps`: all lamps as `{num, col, row, active}`.
+- `GET /api/solenoids`: all solenoids as `{num, active}`.
+
+Note: the coin-door column (switches 1-8) is refreshed from the emulated
+input port every frame, so a plain level set only persists while the game
+runs when re-asserted — use a pulse for coins.
+
+### Object Monitoring
+- `GET /api/monitor?cmd=add&type=[sw|lamp|sol]&id=N[&break=1]`: watch an
+  object; with `break=1` the emulator is paused on the next frame after the
+  object changes (frame-granular — to pin the exact writing instruction, use
+  a write watchpoint on the underlying I/O register instead).
+- `GET /api/monitor?cmd=clear` / `GET /api/monitor`: clear / list monitors.
+- `GET /api/monitor/log`: timestamped action log
+  `{actions: [{type, id, val, t(ms)}, ...]}`; `?cmd=clear` resets it.
+  State changes are also pushed as `{"event": "action", ...}` SSE events;
+  a break also pushes `{"event": "halt", "reason": "monitor", ...}`.
+
+### Execution Trace
+Ring buffer of the most recently executed instructions — fetch it after a
+halt to see how execution got there.
+- `GET /api/debugger/exectrace?cmd=[start|stop|clear]`
+- `GET /api/debugger/exectrace`: `{enabled, count, capacity, trace: [{pc,
+  bank, a, b, x}, ...]}` (oldest to newest; capacity 8192).
+
+### Code Coverage
+Record which addresses executed. Banked-window code (0x4000-0x7FFF) is
+tracked per bank so different banks are not conflated.
+- `GET /api/debugger/coverage?cmd=[start|stop|clear]`
+- `GET /api/debugger/coverage`: `{enabled, executed, addressable}`.
+- `GET /api/debugger/coverage?addr=HEX[&size=N][&bank=HEX]`: per-address
+  executed flags `{addr, bank, executed: [0|1, ...]}` (like a memory read).
+  The web UI uses this to highlight executed lines in the disassembler.
+
+### Tracepoints
+Like breakpoints, but log a register snapshot and keep running.
+- `GET /api/debugger/tracepoints?cmd=add&addr=HEX[&bank=HEX]`
+- `GET /api/debugger/tracepoints?cmd=clear`
+- `GET /api/debugger/tracepoints`: `{points: [{addr, bank, hits}, ...],
+  log: [{pc, bank, a, b, x, y, u, s, dp, cc}, ...]}` (log capacity 512).
+
+### Code Instrumentation (PC hit counting)
+- `GET /api/debugger/instrument?cmd=add&addr=HEX[&bank=HEX]`: count passes
+  over a code address (bank -1/omitted matches any bank).
+- `GET /api/debugger/instrument?cmd=clear` / `GET /api/debugger/instrument`:
+  clear / list `{points: [{addr, bank, count}, ...]}`.
+
+### Value Scan (variable search)
+Classic cheat-engine workflow to locate a variable in RAM (no `bank`
+parameter — variables live in the unbanked RAM/ASIC region `0x0000`-`0x3FFF`):
+- `GET /api/debugger/scan?cmd=new&addr=HEX[&size=N][&cpu=N]`: snapshot a
+  region (size 1..8192); every byte becomes a candidate.
+- `GET /api/debugger/scan?cmd=filter&op=[eq|ne|changed|unchanged|inc|dec][&val=HEX]`:
+  keep candidates matching the comparison against the previous snapshot
+  (`changed`/`inc`/...) or a value (`eq`/`ne`). Repeat to narrow down.
+- `GET /api/debugger/scan`: current `{count, results: [{addr, val}, ...]}`
+  (results capped at 256).
+
+### Save States
+Lightweight checkpoints of the game logic state (WPC RAM + main CPU
+registers), kept in memory in up to 8 named slots. This intentionally does
+**not** use MAME's full state-save machinery, which is incomplete for
+WPC/DCS and crashes on this driver; the checkpoint captures exactly what is
+useful for reverse engineering and works reliably, including while paused.
+It does not restore sound/DMD hardware state.
+- `GET /api/debugger/savestate?cmd=save&slot=NAME`
+- `GET /api/debugger/savestate?cmd=load&slot=NAME`
+- `GET /api/debugger/savestate?cmd=delete&slot=NAME`
+- `GET /api/debugger/savestate`: list slots `{slots: [{name, pc}, ...]}`.
+- `GET /api/debugger/savestate/diff?a=SLOT[&b=SLOT]`: diff slot `a`'s RAM
+  against slot `b`, or against the live RAM when `b` is omitted —
+  `{a, b, count, diffs: [{addr, a, b}, ...]}` (up to 1024 entries). Handy
+  for "what changed between these two moments".
+
+### DMD Recorder
+Capture DMD frames into a ring buffer (one per emulated video frame,
+capacity ~512 frames) and download them for playback/analysis.
+- `GET /api/debugger/dmdrec?cmd=[start|stop|clear]`
+- `GET /api/debugger/dmdrec`: status `{recording, count, width, height, capacity}`.
+- `GET /api/debugger/dmdrec/data`: packed binary of all frames —
+  little-endian `u32 count, u32 width, u32 height`, then per frame
+  `u32 t_ms` followed by `width*height` luminance bytes.
+
+### Input & Classic Commands
+- `GET /api/input?sw=N&val=[0|1][&pulse=MS]`: set a cabinet/matrix switch;
+  with `pulse=MS` it holds the value for MS milliseconds then restores the
+  opposite (works for coin switches too, re-asserted each frame).
+- `GET /api/debugger/command?cmd=STRING`: classic MAME-style commands
+  (URL-encoded): `BP [bank:]addr`, `BC`, `WP [bank:]addr[,len[,type]]`, `WC`,
+  `G`, `S`, `F addr,len,val`, `QUIT`, `HELP` — all values hex.
+
+## Web UI
+`http://localhost:<port>/ui` — single-file dashboard (vanilla JS):
+- SSE push with automatic fallback to adaptive polling (fast while running,
+  slow while paused/offline), offline banner and error toasts.
+- Keyboard shortcuts: `F8` pause/resume, `F10` step over, `F11` step into,
+  `Shift+F11` step out.
+- Disassembler with auto-follow-PC (incl. context lines above PC), click a
+  line to prefill the breakpoint form.
+- Registers editable by clicking the hex value.
+- Hex editor: inline byte editing (Enter commits, Esc cancels), page up/down,
+  changed-byte highlighting, auto-refresh on halt, pattern search with
+  "Next", NVRAM view preset and NVRAM dump download.
+- Watches panel (persisted in the browser) and memory trace panel.
+- Conditional breakpoints with hit counters in the points list.
+- Cabinet/service buttons built from the named switches, with a
+  configurable pulse duration.
+- Switch matrix tooltips show the switch name; Shift+click a switch to
+  assign a custom label (stored in the browser).
+- Code instrumentation, value scan and object monitor / action log panels.
+- Execution-trace, code-coverage and tracepoint panels; coverage can
+  highlight executed lines directly in the disassembler.
+- Watchpoint value-condition inputs; monitor "break on change" checkbox;
+  save-state "diff vs live" button.
+- Save-state slots and a DMD recorder with in-browser frame playback.
+- Authoritative 16-segment alphanumeric rendering: the glyph pixel maps are
+  decoded from PinMAME's own core segment table, so the display matches the
+  emulator exactly (all 16 segments incl. commas/periods).
+
+## Platform Support
+
+The debugger was developed and verified against **Williams WPC** (`taf_l7`).
+Most of it is *platform-generic*, because it hooks PinMAME's shared
+subsystems rather than WPC-specific code:
+
+- the per-instruction debug hook (`CALL_MAME_DEBUG`) → breakpoints, stepping,
+  code instrumentation;
+- the generic memory access macros (`memory.c`) → watchpoints, value scan,
+  memory trace;
+- the core object state (`coreGlobals` switches/lamps/solenoids/segments and
+  `core_get_dmd_data`) → matrices, segment/DMD rendering, monitoring.
+
+A few things are WPC-specific and *degrade gracefully* on other platforms
+(they check for the WPC RAM/banking and return `-1`, an empty value, or a
+`404`/`500` instead of crashing): bank-aware breakpoints & disassembly, the
+binary NVRAM dump, save states, the "dedicated" switch field in `/api/info`,
+and the WPC memory-protection bypass on writes. The callstack is built from
+hooks that live only in the **M6809** CPU core.
+
+### Support tiers
+
+**Tier 1 — Full (developed & tested): Williams WPC** (Alpha → DMD → WPC-95),
+M6809 main CPU. Every feature works, including bank-aware breakpoints/
+disassembly, callstack, NVRAM dump and save states.
+
+**Tier 2 — M6809-based (untested, expected full run-control + callstack):**
+Sega/Stern Whitestar (`se.c`), Wico, Barni, Ice Cold Beer, Bally video
+(video CPU); also the M6809 DMD sound board of Data East / Whitestar. All
+debugging works; the WPC-only endpoints above are unavailable (save states
+and NVRAM dump rely on the WPC RAM pointer).
+
+**Tier 3 — Other CPUs *with* the instruction hook (run control +
+breakpoints + all generic tools; no callstack; register *names* only for
+M6809/ADSP2105, others by numeric id):** Williams System 3-11, all Data East
+main CPUs, Bally MPU-17/35/6803, Gottlieb System 1/80/3, Atari, Zaccaria,
+Capcom, Alvin G., Spinball, Inder, Mr. Game and most of the smaller
+Z80/M6800/M6502/M68000 systems. CPU families covered by the hook:
+M6800/02/03/08, M6502/M65C02, Z80, S2650, SCAMP, M68000/M68306, PPS4, i8085,
+i86, i8039, CDP1802, i4004, COP420, TMS7000, i8051.
+
+**Tier 4 — Limited, *no* instruction hook:** Stern **S.A.M.** (AT91/ARM7),
+**NSM** and the **JVH** main CPU (TMS99xx). These CPU cores do not emit
+`CALL_MAME_DEBUG`, so PC breakpoints, step-over/run-to and code
+instrumentation do not fire. Still available: pause/resume, memory
+read/write/fill/find, watchpoints and value scan (via the generic memory
+hooks), switches/lamps/solenoids, DMD/segments, monitoring, screenshots and
+numeric register access.
+
+### Feature availability
+
+| Feature | Works on |
+|---|---|
+| Pause / resume / single step, `/api/info`, matrices, screenshot | all platforms |
+| Switches / lamps / solenoids, input, pulse, monitoring, value scan, memory read/write/fill/find, watchpoints, memory trace | all platforms |
+| DMD info/raw/pnm + recorder | any DMD game |
+| Segment display (`/api/info` segments, UI rendering) | any alphanumeric game |
+| Disassembly (`/api/debugger/dasm`, unbanked) | any CPU with a MAME disassembler (needs `DEBUG=1`, the fork default) |
+| PC breakpoints, conditional BP, step-over, run-to, code instrumentation, execution trace, coverage, tracepoints | CPUs that emit the instruction hook (Tier 1-3; **not** Tier 4) |
+| Watchpoint value condition, monitor break-on-change | all platforms (watchpoints/monitoring are generic) |
+| Save-state diff | WPC only (uses the WPC RAM checkpoint) |
+| Register *names* in `state/write` | M6809 and ADSP2105 (others: numeric id) |
+| Callstack, step-out | M6809 core only (Tier 1-2) |
+| Bank-aware breakpoints / disassembly, NVRAM binary dump, save states, dedicated-switch field | WPC only |
+| NVRAM clear | any driver with an `nvram_handler` |
+
+Non-WPC platforms are untested — the analysis above is from the code paths,
+not from running each ROM. Switch/lamp/solenoid *names* are WPC-specific;
+on other platforms the objects are still enumerated by matrix number, just
+without a friendly name (assign your own via the UI or ignore the `name`).
+
+## Testing
+Run from `src/remote_debug` (ROM `taf_l7` expected in `~/.pinmame`, override
+via `ROMPATH=/path`):
+- `./test_suite.sh` — full API verification suite.
+- `./test_breakpoint.sh` — end-to-end breakpoint hit test.
+- `./re_demo.sh` — guided tour of the RE tooling (coverage, execution
+  trace, tracepoints, value-condition watchpoint with callstack, monitor
+  break-on-change, save-state diff) on a running game.
+- `./find_nvram_coins.sh` — example RE workflow: locate the coin/credit
+  counters in NVRAM using the value scan (insert coins, alternate
+  `inc`/`unchanged` filters). Pretty-prints with python3 if present.
+
+## Misc
+
+### CPU Register Mapping (M6809)
+| Index | Name | Description |
+|-------|------|-------------|
+| 1     | PC   | Program Counter |
+| 2     | S    | Stack Pointer (SP) |
+| 3     | CC   | Condition Codes (FLAGS) |
+| 4     | A    | Accumulator A |
+| 5     | B    | Accumulator B |
+| 6     | U    | User Stack Pointer |
+| 7     | X    | Index Register X |
+| 8     | Y    | Index Register Y |
+| 9     | DP   | Direct Page Register |
+
+### Williams 16-Segment Mapping
+The alphanumeric renderer uses the hardware mapping (bits 0-indexed):
+- **Bits 0-5**: outer segments (a, b, c, d, e, f)
+- **Bit 6**: middle-left horizontal (g1), **Bit 11**: middle-right (g2)
+- **Bit 9**: center-top vertical (h), **Bit 13**: center-bottom (i)
+- **Bit 8**: diag top-left (j), **Bit 10**: diag top-right (k)
+- **Bit 14**: diag bottom-left (l), **Bit 12**: diag bottom-right (m)
+- **Bit 15**: period, **Bit 7**: comma
+
+### Known warnings
+None. The remote_debug objects build warning-free with
+`-std=gnu99 -Wall -Wextra -Wunused -pedantic -Werror`.

--- a/src/remote_debug/api_handler.c
+++ b/src/remote_debug/api_handler.c
@@ -1,0 +1,1515 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - HTTP API handlers                             *
+ * See api_handler.h; endpoint reference is served at /api/doc.            *
+ *                                                                         *
+ * Parameter conventions (also documented in README.md):                   *
+ *   addr, val, bank, pattern, data : hexadecimal (optional 0x/$ prefix)   *
+ *   size, lines, before, cpu, sw, idx, len, mode, ignore : decimal        *
+ * All handlers run on the HTTP server thread and take the debugger lock   *
+ * (directly or via remote_debug_* functions) around emulator access.      *
+ ***************************************************************************/
+#ifdef REMOTE_DEBUG
+
+#include "api_handler.h"
+#include "remote_debug.h"
+#include "http_server.h"
+#include "driver.h"
+#include "mame.h"
+#include "wpc/core.h"
+#include "wpc/wpc.h"
+#include "cpuintrf.h"
+#include "cpu/m6809/m6809.h"
+#include "cpu/adsp2100/adsp2100.h"
+#include "memory.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+/* Provided by src/wpc/wpc.c / src/wpc/core.c */
+extern int wpc_get_bank(void);
+extern void core_get_dmd_data(int layout_idx, float **pixels, int *width, int *height);
+extern UINT8 *wpc_ram;
+
+/* ------------------------------------------------------------------ */
+/* Small helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+/* Decode %XX and '+' URL escapes; dst holds at most dstlen bytes. */
+static void url_decode(char *dst, int dstlen, const char *src)
+{
+	int o = 0;
+	while (*src && o < dstlen - 1) {
+		if (src[0] == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
+			char hex[3];
+			hex[0] = src[1];
+			hex[1] = src[2];
+			hex[2] = 0;
+			dst[o++] = (char)strtoul(hex, NULL, 16);
+			src += 3;
+		}
+		else if (*src == '+') {
+			dst[o++] = ' ';
+			src++;
+		}
+		else {
+			dst[o++] = *src++;
+		}
+	}
+	dst[o] = 0;
+}
+
+/* Extract the (URL-decoded) value of key from a query string.
+ * Matches keys exactly (start of string or after '&'). dest is set to
+ * the empty string when the key is absent. */
+static void get_query_param(const char *query, const char *key, char *dest, int max_len)
+{
+	size_t klen = strlen(key);
+	const char *p = query;
+	dest[0] = 0;
+	while (p && *p) {
+		if (strncmp(p, key, klen) == 0 && p[klen] == '=') {
+			const char *v = p + klen + 1;
+			const char *end = strchr(v, '&');
+			char raw[512];
+			size_t n = end ? (size_t)(end - v) : strlen(v);
+			if (n >= sizeof(raw))
+				n = sizeof(raw) - 1;
+			memcpy(raw, v, n);
+			raw[n] = 0;
+			url_decode(dest, max_len, raw);
+			return;
+		}
+		p = strchr(p, '&');
+		if (p)
+			p++;
+	}
+}
+
+/* Parse a hexadecimal number (optional 0x/0X/$ prefix). */
+static UINT32 parse_hex(const char *str)
+{
+	if (!str || !*str)
+		return 0;
+	if (str[0] == '$')
+		return (UINT32)strtoul(str + 1, NULL, 16);
+	if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
+		return (UINT32)strtoul(str + 2, NULL, 16);
+	return (UINT32)strtoul(str, NULL, 16);
+}
+
+/* Parse a decimal number; a 0x/$ prefix switches to hexadecimal. */
+static int parse_int(const char *str)
+{
+	if (!str || !*str)
+		return 0;
+	if (str[0] == '$')
+		return (int)strtoul(str + 1, NULL, 16);
+	if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
+		return (int)strtoul(str + 2, NULL, 16);
+	return atoi(str);
+}
+
+/* Parse a hex byte string ("DEADBEEF") into bytes; returns the count. */
+static int parse_hex_bytes(const char *str, UINT8 *out, int maxlen)
+{
+	int n = 0;
+	size_t len = strlen(str);
+	size_t i;
+	for (i = 0; i + 1 < len && n < maxlen; i += 2) {
+		char hex[3];
+		if (!isxdigit((unsigned char)str[i]) || !isxdigit((unsigned char)str[i + 1]))
+			break;
+		hex[0] = str[i];
+		hex[1] = str[i + 1];
+		hex[2] = 0;
+		out[n++] = (UINT8)strtoul(hex, NULL, 16);
+	}
+	return n;
+}
+
+/* Respond with a malloc()ed copy of json and the given HTTP status. */
+static void respond_json(http_response_t *resp, int status, const char *json)
+{
+	resp->body = strdup(json);
+	resp->len = resp->body ? (int)strlen(resp->body) : 0;
+	resp->status = status;
+	strcpy(resp->content_type, "application/json");
+}
+
+static void respond_ok(http_response_t *resp)
+{
+	respond_json(resp, 200, "{\"status\": \"ok\"}");
+}
+
+static void respond_error(http_response_t *resp, int status, const char *message)
+{
+	char buf[256];
+	char esc[160];
+	snprintf(buf, sizeof(buf), "{\"status\": \"error\", \"message\": \"%s\"}",
+	         remote_debug_json_escape(esc, (int)sizeof(esc), message));
+	respond_json(resp, status, buf);
+}
+
+/* Take a buffer produced by a remote_debug_get_* function. */
+static void respond_owned(http_response_t *resp, char *body, int len, const char *ctype)
+{
+	if (body) {
+		resp->body = body;
+		resp->len = len;
+		resp->status = 200;
+		strcpy(resp->content_type, ctype);
+	}
+	else {
+		respond_error(resp, 500, "out of memory");
+	}
+}
+
+/* Resolve a register name or numeric id for /api/debugger/state/write.
+ * Understands M6809 and ADSP2100 family names. Returns -1 if unknown. */
+static int resolve_register_id(int cpu_idx, const char *name)
+{
+	static const struct { const char *name; int id; } m6809_regs[] = {
+		{"PC", M6809_PC}, {"S", M6809_S}, {"SP", M6809_S},
+		{"CC", M6809_CC}, {"FLAGS", M6809_CC}, {"A", M6809_A},
+		{"B", M6809_B}, {"U", M6809_U}, {"X", M6809_X},
+		{"Y", M6809_Y}, {"DP", M6809_DP}
+	};
+	static const struct { const char *name; int id; } adsp_regs[] = {
+		{"PC", ADSP2100_PC}, {"AX0", ADSP2100_AX0}, {"AX1", ADSP2100_AX1},
+		{"AY0", ADSP2100_AY0}, {"AY1", ADSP2100_AY1}, {"AR", ADSP2100_AR},
+		{"AF", ADSP2100_AF}, {"MX0", ADSP2100_MX0}, {"MX1", ADSP2100_MX1},
+		{"MY0", ADSP2100_MY0}, {"MY1", ADSP2100_MY1}, {"MR0", ADSP2100_MR0},
+		{"MR1", ADSP2100_MR1}, {"MR2", ADSP2100_MR2}, {"MF", ADSP2100_MF},
+		{"SI", ADSP2100_SI}, {"SE", ADSP2100_SE}, {"SB", ADSP2100_SB},
+		{"SR0", ADSP2100_SR0}, {"SR1", ADSP2100_SR1}, {"CNTR", ADSP2100_CNTR},
+		{"ASTAT", ADSP2100_ASTAT}, {"MSTAT", ADSP2100_MSTAT},
+		{"SSTAT", ADSP2100_SSTAT}, {"IMASK", ADSP2100_IMASK},
+		{"ICNTL", ADSP2100_ICNTL}
+	};
+	int cpu_type;
+	size_t i;
+
+	if (name[0] == '\0')
+		return -1;
+	if (isdigit((unsigned char)name[0]))
+		return atoi(name);
+
+	cpu_type = CPU_M6809;
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu())
+		cpu_type = Machine->drv->cpu[cpu_idx].cpu_type;
+	remote_debug_unlock();
+
+	if (cpu_type == CPU_ADSP2105) {
+		for (i = 0; i < sizeof(adsp_regs) / sizeof(adsp_regs[0]); i++) {
+			if (strcasecmp(name, adsp_regs[i].name) == 0)
+				return adsp_regs[i].id;
+		}
+	}
+	else {
+		for (i = 0; i < sizeof(m6809_regs) / sizeof(m6809_regs[0]); i++) {
+			if (strcasecmp(name, m6809_regs[i].name) == 0)
+				return m6809_regs[i].id;
+		}
+	}
+	return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Classic single-line commands (MAME debugger style)                 */
+/* ------------------------------------------------------------------ */
+
+static void handle_classic_command(const char *cmd_line)
+{
+	char clean[256];
+	char *p, *cmd;
+
+	strncpy(clean, cmd_line, sizeof(clean) - 1);
+	clean[sizeof(clean) - 1] = 0;
+	for (p = clean; *p; p++)
+		*p = (char)toupper((unsigned char)*p);
+
+	cmd = strtok(clean, " ,");
+	if (!cmd)
+		return;
+	if (strcmp(cmd, "BP") == 0) {
+		char *as = strtok(NULL, " ,");
+		if (as) {
+			char *colon = strchr(as, ':');
+			if (colon) {
+				*colon = 0;
+				remote_debug_breakpoint_add_banked(parse_hex(colon + 1), (int)parse_hex(as));
+			}
+			else {
+				remote_debug_breakpoint_add(parse_hex(as));
+			}
+		}
+	}
+	else if (strcmp(cmd, "BC") == 0) {
+		remote_debug_breakpoint_clear();
+	}
+	else if (strcmp(cmd, "WP") == 0) {
+		char *as = strtok(NULL, " ,");
+		char *sz = strtok(NULL, " ,");
+		char *md = strtok(NULL, " ,");
+		if (as) {
+			int mode = REMOTE_DEBUG_WP_RW;
+			int len = sz ? (int)parse_hex(sz) : 1;
+			int bank = -1;
+			char *colon = strchr(as, ':');   /* optional bank:addr */
+			if (colon) {
+				*colon = 0;
+				bank = (int)parse_hex(as);
+				as = colon + 1;
+			}
+			if (md) {
+				if (strstr(md, "RW"))
+					mode = REMOTE_DEBUG_WP_RW;
+				else if (strchr(md, 'R'))
+					mode = REMOTE_DEBUG_WP_READ;
+				else if (strchr(md, 'W'))
+					mode = REMOTE_DEBUG_WP_WRITE;
+			}
+			remote_debug_watchpoint_add(parse_hex(as), len, mode, bank,
+			                            REMOTE_DEBUG_COND_NONE, 0);
+		}
+	}
+	else if (strcmp(cmd, "WC") == 0) {
+		remote_debug_watchpoint_clear();
+	}
+	else if (strcmp(cmd, "G") == 0) {
+		remote_debug_set_paused(0);
+	}
+	else if (strcmp(cmd, "S") == 0) {
+		remote_debug_step();
+	}
+	else if (strcmp(cmd, "F") == 0) {
+		char *as = strtok(NULL, " ,");
+		char *sz = strtok(NULL, " ,");
+		char *vl = strtok(NULL, " ,");
+		if (as && sz && vl)
+			remote_debug_memory_fill(0, parse_hex(as), (int)parse_hex(sz), (UINT8)parse_hex(vl));
+	}
+	else if (strcmp(cmd, "QUIT") == 0) {
+		remote_debug_quit();
+	}
+	else if (strcmp(cmd, "HELP") == 0) {
+		remote_debug_add_message("Commands: BP [bank:]addr, BC, WP addr[,len[,type]], WC, G, S, F addr,len,val, QUIT (all values hex)");
+	}
+	else {
+		char err[128];
+		snprintf(err, sizeof(err), "Unknown command: %.80s", cmd);
+		remote_debug_add_message(err);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* Handlers                                                           */
+/* ------------------------------------------------------------------ */
+
+static void handle_api_info(const http_request_t *req, http_response_t *resp)
+{
+	char *buffer;
+	(void)req;
+	buffer = malloc(8192);
+	if (!buffer) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	remote_debug_lock();
+	if (Machine && Machine->gamedrv) {
+		int bank = wpc_get_bank();
+		char lamp_hex[CORE_MAXLAMPCOL * 2 + 1];
+		char sw_hex[CORE_MAXSWCOL * 2 + 1];
+		char seg_hex[CORE_SEGCOUNT * 4 + 1];
+		char desc_esc[256];
+		int i, ded, len;
+		for (i = 0; i < CORE_MAXLAMPCOL; i++)
+			sprintf(lamp_hex + i * 2, "%02X", coreGlobals.lampMatrix[i]);
+		for (i = 0; i < CORE_MAXSWCOL; i++)
+			sprintf(sw_hex + i * 2, "%02X", coreGlobals.swMatrix[i]);
+		for (i = 0; i < CORE_SEGCOUNT; i++)
+			sprintf(seg_hex + i * 4, "%04X", coreGlobals.segments[i].w);
+		ded = wpc_data ? wpc_data[0] : 0;
+		len = snprintf(buffer, 8192,
+			"{\"game\": \"%s\", \"description\": \"%s\", \"manufacturer\": \"%s\", "
+			"\"year\": \"%s\", \"paused\": %d, \"wpc_bank\": %d, \"lamps\": \"%s\", "
+			"\"switches\": \"%s\", \"segments\": \"%s\", \"dedicated\": %d, "
+			"\"solenoids\": %u, \"solenoids2\": %u}",
+			Machine->gamedrv->name,
+			remote_debug_json_escape(desc_esc, (int)sizeof(desc_esc), Machine->gamedrv->description),
+			Machine->gamedrv->manufacturer, Machine->gamedrv->year,
+			remote_debug_is_paused(), bank, lamp_hex, sw_hex, seg_hex, ded,
+			coreGlobals.solenoids, coreGlobals.solenoids2);
+		remote_debug_unlock();
+		resp->body = buffer;
+		resp->len = (len > 0 && len < 8192) ? len : (int)strlen(buffer);
+		resp->status = 200;
+		strcpy(resp->content_type, "application/json");
+	}
+	else {
+		remote_debug_unlock();
+		free(buffer);
+		respond_json(resp, 503, "{\"status\": \"initializing\"}");
+	}
+}
+
+static void handle_api_events(const http_request_t *req, http_response_t *resp)
+{
+	(void)req;
+	resp->sse = 1;
+	resp->status = 200;
+}
+
+static void handle_api_dmd_info(const http_request_t *req, http_response_t *resp)
+{
+	float *px;
+	int w, h;
+	(void)req;
+	remote_debug_lock();
+	core_get_dmd_data(0, &px, &w, &h);
+	remote_debug_unlock();
+	if (px && w > 0 && h > 0) {
+		char res[128];
+		snprintf(res, sizeof(res), "{\"width\": %d, \"height\": %d}", w, h);
+		respond_json(resp, 200, res);
+	}
+	else {
+		respond_error(resp, 404, "DMD not initialized");
+	}
+}
+
+static void handle_api_dmd_raw(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_dmd_screenshot(&body, &len, resp->content_type);
+	if (body)
+		respond_owned(resp, body, len, resp->content_type);
+	else
+		respond_error(resp, 404, "DMD not initialized");
+}
+
+static void handle_api_dmd_pnm(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_dmd_pnm(&body, &len, resp->content_type);
+	if (body)
+		respond_owned(resp, body, len, resp->content_type);
+	else
+		respond_error(resp, 404, "DMD not initialized");
+}
+
+static void handle_api_screenshot_info(const http_request_t *req, http_response_t *resp)
+{
+	int w, h;
+	char res[128];
+	(void)req;
+	remote_debug_get_screenshot_info(&w, &h);
+	snprintf(res, sizeof(res), "{\"width\": %d, \"height\": %d}", w, h);
+	respond_json(resp, 200, res);
+}
+
+static void handle_api_screenshot_raw(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_raw_screenshot(&body, &len);
+	if (body)
+		respond_owned(resp, body, len, "application/octet-stream");
+	else
+		respond_error(resp, 404, "no display captured yet");
+}
+
+static void handle_api_screenshot_pnm(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_screenshot(&body, &len, resp->content_type);
+	if (body)
+		respond_owned(resp, body, len, resp->content_type);
+	else
+		respond_error(resp, 404, "no display captured yet");
+}
+
+static void handle_api_debugger_command(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[256];
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (!cmd_buf[0]) {
+		respond_error(resp, 400, "missing parameter: cmd");
+		return;
+	}
+	handle_classic_command(cmd_buf);
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_control_runto(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], bank_buf[32];
+	int bank;
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+	if (!addr_buf[0]) {
+		respond_error(resp, 400, "missing parameter: addr");
+		return;
+	}
+	bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+	remote_debug_run_to(parse_hex(addr_buf), bank);
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_control(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32];
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "pause") == 0)
+		remote_debug_set_paused(1);
+	else if (strcmp(cmd_buf, "resume") == 0)
+		remote_debug_set_paused(0);
+	else if (strcmp(cmd_buf, "step") == 0)
+		remote_debug_step();
+	else if (strcmp(cmd_buf, "stepover") == 0)
+		remote_debug_step_over();
+	else if (strcmp(cmd_buf, "stepout") == 0)
+		remote_debug_step_out();
+	else if (strcmp(cmd_buf, "exit") == 0)
+		remote_debug_quit();
+	else {
+		respond_error(resp, 400, "cmd must be pause|resume|step|stepover|stepout|exit");
+		return;
+	}
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_messages(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_messages(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_callstack(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_callstack(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_trace(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], bank_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int bank;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		if (!addr_buf[0]) {
+			respond_error(resp, 400, "missing parameter: addr");
+			return;
+		}
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		remote_debug_trace_add(parse_hex(addr_buf), bank);
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_trace_clear();
+	}
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be add|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_trace(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_breakpoints(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], bank_buf[32], cond_buf[32], ignore_buf[32];
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int bank;
+		UINT32 ignore;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		get_query_param(req->query, "cond", cond_buf, (int)sizeof(cond_buf));
+		get_query_param(req->query, "ignore", ignore_buf, (int)sizeof(ignore_buf));
+		if (!addr_buf[0]) {
+			respond_error(resp, 400, "missing parameter: addr");
+			return;
+		}
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		ignore = ignore_buf[0] ? (UINT32)parse_int(ignore_buf) : 0;
+		if (remote_debug_breakpoint_add_ex(parse_hex(addr_buf), bank, cond_buf, ignore) != 0) {
+			respond_error(resp, 400, "bad condition or breakpoint table full");
+			return;
+		}
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_breakpoint_clear();
+	}
+	else {
+		respond_error(resp, 400, "cmd must be add|clear");
+		return;
+	}
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_watchpoints(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], len_buf[32], mode_buf[32], bank_buf[32];
+	char cond_buf[32], val_buf[32];
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int len, mode, bank, cond_op = REMOTE_DEBUG_COND_NONE;
+		UINT8 cond_val = 0;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "len", len_buf, (int)sizeof(len_buf));
+		get_query_param(req->query, "mode", mode_buf, (int)sizeof(mode_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		get_query_param(req->query, "cond", cond_buf, (int)sizeof(cond_buf));
+		get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+		if (!addr_buf[0]) {
+			respond_error(resp, 400, "missing parameter: addr");
+			return;
+		}
+		len = len_buf[0] ? parse_int(len_buf) : 1;
+		mode = mode_buf[0] ? parse_int(mode_buf) : REMOTE_DEBUG_WP_RW;
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		if (mode < REMOTE_DEBUG_WP_READ || mode > REMOTE_DEBUG_WP_RW) {
+			respond_error(resp, 400, "mode must be 1 (read), 2 (write) or 3 (rw)");
+			return;
+		}
+		if (cond_buf[0]) {
+			if (strcmp(cond_buf, "eq") == 0) cond_op = REMOTE_DEBUG_COND_EQ;
+			else if (strcmp(cond_buf, "ne") == 0) cond_op = REMOTE_DEBUG_COND_NE;
+			else if (strcmp(cond_buf, "lt") == 0) cond_op = REMOTE_DEBUG_COND_LT;
+			else if (strcmp(cond_buf, "gt") == 0) cond_op = REMOTE_DEBUG_COND_GT;
+			else if (strcmp(cond_buf, "le") == 0) cond_op = REMOTE_DEBUG_COND_LE;
+			else if (strcmp(cond_buf, "ge") == 0) cond_op = REMOTE_DEBUG_COND_GE;
+			else {
+				respond_error(resp, 400, "cond must be eq|ne|lt|gt|le|ge (with val=HEX)");
+				return;
+			}
+			cond_val = (UINT8)parse_hex(val_buf);
+		}
+		remote_debug_watchpoint_add(parse_hex(addr_buf), len, mode, bank, cond_op, cond_val);
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_watchpoint_clear();
+	}
+	else {
+		respond_error(resp, 400, "cmd must be add|clear");
+		return;
+	}
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_points(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], type_buf[32], idx_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (cmd_buf[0]) {
+		int idx;
+		get_query_param(req->query, "type", type_buf, (int)sizeof(type_buf));
+		get_query_param(req->query, "idx", idx_buf, (int)sizeof(idx_buf));
+		idx = parse_int(idx_buf);
+		if (strcmp(type_buf, "bp") == 0) {
+			if (strcmp(cmd_buf, "toggle") == 0)
+				remote_debug_breakpoint_toggle(idx);
+			else if (strcmp(cmd_buf, "delete") == 0)
+				remote_debug_breakpoint_delete(idx);
+		}
+		else {
+			if (strcmp(cmd_buf, "toggle") == 0)
+				remote_debug_watchpoint_toggle(idx);
+			else if (strcmp(cmd_buf, "delete") == 0)
+				remote_debug_watchpoint_delete(idx);
+		}
+	}
+	remote_debug_get_points(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_memory_find(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], size_buf[32], pat_buf[256], cpu_buf[32], bank_buf[32];
+	UINT8 pattern[128];
+	UINT32 addr, found = 0;
+	int size, cpu, pat_len, bank;
+
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "size", size_buf, (int)sizeof(size_buf));
+	get_query_param(req->query, "pattern", pat_buf, (int)sizeof(pat_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+	addr = parse_hex(addr_buf);
+	size = size_buf[0] ? parse_int(size_buf) : 0x2000;
+	cpu = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+	bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+	pat_len = parse_hex_bytes(pat_buf, pattern, (int)sizeof(pattern));
+	if (pat_len == 0) {
+		respond_error(resp, 400, "missing or malformed parameter: pattern");
+		return;
+	}
+	if (remote_debug_memory_find(cpu, addr, size, pattern, pat_len, &found, bank)) {
+		char res[64];
+		snprintf(res, sizeof(res), "{\"status\": \"ok\", \"found\": %u}", found);
+		respond_json(resp, 200, res);
+	}
+	else {
+		respond_json(resp, 200, "{\"status\": \"not_found\"}");
+	}
+}
+
+static void handle_api_debugger_memory_fill(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], size_buf[32], val_buf[32], cpu_buf[32];
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "size", size_buf, (int)sizeof(size_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	if (!addr_buf[0] || !size_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: addr, size, val");
+		return;
+	}
+	remote_debug_memory_fill(cpu_buf[0] ? parse_int(cpu_buf) : 0,
+	                         parse_hex(addr_buf), parse_int(size_buf),
+	                         (UINT8)parse_hex(val_buf));
+	respond_ok(resp);
+}
+
+/* Disassemble one instruction; returns its size (at least 1). */
+static unsigned dasm_one(char *buf, size_t buflen, UINT32 addr)
+{
+	unsigned size;
+	(void)buflen;
+	activecpu_set_op_base(addr);
+	size = activecpu_dasm(buf, addr);
+	return size ? size : 1;
+}
+
+/* Find a start address <= target so that forward disassembly from it hits
+ * target exactly, yielding up to want_lines instructions before target.
+ * Best-effort heuristic (6809 instructions are 1-5 bytes long). */
+static UINT32 dasm_backtrack(UINT32 target, int want_lines)
+{
+	UINT32 best_start = target;
+	int best_lines = 0;
+	int max_back = want_lines * 5 + 4;
+	int off;
+	char buf[64];
+
+	for (off = 1; off <= max_back; off++) {
+		UINT32 a = target - (UINT32)off;
+		int count = 0;
+		while (a < target)
+			a += dasm_one(buf, sizeof(buf), a);
+		if (a != target)
+			continue;
+		a = target - (UINT32)off;
+		count = 0;
+		while (a < target) {
+			a += dasm_one(buf, sizeof(buf), a);
+			count++;
+		}
+		if (count > best_lines && count <= want_lines + 4) {
+			best_lines = count;
+			best_start = target - (UINT32)off;
+			if (best_lines >= want_lines)
+				break;
+		}
+	}
+	/* skip surplus instructions so at most want_lines remain */
+	while (best_lines > want_lines) {
+		best_start += dasm_one(buf, sizeof(buf), best_start);
+		best_lines--;
+	}
+	return best_start;
+}
+
+static void handle_api_debugger_dasm(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], lines_buf[32], before_buf[32], cpu_buf[32], bank_buf[32];
+	UINT32 addr, start;
+	int lines, before, cpu_idx, bank;
+	char *buf;
+	char *ptr;
+
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "lines", lines_buf, (int)sizeof(lines_buf));
+	get_query_param(req->query, "before", before_buf, (int)sizeof(before_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+	addr = parse_hex(addr_buf);
+	lines = lines_buf[0] ? parse_int(lines_buf) : 10;
+	before = before_buf[0] ? parse_int(before_buf) : 0;
+	cpu_idx = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+	bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+	if (lines < 1)
+		lines = 1;
+	if (lines > 100)
+		lines = 100;
+	if (before < 0)
+		before = 0;
+	if (before > 50)
+		before = 50;
+
+	buf = malloc((size_t)(lines + before) * 256 + 256);
+	if (!buf) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	ptr = buf;
+	ptr += sprintf(ptr, "{\"cpu\": %d, \"bank\": %d, \"lines\": [", cpu_idx, bank);
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu()) {
+		int old_bank = -1;
+		int i, total;
+		cpuintrf_push_context(cpu_idx);
+		if (bank != -1 && Machine->drv->cpu[cpu_idx].cpu_type == CPU_M6809) {
+			old_bank = wpc_get_bank();
+			cpu_setbank(1, memory_region(WPC_ROMREGION) + bank * 0x4000);
+		}
+		start = addr;
+		total = lines;
+		if (before > 0) {
+			char tmp[64];
+			UINT32 a;
+			start = dasm_backtrack(addr, before);
+			/* count how many instructions the backtrack actually found */
+			for (a = start; a < addr; total++)
+				a += dasm_one(tmp, sizeof(tmp), a);
+		}
+		for (i = 0; i < total; i++) {
+			char dasm_buf[64];
+			char esc[160];
+			unsigned size = dasm_one(dasm_buf, sizeof(dasm_buf), start);
+			ptr += sprintf(ptr, "%s{\"addr\": %u, \"size\": %u, \"text\": \"%s\"}",
+			               (i > 0) ? "," : "", start, size,
+			               remote_debug_json_escape(esc, (int)sizeof(esc), dasm_buf));
+			start += size;
+		}
+		if (old_bank != -1)
+			cpu_setbank(1, memory_region(WPC_ROMREGION) + old_bank * 0x4000);
+		cpuintrf_pop_context();
+	}
+	remote_debug_unlock();
+	ptr += sprintf(ptr, "]}");
+	resp->body = buf;
+	resp->len = (int)(ptr - buf);
+	resp->status = 200;
+	strcpy(resp->content_type, "application/json");
+}
+
+static void handle_api_debugger_nvram_dump(const http_request_t *req, http_response_t *resp)
+{
+	(void)req;
+	remote_debug_lock();
+	if (Machine && Machine->drv && Machine->drv->nvram_handler && wpc_ram) {
+		char *body = malloc(0x2000);
+		if (body) {
+			memcpy(body, wpc_ram, 0x2000);
+			remote_debug_unlock();
+			respond_owned(resp, body, 0x2000, "application/octet-stream");
+			return;
+		}
+		remote_debug_unlock();
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	remote_debug_unlock();
+	respond_error(resp, 404, "no WPC NVRAM available");
+}
+
+static void handle_api_debugger_nvram(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32];
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "clear") != 0) {
+		respond_error(resp, 400, "cmd must be clear");
+		return;
+	}
+	remote_debug_lock();
+	if (Machine && Machine->drv && Machine->drv->nvram_handler) {
+		Machine->drv->nvram_handler(NULL, 0);
+		remote_debug_unlock();
+		respond_ok(resp);
+	}
+	else {
+		remote_debug_unlock();
+		respond_error(resp, 404, "no NVRAM handler");
+	}
+}
+
+static void handle_api_debugger_memory_write(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], val_buf[32], data_buf[512], cpu_buf[32];
+	UINT32 addr;
+	int cpu_idx;
+
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	get_query_param(req->query, "data", data_buf, (int)sizeof(data_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	if (!addr_buf[0] || (!val_buf[0] && !data_buf[0])) {
+		respond_error(resp, 400, "missing parameters: addr and val or data");
+		return;
+	}
+	addr = parse_hex(addr_buf);
+	cpu_idx = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+	if (data_buf[0]) {
+		UINT8 bytes[256];
+		int n = parse_hex_bytes(data_buf, bytes, (int)sizeof(bytes));
+		if (n == 0) {
+			respond_error(resp, 400, "malformed parameter: data");
+			return;
+		}
+		if (remote_debug_memory_write_block(cpu_idx, addr, bytes, n) != 0) {
+			respond_error(resp, 400, "bad cpu index or machine not running");
+			return;
+		}
+	}
+	else {
+		UINT8 val = (UINT8)parse_hex(val_buf);
+		if (remote_debug_memory_write_block(cpu_idx, addr, &val, 1) != 0) {
+			respond_error(resp, 400, "bad cpu index or machine not running");
+			return;
+		}
+	}
+	respond_ok(resp);
+}
+
+static void handle_api_debugger_state_write(const http_request_t *req, http_response_t *resp)
+{
+	char cpu_buf[32], reg_buf[32], val_buf[32];
+	int cpu_idx, reg_id;
+
+	get_query_param(req->query, "reg", reg_buf, (int)sizeof(reg_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	if (!reg_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: reg, val");
+		return;
+	}
+	cpu_idx = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+	reg_id = resolve_register_id(cpu_idx, reg_buf);
+	if (reg_id < 0) {
+		respond_error(resp, 400, "invalid register name or id");
+		return;
+	}
+	remote_debug_set_register(cpu_idx, reg_id, parse_hex(val_buf));
+	respond_ok(resp);
+}
+
+/* Append the register set of CPU i (context already pushed). */
+static void append_cpu_registers(int i, char **p)
+{
+	int type = Machine->drv->cpu[i].cpu_type;
+	*p += sprintf(*p, "\"type\": %d, \"pc\": %u, \"sp\": %u",
+	              type, cpunum_get_reg(i, REG_PC), cpunum_get_reg(i, REG_SP));
+	if (type == CPU_M6809) {
+		*p += sprintf(*p,
+			", \"a\": %u, \"b\": %u, \"x\": %u, \"y\": %u, \"u\": %u, \"dp\": %u, \"cc\": %u",
+			cpunum_get_reg(i, M6809_A), cpunum_get_reg(i, M6809_B),
+			cpunum_get_reg(i, M6809_X), cpunum_get_reg(i, M6809_Y),
+			cpunum_get_reg(i, M6809_U), cpunum_get_reg(i, M6809_DP),
+			cpunum_get_reg(i, M6809_CC));
+	}
+	else if (type == CPU_ADSP2105) {
+		*p += sprintf(*p,
+			", \"ax0\": %u, \"ax1\": %u, \"ay0\": %u, \"ay1\": %u, \"ar\": %u, \"cntr\": %u, \"astat\": %u",
+			cpunum_get_reg(i, ADSP2100_AX0), cpunum_get_reg(i, ADSP2100_AX1),
+			cpunum_get_reg(i, ADSP2100_AY0), cpunum_get_reg(i, ADSP2100_AY1),
+			cpunum_get_reg(i, ADSP2100_AR), cpunum_get_reg(i, ADSP2100_CNTR),
+			cpunum_get_reg(i, ADSP2100_ASTAT));
+	}
+}
+
+static void handle_api_debugger_state(const http_request_t *req, http_response_t *resp)
+{
+	char *buf;
+	char *ptr;
+	(void)req;
+	buf = malloc(8192);
+	if (!buf) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	ptr = buf;
+	ptr += sprintf(ptr, "{\"cpus\": [");
+	remote_debug_lock();
+	if (Machine) {
+		int i;
+		for (i = 0; i < cpu_gettotalcpu(); i++) {
+			if (i > 0)
+				ptr += sprintf(ptr, ",");
+			ptr += sprintf(ptr, "{\"id\": %d, ", i);
+			cpuintrf_push_context(i);
+			append_cpu_registers(i, &ptr);
+			cpuintrf_pop_context();
+			ptr += sprintf(ptr, "}");
+		}
+	}
+	remote_debug_unlock();
+	ptr += sprintf(ptr, "]}");
+	resp->body = buf;
+	resp->len = (int)(ptr - buf);
+	resp->status = 200;
+	strcpy(resp->content_type, "application/json");
+}
+
+static void handle_api_debugger_memory(const http_request_t *req, http_response_t *resp)
+{
+	char addr_buf[32], size_buf[32], cpu_buf[32], bank_buf[32];
+	UINT32 addr;
+	int size, cpu_idx, bank;
+	char *buf;
+	char *ptr;
+
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	get_query_param(req->query, "size", size_buf, (int)sizeof(size_buf));
+	get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+	get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+	addr = parse_hex(addr_buf);
+	size = size_buf[0] ? parse_int(size_buf) : 16;
+	cpu_idx = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+	bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+	if (size < 1)
+		size = 1;
+	if (size > 2048)
+		size = 2048;
+
+	buf = malloc((size_t)size * 4 + 256);
+	if (!buf) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	ptr = buf;
+	ptr += sprintf(ptr, "{\"addr\": %u, \"cpu\": %d, \"bank\": %d, \"data\": [", addr, cpu_idx, bank);
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu()) {
+		int i;
+		for (i = 0; i < size; i++) {
+			ptr += sprintf(ptr, "%s%u", (i > 0) ? "," : "",
+			               (unsigned)remote_debug_read_byte(cpu_idx, addr + (UINT32)i, bank));
+		}
+	}
+	remote_debug_unlock();
+	ptr += sprintf(ptr, "]}");
+	resp->body = buf;
+	resp->len = (int)(ptr - buf);
+	resp->status = 200;
+	strcpy(resp->content_type, "application/json");
+}
+
+static void handle_api_input(const http_request_t *req, http_response_t *resp)
+{
+	char sw_buf[32], val_buf[32], pulse_buf[32];
+	get_query_param(req->query, "sw", sw_buf, (int)sizeof(sw_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	get_query_param(req->query, "pulse", pulse_buf, (int)sizeof(pulse_buf));
+	if (!sw_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: sw, val");
+		return;
+	}
+	if (remote_debug_set_switch(parse_int(sw_buf), parse_int(val_buf),
+	                            pulse_buf[0] ? parse_int(pulse_buf) : 0) == 0)
+		respond_ok(resp);
+	else
+		respond_error(resp, 503, "core not initialized");
+}
+
+static void handle_api_switches(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_switches(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_lamps(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_lamps(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_solenoids(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_solenoids(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+/* Parse a monitor object type name; -1 if unknown. */
+static int parse_obj_type(const char *s)
+{
+	if (strcmp(s, "sw") == 0 || strcmp(s, "switch") == 0) return REMOTE_DEBUG_OBJ_SWITCH;
+	if (strcmp(s, "lamp") == 0)                            return REMOTE_DEBUG_OBJ_LAMP;
+	if (strcmp(s, "sol") == 0 || strcmp(s, "solenoid") == 0) return REMOTE_DEBUG_OBJ_SOL;
+	return -1;
+}
+
+static void handle_api_monitor(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], type_buf[32], id_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int type;
+		char brk_buf[32];
+		get_query_param(req->query, "type", type_buf, (int)sizeof(type_buf));
+		get_query_param(req->query, "id", id_buf, (int)sizeof(id_buf));
+		get_query_param(req->query, "break", brk_buf, (int)sizeof(brk_buf));
+		type = parse_obj_type(type_buf);
+		if (type < 0 || !id_buf[0]) {
+			respond_error(resp, 400, "need type=sw|lamp|sol and id");
+			return;
+		}
+		if (remote_debug_monitor_add(type, parse_int(id_buf),
+		                             (brk_buf[0] && brk_buf[0] != '0')) != 0) {
+			respond_error(resp, 400, "monitor table full");
+			return;
+		}
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_monitor_clear();
+	}
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be add|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_monitors(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_monitor_log(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "clear") == 0)
+		remote_debug_action_log_clear();
+	remote_debug_get_action_log(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_instrument(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], bank_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int bank;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		if (!addr_buf[0]) {
+			respond_error(resp, 400, "missing parameter: addr");
+			return;
+		}
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		if (remote_debug_instrument_add(parse_hex(addr_buf), bank) != 0) {
+			respond_error(resp, 400, "instrumentation table full");
+			return;
+		}
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_instrument_clear();
+	}
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be add|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_instrumentation(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_scan(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], size_buf[32], cpu_buf[32], op_buf[32], val_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "new") == 0) {
+		int cpu, size;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "size", size_buf, (int)sizeof(size_buf));
+		get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
+		cpu = cpu_buf[0] ? parse_int(cpu_buf) : 0;
+		size = size_buf[0] ? parse_int(size_buf) : 0x2000;
+		if (remote_debug_scan_new(cpu, parse_hex(addr_buf), size) < 0) {
+			respond_error(resp, 400, "bad scan region (size 1..8192, valid cpu)");
+			return;
+		}
+	}
+	else if (strcmp(cmd_buf, "filter") == 0) {
+		static const struct { const char *name; int op; } ops[] = {
+			{"eq", REMOTE_DEBUG_SCAN_EQ}, {"ne", REMOTE_DEBUG_SCAN_NE},
+			{"changed", REMOTE_DEBUG_SCAN_CHANGED}, {"unchanged", REMOTE_DEBUG_SCAN_UNCHANGED},
+			{"inc", REMOTE_DEBUG_SCAN_INC}, {"dec", REMOTE_DEBUG_SCAN_DEC}
+		};
+		int op = -1;
+		size_t i;
+		get_query_param(req->query, "op", op_buf, (int)sizeof(op_buf));
+		get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+		for (i = 0; i < sizeof(ops) / sizeof(ops[0]); i++)
+			if (strcmp(op_buf, ops[i].name) == 0)
+				op = ops[i].op;
+		if (op < 0) {
+			respond_error(resp, 400, "op must be eq|ne|changed|unchanged|inc|dec");
+			return;
+		}
+		if (remote_debug_scan_filter(op, (UINT8)parse_hex(val_buf)) < 0) {
+			respond_error(resp, 400, "no active scan; run cmd=new first");
+			return;
+		}
+	}
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be new|filter (or omitted)");
+		return;
+	}
+	remote_debug_get_scan(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_savestate(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], slot_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	get_query_param(req->query, "slot", slot_buf, (int)sizeof(slot_buf));
+	if (strcmp(cmd_buf, "save") == 0) {
+		if (!slot_buf[0]) { respond_error(resp, 400, "missing parameter: slot"); return; }
+		if (remote_debug_savestate_save(slot_buf) != 0) {
+			respond_error(resp, 500, "cannot save (no RAM or all slots full)");
+			return;
+		}
+		respond_ok(resp);
+		return;
+	}
+	if (strcmp(cmd_buf, "load") == 0) {
+		if (!slot_buf[0]) { respond_error(resp, 400, "missing parameter: slot"); return; }
+		if (remote_debug_savestate_load(slot_buf) != 0) {
+			respond_error(resp, 404, "unknown slot");
+			return;
+		}
+		respond_ok(resp);
+		return;
+	}
+	if (strcmp(cmd_buf, "delete") == 0) {
+		remote_debug_savestate_delete(slot_buf);
+		respond_ok(resp);
+		return;
+	}
+	if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be save|load|delete (or omitted to list)");
+		return;
+	}
+	remote_debug_get_savestates(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_dmdrec(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "start") == 0)
+		remote_debug_dmdrec_start();
+	else if (strcmp(cmd_buf, "stop") == 0)
+		remote_debug_dmdrec_stop();
+	else if (strcmp(cmd_buf, "clear") == 0)
+		remote_debug_dmdrec_clear();
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be start|stop|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_dmdrec_info(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_dmdrec_data(const http_request_t *req, http_response_t *resp)
+{
+	char *body = NULL;
+	int len = 0;
+	(void)req;
+	remote_debug_get_dmdrec_data(&body, &len);
+	if (body)
+		respond_owned(resp, body, len, "application/octet-stream");
+	else
+		respond_error(resp, 404, "no frames recorded");
+}
+
+static void handle_api_debugger_exectrace(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "start") == 0)
+		remote_debug_exectrace_start();
+	else if (strcmp(cmd_buf, "stop") == 0)
+		remote_debug_exectrace_stop();
+	else if (strcmp(cmd_buf, "clear") == 0)
+		remote_debug_exectrace_clear();
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be start|stop|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_exectrace(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_coverage(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], size_buf[32], bank_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "start") == 0)
+		remote_debug_coverage_start();
+	else if (strcmp(cmd_buf, "stop") == 0)
+		remote_debug_coverage_stop();
+	else if (strcmp(cmd_buf, "clear") == 0)
+		remote_debug_coverage_clear();
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be start|stop|clear (or omitted)");
+		return;
+	}
+	/* a region query returns the per-address executed flags */
+	get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+	if (addr_buf[0]) {
+		int size, bank;
+		get_query_param(req->query, "size", size_buf, (int)sizeof(size_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		size = size_buf[0] ? parse_int(size_buf) : 256;
+		if (size < 1) size = 1;
+		if (size > 4096) size = 4096;
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		remote_debug_get_coverage_region(&body, &len, parse_hex(addr_buf), size, bank);
+	}
+	else {
+		remote_debug_get_coverage_info(&body, &len);
+	}
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_tracepoints(const http_request_t *req, http_response_t *resp)
+{
+	char cmd_buf[32], addr_buf[32], bank_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
+	if (strcmp(cmd_buf, "add") == 0) {
+		int bank;
+		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
+		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		if (!addr_buf[0]) {
+			respond_error(resp, 400, "missing parameter: addr");
+			return;
+		}
+		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		if (remote_debug_tracepoint_add(parse_hex(addr_buf), bank) != 0) {
+			respond_error(resp, 400, "tracepoint table full");
+			return;
+		}
+	}
+	else if (strcmp(cmd_buf, "clear") == 0) {
+		remote_debug_tracepoint_clear();
+	}
+	else if (cmd_buf[0]) {
+		respond_error(resp, 400, "cmd must be add|clear (or omitted)");
+		return;
+	}
+	remote_debug_get_tracepoints(&body, &len);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_api_debugger_savestate_diff(const http_request_t *req, http_response_t *resp)
+{
+	char a_buf[32], b_buf[32];
+	char *body = NULL;
+	int len = 0;
+	get_query_param(req->query, "a", a_buf, (int)sizeof(a_buf));
+	get_query_param(req->query, "b", b_buf, (int)sizeof(b_buf));
+	if (!a_buf[0]) {
+		respond_error(resp, 400, "missing parameter: a (slot name)");
+		return;
+	}
+	remote_debug_savestate_diff(&body, &len, a_buf, b_buf);
+	respond_owned(resp, body, len, "application/json");
+}
+
+static void handle_ui(const http_request_t *req, http_response_t *resp)
+{
+/* ui_html.h is generated from ui.html by the makefile; it contains the
+ * HTML content as a C array plus its length. */
+#include "remote_debug/ui_html.h"
+	(void)req;
+	resp->body = malloc(src_remote_debug_ui_html_len);
+	if (!resp->body) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	memcpy(resp->body, src_remote_debug_ui_html, src_remote_debug_ui_html_len);
+	resp->len = (int)src_remote_debug_ui_html_len;
+	resp->status = 200;
+	strcpy(resp->content_type, "text/html");
+}
+
+static void handle_api_doc(const http_request_t *req, http_response_t *resp);
+
+/* ------------------------------------------------------------------ */
+/* Routing                                                            */
+/* ------------------------------------------------------------------ */
+
+static const api_route_t api_routes[] = {
+	{"/api/info", handle_api_info,
+	 "game info, pause state, lamp/switch/segment matrices, solenoids"},
+	{"/api/events", handle_api_events,
+	 "Server-Sent-Events stream of debugger events (halt, resume, step, message)"},
+	{"/api/dmd/info", handle_api_dmd_info, "DMD dimensions"},
+	{"/api/dmd/raw", handle_api_dmd_raw, "DMD frame, 1 luminance byte per pixel"},
+	{"/api/dmd/pnm", handle_api_dmd_pnm, "DMD frame as PGM (P5) image"},
+	{"/api/screenshot/info", handle_api_screenshot_info, "screen dimensions"},
+	{"/api/screenshot/raw", handle_api_screenshot_raw, "screen as raw RGB24"},
+	{"/api/screenshot/pnm", handle_api_screenshot_pnm, "screen as PPM (P6) image"},
+	{"/api/screenshot", handle_api_screenshot_pnm, "alias of /api/screenshot/pnm"},
+	{"/api/debugger/control", handle_api_debugger_control,
+	 "?cmd=pause|resume|step|stepover|stepout|exit"},
+	{"/api/debugger/control/runto", handle_api_debugger_control_runto,
+	 "?addr=HEX[&bank=HEX] - resume until addr is reached (bank: 0x4000-0x7FFF only)"},
+	{"/api/debugger/state", handle_api_debugger_state, "registers of all CPUs"},
+	{"/api/debugger/state/write", handle_api_debugger_state_write,
+	 "?reg=NAME|ID&val=HEX[&cpu=N] - set a register (M6809/ADSP names)"},
+	{"/api/debugger/dasm", handle_api_debugger_dasm,
+	 "?addr=HEX[&lines=N][&before=N][&cpu=N][&bank=HEX] - disassemble"},
+	{"/api/debugger/callstack", handle_api_debugger_callstack,
+	 "callstack with register context"},
+	{"/api/debugger/messages", handle_api_debugger_messages, "message log"},
+	{"/api/debugger/command", handle_api_debugger_command,
+	 "?cmd=... - classic command (BP/BC/WP/WC/G/S/F/QUIT/HELP)"},
+	{"/api/debugger/breakpoints", handle_api_debugger_breakpoints,
+	 "?cmd=add&addr=HEX[&bank=HEX][&cond=REG==HEX][&ignore=N] | ?cmd=clear"},
+	{"/api/debugger/watchpoints", handle_api_debugger_watchpoints,
+	 "?cmd=add&addr=HEX[&len=N][&mode=1|2|3][&bank=HEX][&cond=eq|ne|lt|gt|le|ge&val=HEX] | ?cmd=clear"},
+	{"/api/debugger/points", handle_api_debugger_points,
+	 "list all points; ?cmd=toggle|delete&type=bp|wp&idx=N to modify"},
+	{"/api/debugger/memory", handle_api_debugger_memory,
+	 "?addr=HEX[&size=N][&cpu=N][&bank=HEX] - read memory (bank: 0x4000-0x7FFF ROM)"},
+	{"/api/debugger/memory/write", handle_api_debugger_memory_write,
+	 "?addr=HEX&val=HEX | ?addr=HEX&data=HEXBYTES [&cpu=N] - write memory"},
+	{"/api/debugger/memory/fill", handle_api_debugger_memory_fill,
+	 "?addr=HEX&size=N&val=HEX[&cpu=N] - fill memory"},
+	{"/api/debugger/memory/find", handle_api_debugger_memory_find,
+	 "?pattern=HEXBYTES[&addr=HEX][&size=N][&cpu=N][&bank=HEX] - search memory"},
+	{"/api/debugger/trace", handle_api_debugger_trace,
+	 "memory access trace; ?cmd=add&addr=HEX[&bank=HEX] | ?cmd=clear"},
+	{"/api/debugger/nvram", handle_api_debugger_nvram, "?cmd=clear - wipe NVRAM"},
+	{"/api/debugger/nvram/dump", handle_api_debugger_nvram_dump,
+	 "raw 8KB WPC CMOS RAM dump"},
+	{"/api/debugger/instrument", handle_api_debugger_instrument,
+	 "PC hit counting; ?cmd=add&addr=HEX[&bank=HEX] | ?cmd=clear | list"},
+	{"/api/debugger/exectrace", handle_api_debugger_exectrace,
+	 "instruction trace ring; ?cmd=start|stop|clear | list (last N executed)"},
+	{"/api/debugger/coverage", handle_api_debugger_coverage,
+	 "code coverage; ?cmd=start|stop|clear | summary | ?addr=HEX[&size=N][&bank=HEX] region"},
+	{"/api/debugger/tracepoints", handle_api_debugger_tracepoints,
+	 "log-and-continue points; ?cmd=add&addr=HEX[&bank=HEX] | ?cmd=clear | list+log"},
+	{"/api/debugger/scan", handle_api_debugger_scan,
+	 "value scan; ?cmd=new&addr=HEX[&size=N][&cpu=N] | ?cmd=filter&op=eq|ne|changed|unchanged|inc|dec[&val=HEX]"},
+	{"/api/switches", handle_api_switches,
+	 "all switches with number, matrix position, state and name"},
+	{"/api/lamps", handle_api_lamps, "all lamps with number, matrix position, state"},
+	{"/api/solenoids", handle_api_solenoids, "all solenoids with number and state"},
+	{"/api/monitor", handle_api_monitor,
+	 "object monitoring; ?cmd=add&type=sw|lamp|sol&id=N[&break=1] | ?cmd=clear | list"},
+	{"/api/monitor/log", handle_api_monitor_log,
+	 "recorded state-change action log; ?cmd=clear to reset"},
+	{"/api/debugger/savestate", handle_api_debugger_savestate,
+	 "checkpoint WPC RAM + main CPU regs; ?cmd=save|load|delete&slot=NAME | list"},
+	{"/api/debugger/savestate/diff", handle_api_debugger_savestate_diff,
+	 "?a=SLOT[&b=SLOT] - diff two save slots' RAM (b omitted = live RAM)"},
+	{"/api/debugger/dmdrec", handle_api_debugger_dmdrec,
+	 "DMD frame recorder; ?cmd=start|stop|clear | status"},
+	{"/api/debugger/dmdrec/data", handle_api_debugger_dmdrec_data,
+	 "packed binary of recorded DMD frames (u32 count,w,h; per frame u32 t + w*h bytes)"},
+	{"/api/input", handle_api_input,
+	 "?sw=N&val=0|1[&pulse=MS] - set a switch, optionally as a timed pulse"},
+	{"/ui", handle_ui, "the web UI"},
+	{"/api/doc", handle_api_doc, "this document"},
+};
+
+static void handle_api_doc(const http_request_t *req, http_response_t *resp)
+{
+	char *buf = malloc(8192);
+	char *ptr;
+	size_t i;
+	(void)req;
+	if (!buf) {
+		respond_error(resp, 500, "out of memory");
+		return;
+	}
+	ptr = buf;
+	ptr += sprintf(ptr,
+		"PinMAME Remote Debugger API\n"
+		"===========================\n"
+		"All endpoints use GET. Parameter conventions:\n"
+		"  addr, val, bank, pattern, data: hex (optional 0x/$ prefix)\n"
+		"  size, lines, before, cpu, sw, idx, len, mode, ignore: decimal\n\n");
+	for (i = 0; i < sizeof(api_routes) / sizeof(api_routes[0]); i++) {
+		ptr += snprintf(ptr, (size_t)(8192 - (ptr - buf)), "%-32s %s\n",
+		                api_routes[i].path, api_routes[i].doc);
+		if (ptr - buf > 8192 - 160)
+			break;
+	}
+	resp->body = buf;
+	resp->len = (int)(ptr - buf);
+	resp->status = 200;
+	strcpy(resp->content_type, "text/plain");
+}
+
+void api_handler(const http_request_t *req, http_response_t *resp)
+{
+	size_t i;
+	if (!remote_debug_ready) {
+		respond_json(resp, 503, "{\"status\": \"not_ready\"}");
+		return;
+	}
+	for (i = 0; i < sizeof(api_routes) / sizeof(api_routes[0]); i++) {
+		if (strcmp(req->path, api_routes[i].path) == 0) {
+			api_routes[i].handler(req, resp);
+			return;
+		}
+	}
+	respond_error(resp, 404, "not found; see /api/doc");
+}
+
+#endif /* REMOTE_DEBUG */

--- a/src/remote_debug/api_handler.h
+++ b/src/remote_debug/api_handler.h
@@ -1,0 +1,26 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - HTTP API dispatch                             *
+ *                                                                         *
+ * Maps request paths to handler functions; see /api/doc (or README.md)    *
+ * for the endpoint reference. Runs on the HTTP server thread.             *
+ ***************************************************************************/
+#ifndef API_HANDLER_H
+#define API_HANDLER_H
+
+#include "http_server.h"
+
+/* Handler for one API route. */
+typedef void (*api_route_fn)(const http_request_t *req, http_response_t *resp);
+
+typedef struct {
+	const char *path;     /* exact request path */
+	api_route_fn handler;
+	const char *doc;      /* one-line description incl. parameters */
+} api_route_t;
+
+/* Top level request handler passed to http_server_start(). */
+void api_handler(const http_request_t *req, http_response_t *resp);
+
+#endif /* API_HANDLER_H */

--- a/src/remote_debug/find_nvram_coins.sh
+++ b/src/remote_debug/find_nvram_coins.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# WPC NVRAM coin-counter finder — a worked reverse-engineering example.
+#
+# Locates the coin/credit counters in the battery-backed RAM by using the
+# debugger's value-scan (cheat-engine style) rather than a raw dump diff.
+# A plain "insert coins, diff the NVRAM" comparison is swamped by unrelated
+# churn (the real-time clock, audits, checksums). Instead we alternate:
+#
+#   1. insert a coin  -> the coin counter INCREASES  -> keep "inc" candidates
+#   2. wait, no coin   -> the RTC keeps moving but the coin counter is stable
+#                        -> keep "unchanged" candidates (drops the RTC bytes)
+#
+# After a few rounds only the coin/credit counters survive. Coins are injected
+# as timed pulses (the coin-door column is refreshed by the input port every
+# frame, so a plain on/off level would not stick — a pulse is re-asserted).
+#
+# Usage: ./find_nvram_coins.sh   (run from src/remote_debug)
+# Env overrides: ROM, ROMPATH, PORT, BINARY, ROUNDS.
+
+PORT=${PORT:-8943}
+ROM=${ROM:-taf_l7}
+BINARY=${BINARY:-../../xpinmamed.x11}
+ROMPATH=${ROMPATH:-$HOME/.pinmame}
+ROUNDS=${ROUNDS:-5}
+BASE="http://localhost:$PORT"
+
+ROMPATH_ARGS=()
+[ -d "$ROMPATH" ] && ROMPATH_ARGS=(-rompath "$ROMPATH")
+
+echo "--------------------------------------------------"
+echo "WPC NVRAM Coin Finder (value-scan method)"
+echo "--------------------------------------------------"
+
+killall -9 "$(basename "$BINARY")" 2>/dev/null
+echo "1. Starting PinMAME and letting the game boot..."
+"$BINARY" -headless -httpport "$PORT" -nosound "${ROMPATH_ARGS[@]}" "$ROM" > /dev/null 2>&1 &
+PID=$!
+sleep 10
+
+count() { curl -s "$BASE/api/debugger/scan" | sed -n 's/.*"count": *\([0-9]*\).*/\1/p'; }
+
+echo "2. Snapshotting the battery-backed RAM (0x0000-0x1FFF)..."
+curl -s "$BASE/api/debugger/scan?cmd=new&addr=0000&size=8192" > /dev/null
+echo "   candidates: $(count)"
+
+echo "3. Isolating the coin counters over $ROUNDS rounds..."
+for r in $(seq 1 "$ROUNDS"); do
+    # insert a coin -> counter increases
+    curl -s "$BASE/api/input?sw=1&val=1&pulse=300" > /dev/null
+    sleep 1.5
+    curl -s "$BASE/api/debugger/scan?cmd=filter&op=inc" > /dev/null
+    # let the RTC advance without a coin -> counter unchanged
+    sleep 2.5
+    curl -s "$BASE/api/debugger/scan?cmd=filter&op=unchanged" > /dev/null
+    echo "   round $r -> candidates: $(count)"
+done
+
+echo "4. Remaining coin/credit counter candidates:"
+echo "   OFFSET | VALUE"
+echo "   --------------"
+curl -s "$BASE/api/debugger/scan" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("   (could not parse scan result)"); sys.exit(0)
+for r in d.get("results", []):
+    print("   0x%04X | %d" % (r["addr"], r["val"]))
+' 2>/dev/null || curl -s "$BASE/api/debugger/scan"
+
+# Also keep a raw NVRAM dump for reference / external tooling.
+curl -s "$BASE/api/debugger/nvram/dump" > nvram.bin
+echo "   (raw 8KB NVRAM dump saved to nvram.bin)"
+
+kill -9 $PID 2>/dev/null
+echo "--------------------------------------------------"
+echo "Done. The surviving offsets are the coin/credit counters"
+echo "(on WPC, the per-chute coin audits plus a total). Set a"
+echo "write watchpoint on one to see the code that updates it, e.g.:"
+echo "  curl \"$BASE/api/debugger/watchpoints?cmd=add&addr=<offset>&mode=2\""
+echo "--------------------------------------------------"

--- a/src/remote_debug/http_server.c
+++ b/src/remote_debug/http_server.c
@@ -1,0 +1,372 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - minimal embedded HTTP server                  *
+ * See http_server.h for the interface description.                       *
+ ***************************************************************************/
+#ifdef REMOTE_DEBUG
+
+#include "http_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+/* Maximum number of concurrently connected SSE clients. */
+#define SSE_MAX_CLIENTS 8
+/* Maximum size of an incoming request (headers included). */
+#define REQUEST_BUF_SIZE 8192
+/* select() timeout; also the maximum latency for SSE event delivery. */
+#define POLL_TIMEOUT_USEC 200000
+
+static int server_fd = -1;
+static volatile int stop_requested = 0;
+static pthread_t server_thread;
+static int thread_started = 0;
+static http_handler_t global_handler = NULL;
+static http_event_source_t global_events = NULL;
+static int sse_clients[SSE_MAX_CLIENTS];
+
+static const char *status_text(int status)
+{
+	switch (status) {
+		case 200: return "OK";
+		case 400: return "Bad Request";
+		case 404: return "Not Found";
+		case 405: return "Method Not Allowed";
+		case 500: return "Internal Server Error";
+		case 503: return "Service Unavailable";
+		default:  return "OK";
+	}
+}
+
+/* Write the whole buffer, retrying on partial writes and EINTR.
+ * MSG_NOSIGNAL avoids SIGPIPE when the client disconnected.
+ * Returns 0 on success, -1 on error. */
+static int write_all(int fd, const char *buf, int len)
+{
+	int done = 0;
+	while (done < len) {
+		ssize_t n = send(fd, buf + done, (size_t)(len - done), MSG_NOSIGNAL);
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		done += (int)n;
+	}
+	return 0;
+}
+
+/* Read until the end of the request headers ("\r\n\r\n"), the buffer is
+ * full, or a short timeout expires. Returns the number of bytes read. */
+static int read_request(int fd, char *buf, int maxlen)
+{
+	int total = 0;
+	while (total < maxlen - 1) {
+		fd_set fds;
+		struct timeval tv;
+		ssize_t n;
+		int ret;
+
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
+		tv.tv_sec = 0;
+		tv.tv_usec = 500000;
+		ret = select(fd + 1, &fds, NULL, NULL, &tv);
+		if (ret <= 0)
+			break;
+		n = read(fd, buf + total, (size_t)(maxlen - 1 - total));
+		if (n <= 0)
+			break;
+		total += (int)n;
+		buf[total] = 0;
+		if (strstr(buf, "\r\n\r\n") != NULL)
+			break;
+	}
+	buf[total] = 0;
+	return total;
+}
+
+/* Parse the request line ("GET /path?query HTTP/1.1") into req.
+ * Returns 0 on success, -1 on a malformed request. */
+static int parse_request(const char *buf, http_request_t *req)
+{
+	const char *method_end, *path_start, *path_end, *query;
+	size_t n;
+
+	memset(req, 0, sizeof(*req));
+	method_end = strchr(buf, ' ');
+	if (!method_end)
+		return -1;
+	n = (size_t)(method_end - buf);
+	if (n >= sizeof(req->method))
+		n = sizeof(req->method) - 1;
+	memcpy(req->method, buf, n);
+	req->method[n] = 0;
+
+	path_start = method_end + 1;
+	path_end = strchr(path_start, ' ');
+	if (!path_end)
+		return -1;
+
+	query = memchr(path_start, '?', (size_t)(path_end - path_start));
+	if (query) {
+		n = (size_t)(path_end - query - 1);
+		if (n >= sizeof(req->query))
+			n = sizeof(req->query) - 1;
+		memcpy(req->query, query + 1, n);
+		req->query[n] = 0;
+		path_end = query;
+	}
+	n = (size_t)(path_end - path_start);
+	if (n >= sizeof(req->path))
+		n = sizeof(req->path) - 1;
+	memcpy(req->path, path_start, n);
+	req->path[n] = 0;
+	return req->path[0] ? 0 : -1;
+}
+
+/* Register fd as an SSE client and send the stream header.
+ * Returns 0 on success, -1 if no slot is free or the write failed. */
+static int sse_add_client(int fd)
+{
+	static const char header[] =
+		"HTTP/1.1 200 OK\r\n"
+		"Content-Type: text/event-stream\r\n"
+		"Cache-Control: no-cache\r\n"
+		"Access-Control-Allow-Origin: *\r\n"
+		"Connection: keep-alive\r\n\r\n"
+		"retry: 2000\n\n";
+	int i;
+	for (i = 0; i < SSE_MAX_CLIENTS; i++) {
+		if (sse_clients[i] < 0) {
+			if (write_all(fd, header, (int)sizeof(header) - 1) < 0)
+				return -1;
+			sse_clients[i] = fd;
+			return 0;
+		}
+	}
+	return -1;
+}
+
+static void sse_drop_client(int i)
+{
+	if (sse_clients[i] >= 0) {
+		close(sse_clients[i]);
+		sse_clients[i] = -1;
+	}
+}
+
+/* Send one event (a JSON object) to all connected SSE clients. */
+static void sse_broadcast(const char *event_json)
+{
+	char frame[1200];
+	int len, i;
+	len = snprintf(frame, sizeof(frame), "data: %s\n\n", event_json);
+	if (len < 0 || len >= (int)sizeof(frame))
+		return;
+	for (i = 0; i < SSE_MAX_CLIENTS; i++) {
+		if (sse_clients[i] >= 0 && write_all(sse_clients[i], frame, len) < 0)
+			sse_drop_client(i);
+	}
+}
+
+/* Serve a single (non-SSE) request on fd: parse, dispatch, respond. */
+static void serve_request(int fd)
+{
+	char buf[REQUEST_BUF_SIZE];
+	http_request_t req;
+	http_response_t resp;
+	char header[512];
+	int header_len;
+
+	if (read_request(fd, buf, sizeof(buf)) <= 0)
+		return;
+
+	memset(&resp, 0, sizeof(resp));
+	resp.status = 200;
+	strcpy(resp.content_type, "text/plain");
+
+	if (parse_request(buf, &req) != 0) {
+		resp.body = strdup("bad request");
+		resp.len = resp.body ? (int)strlen(resp.body) : 0;
+		resp.status = 400;
+	}
+	else if (strcmp(req.method, "GET") != 0) {
+		resp.body = strdup("only GET is supported");
+		resp.len = resp.body ? (int)strlen(resp.body) : 0;
+		resp.status = 405;
+	}
+	else if (global_handler) {
+		global_handler(&req, &resp);
+		if (resp.sse) {
+			if (sse_add_client(fd) == 0)
+				return; /* keep the connection open, fd now owned by sse_clients */
+			free(resp.body);
+			resp.body = strdup("too many event stream clients");
+			resp.len = resp.body ? (int)strlen(resp.body) : 0;
+			resp.status = 503;
+			resp.sse = 0;
+		}
+	}
+	else {
+		resp.body = strdup("no handler");
+		resp.len = resp.body ? (int)strlen(resp.body) : 0;
+		resp.status = 500;
+	}
+
+	header_len = snprintf(header, sizeof(header),
+		"HTTP/1.1 %d %s\r\n"
+		"Content-Type: %s\r\n"
+		"Content-Length: %d\r\n"
+		"Access-Control-Allow-Origin: *\r\n"
+		"Connection: close\r\n\r\n",
+		resp.status, status_text(resp.status), resp.content_type, resp.len);
+	if (header_len > 0 && header_len < (int)sizeof(header)
+			&& write_all(fd, header, header_len) == 0
+			&& resp.body && resp.len > 0)
+		write_all(fd, resp.body, resp.len);
+	free(resp.body);
+}
+
+static void *http_server_thread(void *arg)
+{
+	int port = *(int *)arg;
+	struct sockaddr_in address;
+	int opt = 1;
+	int i;
+	free(arg);
+
+	for (i = 0; i < SSE_MAX_CLIENTS; i++)
+		sse_clients[i] = -1;
+
+	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (server_fd < 0) {
+		perror("remote_debug: socket");
+		return NULL;
+	}
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+		perror("remote_debug: setsockopt");
+
+	memset(&address, 0, sizeof(address));
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = htonl(INADDR_ANY);
+	address.sin_port = htons((unsigned short)port);
+
+	if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+		perror("remote_debug: bind");
+		close(server_fd);
+		server_fd = -1;
+		return NULL;
+	}
+	if (listen(server_fd, 10) < 0) {
+		perror("remote_debug: listen");
+		close(server_fd);
+		server_fd = -1;
+		return NULL;
+	}
+
+	printf("Remote Debugger: HTTP server listening on port %d\n", port);
+
+	while (!stop_requested) {
+		fd_set fds;
+		struct timeval tv;
+		int maxfd = server_fd;
+		int ret;
+
+		FD_ZERO(&fds);
+		FD_SET(server_fd, &fds);
+		for (i = 0; i < SSE_MAX_CLIENTS; i++) {
+			if (sse_clients[i] >= 0) {
+				FD_SET(sse_clients[i], &fds);
+				if (sse_clients[i] > maxfd)
+					maxfd = sse_clients[i];
+			}
+		}
+		tv.tv_sec = 0;
+		tv.tv_usec = POLL_TIMEOUT_USEC;
+		ret = select(maxfd + 1, &fds, NULL, NULL, &tv);
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			perror("remote_debug: select");
+			break;
+		}
+
+		/* Readable SSE clients have either disconnected or sent data we
+		 * do not expect; drop them in both cases. */
+		for (i = 0; i < SSE_MAX_CLIENTS; i++) {
+			if (sse_clients[i] >= 0 && FD_ISSET(sse_clients[i], &fds))
+				sse_drop_client(i);
+		}
+
+		/* Push pending events to SSE clients. */
+		if (global_events) {
+			char event[1024];
+			while (global_events(event, (int)sizeof(event)))
+				sse_broadcast(event);
+		}
+
+		if (FD_ISSET(server_fd, &fds)) {
+			socklen_t addrlen = sizeof(address);
+			int client = accept(server_fd, (struct sockaddr *)&address, &addrlen);
+			if (client < 0) {
+				if (errno != EINTR)
+					perror("remote_debug: accept");
+				continue;
+			}
+			serve_request(client);
+			/* SSE upgrades keep the fd; everything else is closed here.
+			 * Closing an fd twice would be a bug, so check ownership. */
+			for (i = 0; i < SSE_MAX_CLIENTS; i++) {
+				if (sse_clients[i] == client)
+					break;
+			}
+			if (i == SSE_MAX_CLIENTS)
+				close(client);
+		}
+	}
+
+	for (i = 0; i < SSE_MAX_CLIENTS; i++)
+		sse_drop_client(i);
+	close(server_fd);
+	server_fd = -1;
+	return NULL;
+}
+
+int http_server_start(int port, http_handler_t handler, http_event_source_t events)
+{
+	int *port_ptr;
+	global_handler = handler;
+	global_events = events;
+	stop_requested = 0;
+	port_ptr = malloc(sizeof(int));
+	if (!port_ptr)
+		return -1;
+	*port_ptr = port;
+	if (pthread_create(&server_thread, NULL, http_server_thread, port_ptr) != 0) {
+		perror("remote_debug: pthread_create");
+		free(port_ptr);
+		return -1;
+	}
+	thread_started = 1;
+	return 0;
+}
+
+void http_server_stop(void)
+{
+	if (!thread_started)
+		return;
+	stop_requested = 1;
+	pthread_join(server_thread, NULL);
+	thread_started = 0;
+}
+
+#endif /* REMOTE_DEBUG */

--- a/src/remote_debug/http_server.h
+++ b/src/remote_debug/http_server.h
@@ -1,0 +1,54 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - minimal embedded HTTP server                  *
+ *                                                                         *
+ * Single-threaded HTTP/1.1 server running in its own pthread. Regular     *
+ * requests are served strictly one at a time; in addition a small number  *
+ * of Server-Sent-Events (SSE) clients can stay connected and receive      *
+ * push notifications polled from an event source callback.                *
+ *                                                                         *
+ * Threading: the handler callback runs on the server thread. It must do   *
+ * its own locking against the emulator thread (see remote_debug_lock()).  *
+ ***************************************************************************/
+#ifndef HTTP_SERVER_H
+#define HTTP_SERVER_H
+
+/* Parsed HTTP request. query is the part after '?' (may be empty). */
+typedef struct http_request {
+	char method[16];
+	char path[256];
+	char query[512];
+} http_request_t;
+
+/* Response filled in by the handler.
+ * body must be malloc()ed (the server frees it) or NULL.
+ * status is an HTTP status code (200, 400, 404, 500, ...).
+ * Setting sse requests an SSE upgrade: the server sends a text/event-stream
+ * header and keeps the connection open; body/len are ignored in that case. */
+typedef struct http_response {
+	char *body;
+	int   len;
+	int   status;
+	int   sse;
+	char  content_type[64];
+} http_response_t;
+
+/* Request handler; runs on the HTTP server thread. */
+typedef void (*http_handler_t)(const http_request_t *req, http_response_t *resp);
+
+/* Event source for SSE push. Must copy the next pending event (a complete
+ * JSON object) into buf (NUL-terminated, at most maxlen bytes including the
+ * terminator) and return 1, or return 0 if no event is pending.
+ * Runs on the HTTP server thread. */
+typedef int (*http_event_source_t)(char *buf, int maxlen);
+
+/* Start the server thread listening on port. events may be NULL if SSE
+ * push is not used. Returns 0 on success, -1 on error. */
+int http_server_start(int port, http_handler_t handler, http_event_source_t events);
+
+/* Stop the server thread and wait for it to terminate. After this returns
+ * no handler is running anymore. */
+void http_server_stop(void);
+
+#endif /* HTTP_SERVER_H */

--- a/src/remote_debug/re_demo.sh
+++ b/src/remote_debug/re_demo.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Reverse-engineering demo: shows the tracing/coverage/tracepoint tools on a
+# running WPC game, chaining them into a realistic "how does this work" flow.
+#
+#   1. Coverage    - which code ran during a slice of attract mode
+#   2. Exec trace  - the exact instruction stream leading up to a halt
+#   3. Tracepoint  - log registers at a hot routine without stopping the game
+#   4. Watchpoint with value condition - catch the write that sets a value
+#   5. Monitor break-on-change - stop the moment a lamp/solenoid toggles
+#   6. Save-state diff - what RAM changed between two checkpoints
+#
+# Usage: ./re_demo.sh   (run from src/remote_debug)
+# Env overrides: ROM, ROMPATH, PORT, BINARY.
+
+PORT=${PORT:-8955}
+ROM=${ROM:-taf_l7}
+BINARY=${BINARY:-../../xpinmamed.x11}
+ROMPATH=${ROMPATH:-$HOME/.pinmame}
+BASE="http://localhost:$PORT"
+
+ROMPATH_ARGS=()
+[ -d "$ROMPATH" ] && ROMPATH_ARGS=(-rompath "$ROMPATH")
+
+# small JSON field extractor (python3 if present, else sed)
+jget() { python3 -c "import json,sys;print(json.load(sys.stdin)$1)" 2>/dev/null; }
+
+echo "=================================================="
+echo "PinMAME Remote Debugger - RE tooling demo ($ROM)"
+echo "=================================================="
+
+killall -9 "$(basename "$BINARY")" 2>/dev/null
+"$BINARY" -headless -httpport "$PORT" -nosound "${ROMPATH_ARGS[@]}" "$ROM" > /dev/null 2>&1 &
+PID=$!
+trap 'kill -9 $PID 2>/dev/null' EXIT
+echo "Booting..."; sleep 10
+
+echo
+echo "1. CODE COVERAGE -- record which addresses execute in 2s of attract mode"
+curl -s "$BASE/api/debugger/coverage?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/coverage?cmd=start" > /dev/null
+sleep 2
+curl -s "$BASE/api/debugger/coverage?cmd=stop" > /dev/null
+EXECUTED=$(curl -s "$BASE/api/debugger/coverage" | jget "['executed']")
+echo "   -> $EXECUTED distinct code addresses executed"
+echo "   (in the web UI, tick 'mark executed in disassembler' to see them highlighted)"
+
+echo
+echo "2. EXECUTION TRACE -- capture the instruction stream, then show the tail"
+curl -s "$BASE/api/debugger/exectrace?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/exectrace?cmd=start" > /dev/null
+sleep 1
+curl -s "$BASE/api/debugger/exectrace?cmd=stop" > /dev/null
+echo "   last 8 executed instructions (bank:pc  A B X):"
+curl -s "$BASE/api/debugger/exectrace" | python3 -c '
+import json,sys
+for e in json.load(sys.stdin)["trace"][-8:]:
+    bank = "--" if e["bank"]==-1 else "%02X"%e["bank"]
+    print("     %s:%04X  A=%02X B=%02X X=%04X" % (bank, e["pc"], e["a"], e["b"], e["x"]))
+' 2>/dev/null
+HOT=$(curl -s "$BASE/api/debugger/exectrace" | python3 -c "import json,sys;t=json.load(sys.stdin)['trace'];print('%X'%t[-1]['pc'])" 2>/dev/null)
+
+echo
+echo "3. TRACEPOINT -- log registers every time PC hits 0x$HOT, WITHOUT halting"
+curl -s "$BASE/api/debugger/tracepoints?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/tracepoints?cmd=add&addr=$HOT" > /dev/null
+sleep 1
+HITS=$(curl -s "$BASE/api/debugger/tracepoints" | jget "['points'][0]['hits']")
+PAUSED=$(curl -s "$BASE/api/info" | jget "['paused']")
+echo "   -> logged $HITS hits; emulator still running (paused=$PAUSED)"
+curl -s "$BASE/api/debugger/tracepoints?cmd=clear" > /dev/null
+
+echo
+echo "4. VALUE-CONDITION WATCHPOINT -- find a changing RAM byte, then catch the"
+echo "   write that sets it to a specific value"
+curl -s "$BASE/api/debugger/scan?cmd=new&addr=0000&size=2048" > /dev/null; sleep 1
+curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed" > /dev/null; sleep 1
+VAR=$(curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed" | python3 -c "import json,sys;r=json.load(sys.stdin)['results'];print('%X'%r[0]['addr']) if r else print('')" 2>/dev/null)
+if [ -n "$VAR" ]; then
+    echo "   watching 0x$VAR for a write of any non-0xFF value..."
+    curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+    curl -s "$BASE/api/debugger/watchpoints?cmd=add&addr=$VAR&mode=2&cond=ne&val=FF" > /dev/null
+    curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+    sleep 1.5
+    PAUSED=$(curl -s "$BASE/api/info" | jget "['paused']")
+    PC=$(curl -s "$BASE/api/debugger/state" | jget "['cpus'][0]['pc']")
+    echo "   -> halted=$PAUSED at PC=$PC (the instruction that wrote 0x$VAR)"
+    echo "   callstack:"
+    curl -s "$BASE/api/debugger/callstack" | python3 -c '
+import json,sys
+for e in json.load(sys.stdin).get("stack",[])[-4:]:
+    print("     %04X -> %04X (bank %02X)" % (e["caller"], e["receiver"], e["bank"]))
+' 2>/dev/null
+    curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+fi
+
+echo
+echo "5. MONITOR BREAK-ON-CHANGE -- stop the game the moment lamp 11 toggles"
+curl -s "$BASE/api/monitor?cmd=clear" > /dev/null
+curl -s "$BASE/api/monitor?cmd=add&type=lamp&id=11&break=1" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 3
+PAUSED=$(curl -s "$BASE/api/info" | jget "['paused']")
+echo "   -> halted=$PAUSED after lamp 11 changed state"
+curl -s "$BASE/api/monitor?cmd=clear" > /dev/null
+
+echo
+echo "6. SAVE-STATE DIFF -- checkpoint, run a moment, see what RAM changed"
+curl -s "$BASE/api/debugger/savestate?cmd=save&slot=demo" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 1
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+DIFFCOUNT=$(curl -s "$BASE/api/debugger/savestate/diff?a=demo" | jget "['count']")
+echo "   -> $DIFFCOUNT RAM bytes changed vs the checkpoint; first few:"
+curl -s "$BASE/api/debugger/savestate/diff?a=demo" | python3 -c '
+import json,sys
+for x in json.load(sys.stdin)["diffs"][:6]:
+    print("     0x%04X: %02X -> %02X" % (x["addr"], x["a"], x["b"]))
+' 2>/dev/null
+
+echo
+echo "=================================================="
+echo "Demo complete. Open $BASE/ui to drive these interactively."
+echo "=================================================="

--- a/src/remote_debug/remote_debug.c
+++ b/src/remote_debug/remote_debug.c
@@ -1,0 +1,2354 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - core                                          *
+ * See remote_debug.h for the interface and the threading model.           *
+ ***************************************************************************/
+#ifdef REMOTE_DEBUG
+
+#include "remote_debug.h"
+#include "http_server.h"
+#include "mame.h"
+#include "cpuexec.h"
+#include "cpuintrf.h"
+#include "cpu/m6809/m6809.h"
+#include "wpc/core.h"
+#include "wpc/wpc.h"
+#include "memory.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <signal.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <time.h>
+
+/* Control flags shared between the emulator and the HTTP server thread.
+ * sig_atomic_t reads/writes are atomic; no lock needed for these. */
+static volatile sig_atomic_t is_paused = 0;
+static volatile sig_atomic_t step_requested = 0;
+static volatile sig_atomic_t should_quit = 0;
+
+static pthread_mutex_t mame_mutex;
+volatile int remote_debug_ready = 0;
+
+/* Provided by api_handler.c (HTTP request dispatch). */
+extern void api_handler(const http_request_t *req, http_response_t *resp);
+/* Provided by src/wpc/wpc.c; -1 when no WPC banking is active. */
+extern int wpc_get_bank(void);
+/* Provided by src/wpc/wpc.c; base of the WPC RAM (NULL on non-WPC games). */
+extern UINT8 *wpc_ram;
+
+/* ------------------------------------------------------------------ */
+/* Breakpoints / watchpoints                                          */
+/* ------------------------------------------------------------------ */
+
+/* Condition operators for conditional breakpoints. */
+enum {
+	COND_NONE = 0,
+	COND_EQ,
+	COND_NE,
+	COND_LT,
+	COND_GT,
+	COND_LE,
+	COND_GE
+};
+
+#define MAX_POINTS 128
+
+typedef struct {
+	UINT32 adr;
+	int bank;             /* -1: any bank */
+	int enabled;
+	int temp;             /* one-shot (run-to/step-over/step-out) */
+	int cond_op;          /* COND_NONE for unconditional */
+	int cond_reg;         /* cpu core register id */
+	UINT32 cond_val;
+	char cond_str[24];    /* original condition text for display */
+	UINT32 hit_count;     /* number of (condition-true) hits so far */
+	UINT32 ignore_count;  /* skip this many hits before halting */
+} breakpoint_t;
+
+static breakpoint_t breakpoints[MAX_POINTS];
+static int breakpoint_count = 0;
+
+typedef struct {
+	UINT32 adr;
+	int len;              /* watched range is [adr, adr+len) */
+	int mode;             /* REMOTE_DEBUG_WP_* */
+	int bank;             /* -1: any bank (only relevant for 0x4000-0x7FFF) */
+	int cond_op;          /* COND_NONE, or compare the byte at adr to cond_val */
+	UINT8 cond_val;
+	int enabled;
+} watchpoint_t;
+
+static watchpoint_t watchpoints[MAX_POINTS];
+static int watchpoint_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Memory access trace                                                */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	UINT32 adr;
+	int length;
+	int write;
+	UINT32 pc;
+	int cpunum;
+	int bank;
+} trace_entry_t;
+
+#define TRACE_LOG_SIZE 1024
+static trace_entry_t trace_log[TRACE_LOG_SIZE];
+static int trace_head = 0;
+static int trace_count = 0;
+
+#define TRACE_ADDR_MAX 128
+static UINT32 trace_addrs[TRACE_ADDR_MAX];
+static int trace_addr_banks[TRACE_ADDR_MAX];  /* -1: any bank */
+static int trace_addr_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Timed switch pulses                                                */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	int sw;
+	int heldval;   /* value re-asserted every frame during the pulse */
+	int offval;    /* value to restore when the pulse expires */
+	UINT32 expiry; /* monotonic_ms() deadline */
+} pulse_t;
+
+#define PULSE_MAX 32
+static pulse_t pulses[PULSE_MAX];
+static int pulse_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Object monitoring / action log                                     */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	int type;       /* REMOTE_DEBUG_OBJ_* */
+	int id;         /* switch/lamp number or solenoid number */
+	int last;       /* last sampled state */
+	int brk;        /* halt execution when this object changes */
+} monitor_t;
+
+#define MONITOR_MAX 64
+static monitor_t monitors[MONITOR_MAX];
+static int monitor_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Execution trace / coverage / tracepoints (per-instruction hook)    */
+/* ------------------------------------------------------------------ */
+
+/* Execution trace: ring buffer of the most recently executed instructions,
+ * for answering "how did I get here" after a halt. */
+typedef struct {
+	UINT16 pc;
+	INT16  bank;
+	UINT8  a, b;
+	UINT16 x;
+} exec_trace_t;
+
+#define EXEC_TRACE_SIZE 8192
+static exec_trace_t exec_trace[EXEC_TRACE_SIZE];
+static int exec_trace_head = 0;
+static int exec_trace_count = 0;
+static volatile sig_atomic_t exec_trace_enabled = 0;
+
+/* Coverage: a bitmap over an "effective ROM address" so banked code is
+ * tracked per bank. Allocated lazily when coverage is first enabled. */
+static UINT8 *coverage_bitmap = NULL;
+static UINT32 coverage_bits = 0;    /* number of addressable bits */
+static UINT32 coverage_count = 0;   /* distinct addresses executed */
+static volatile sig_atomic_t coverage_enabled = 0;
+
+/* Tracepoints: like breakpoints but log a register snapshot and continue. */
+typedef struct {
+	UINT32 addr;
+	int bank;
+	UINT32 hits;
+} tracepoint_t;
+
+static tracepoint_t tracepoints[MAX_POINTS];
+static int tracepoint_count = 0;
+
+typedef struct {
+	UINT32 pc;
+	int bank;
+	UINT16 x, y, u, s;
+	UINT8 a, b, dp, cc;
+} tp_log_t;
+
+#define TP_LOG_SIZE 512
+static tp_log_t tp_log[TP_LOG_SIZE];
+static int tp_head = 0;
+static int tp_count = 0;
+
+typedef struct {
+	int type;
+	int id;
+	int val;
+	UINT32 time;
+} action_t;
+
+#define ACTION_LOG_SIZE 512
+static action_t action_log[ACTION_LOG_SIZE];
+static int action_head = 0;
+static int action_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Code instrumentation (PC hit counting)                             */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	UINT32 addr;
+	int bank;       /* -1: any bank */
+	UINT32 count;
+} instrument_t;
+
+#define INSTRUMENT_MAX 128
+static instrument_t instruments[INSTRUMENT_MAX];
+static int instrument_count = 0;
+
+/* ------------------------------------------------------------------ */
+/* Memory value scan                                                  */
+/* ------------------------------------------------------------------ */
+
+#define SCAN_MAX 0x2000
+static int    scan_cpu = 0;
+static UINT32 scan_base = 0;
+static int    scan_size = 0;          /* 0 = no active scan */
+static UINT8  scan_snapshot[SCAN_MAX];
+static UINT8  scan_candidate[SCAN_MAX]; /* 1 = offset still matches */
+
+/* ------------------------------------------------------------------ */
+/* Lightweight game-state checkpoints (WPC RAM + main CPU registers)  */
+/* ------------------------------------------------------------------ */
+
+#define SAVESTATE_SLOTS 8
+#define SAVESTATE_RAM   0x3000   /* WPC RAM size */
+
+typedef struct {
+	char   name[32];
+	int    used;
+	int    ramlen;
+	UINT8  ram[SAVESTATE_RAM];
+	UINT16 pc, s, u, x, y;
+	UINT8  a, b, dp, cc;
+} savestate_t;
+
+static savestate_t savestates[SAVESTATE_SLOTS];
+
+/* ------------------------------------------------------------------ */
+/* DMD frame recorder                                                 */
+/* ------------------------------------------------------------------ */
+
+#define DMD_REC_FRAMES 512    /* ring capacity (~8s at 60Hz) */
+#define DMD_REC_PIX    4096   /* max pixels per frame (128x32) */
+
+typedef struct {
+	UINT32 t;                 /* monotonic_ms() timestamp */
+	UINT8  pix[DMD_REC_PIX];  /* one luminance byte per pixel */
+} dmd_frame_t;
+
+static dmd_frame_t *dmd_rec = NULL;   /* allocated lazily on first use */
+static int dmd_rec_head = 0;
+static int dmd_rec_count = 0;
+static int dmd_rec_w = 0, dmd_rec_h = 0;
+static volatile sig_atomic_t dmd_recording = 0;
+
+/* ------------------------------------------------------------------ */
+/* Callstack                                                          */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	UINT32 caller;    /* address of the call instruction */
+	UINT32 receiver;  /* call target */
+	int bank;
+	UINT16 pc, u, s, x, y;  /* pc is the return address */
+	UINT8 a, b, dp, cc;
+} callstack_entry_t;
+
+#define CALLSTACK_SIZE 128
+static callstack_entry_t callstack[CALLSTACK_SIZE];
+static int callstack_ptr = 0;
+
+/* ------------------------------------------------------------------ */
+/* Messages and SSE events                                            */
+/* ------------------------------------------------------------------ */
+
+#define MSG_QUEUE_SIZE 50
+#define MSG_LEN 128
+static char msg_queue[MSG_QUEUE_SIZE][MSG_LEN];
+static int msg_head = 0;
+static int msg_count = 0;
+
+#define EVENT_QUEUE_SIZE 32
+#define EVENT_LEN 320
+static char event_queue[EVENT_QUEUE_SIZE][EVENT_LEN];
+static int event_head = 0;  /* next slot to write */
+static int event_tail = 0;  /* next slot to read */
+
+void remote_debug_lock(void)   { pthread_mutex_lock(&mame_mutex); }
+void remote_debug_unlock(void) { pthread_mutex_unlock(&mame_mutex); }
+
+/* Read a byte, optionally from a specific WPC ROM bank.
+ *
+ * The WPC banked ROM window is 0x4000-0x7FFF; a bank of -1 (or any address
+ * outside that window, or a non-WPC machine) reads through the CPU's current
+ * memory map. When a bank is given for an address in the window, the byte is
+ * read directly from the ROM region without touching live banking, so it is
+ * side-effect free. The caller must hold the debugger lock. */
+UINT8 remote_debug_read_byte(int cpu, UINT32 addr, int bank)
+{
+	if (bank >= 0 && cpu == 0 && wpc_ram && addr >= 0x4000 && addr < 0x8000) {
+		UINT8 *rom = memory_region(WPC_ROMREGION);
+		if (rom) {
+			UINT32 off = (UINT32)bank * 0x4000 + (addr - 0x4000);
+			if (off < (UINT32)memory_region_length(WPC_ROMREGION))
+				return rom[off];
+		}
+	}
+	return cpunum_read_byte(cpu, addr);
+}
+
+/* Monotonic milliseconds since an arbitrary epoch (for timestamps/pulses). */
+static UINT32 monotonic_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (UINT32)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+char *remote_debug_json_escape(char *dst, int dstlen, const char *src)
+{
+	int o = 0;
+	dst[0] = 0;
+	if (!src)
+		return dst;
+	while (*src && o < dstlen - 7) {
+		unsigned char c = (unsigned char)*src++;
+		if (c == '"' || c == '\\') {
+			dst[o++] = '\\';
+			dst[o++] = (char)c;
+		}
+		else if (c < 0x20) {
+			o += snprintf(dst + o, (size_t)(dstlen - o), "\\u%04x", c);
+		}
+		else {
+			dst[o++] = (char)c;
+		}
+	}
+	dst[o] = 0;
+	return dst;
+}
+
+/* Queue a JSON event object for the SSE clients (drops the oldest event
+ * when the queue is full). Takes the lock itself. */
+static void publish_event(const char *fmt, ...)
+{
+	va_list ap;
+	remote_debug_lock();
+	va_start(ap, fmt);
+	vsnprintf(event_queue[event_head], EVENT_LEN, fmt, ap);
+	va_end(ap);
+	event_head = (event_head + 1) % EVENT_QUEUE_SIZE;
+	if (event_head == event_tail)
+		event_tail = (event_tail + 1) % EVENT_QUEUE_SIZE;
+	remote_debug_unlock();
+}
+
+/* forward declarations; defined with the pulse implementation below */
+static void service_pulses(void);
+static void pulse_tick(int reassert);
+
+int remote_debug_next_event(char *buf, int maxlen)
+{
+	int have = 0;
+	/* The HTTP server thread calls this on every poll tick, so it is a
+	 * convenient pause-independent place to expire timed switch pulses. */
+	service_pulses();
+	remote_debug_lock();
+	if (event_tail != event_head) {
+		strncpy(buf, event_queue[event_tail], (size_t)maxlen - 1);
+		buf[maxlen - 1] = 0;
+		event_tail = (event_tail + 1) % EVENT_QUEUE_SIZE;
+		have = 1;
+	}
+	remote_debug_unlock();
+	return have;
+}
+
+void remote_debug_add_message(const char *msg)
+{
+	char esc[2 * MSG_LEN];
+	remote_debug_lock();
+	strncpy(msg_queue[msg_head], msg, MSG_LEN - 1);
+	msg_queue[msg_head][MSG_LEN - 1] = 0;
+	msg_head = (msg_head + 1) % MSG_QUEUE_SIZE;
+	if (msg_count < MSG_QUEUE_SIZE)
+		msg_count++;
+	remote_debug_unlock();
+	publish_event("{\"event\": \"message\", \"text\": \"%s\"}",
+	              remote_debug_json_escape(esc, (int)sizeof(esc), msg));
+}
+
+/* ------------------------------------------------------------------ */
+/* Growable string buffer for the JSON dump functions                 */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+	char *buf;
+	int len;
+	int cap;
+} strbuf_t;
+
+static void sb_init(strbuf_t *sb, int initial)
+{
+	sb->buf = malloc((size_t)initial);
+	sb->cap = sb->buf ? initial : 0;
+	sb->len = 0;
+	if (sb->buf)
+		sb->buf[0] = 0;
+}
+
+static void sb_appendf(strbuf_t *sb, const char *fmt, ...)
+{
+	va_list ap;
+	int need;
+
+	if (!sb->buf)
+		return;
+	va_start(ap, fmt);
+	need = vsnprintf(sb->buf + sb->len, (size_t)(sb->cap - sb->len), fmt, ap);
+	va_end(ap);
+	if (need < 0)
+		return;
+	if (need >= sb->cap - sb->len) {
+		int newcap = sb->cap * 2;
+		char *newbuf;
+		while (newcap - sb->len <= need)
+			newcap *= 2;
+		newbuf = realloc(sb->buf, (size_t)newcap);
+		if (!newbuf)
+			return;  /* keep the truncated content */
+		sb->buf = newbuf;
+		sb->cap = newcap;
+		va_start(ap, fmt);
+		need = vsnprintf(sb->buf + sb->len, (size_t)(sb->cap - sb->len), fmt, ap);
+		va_end(ap);
+		if (need < 0)
+			return;
+	}
+	sb->len += need;
+}
+
+/* ------------------------------------------------------------------ */
+/* Lifecycle                                                          */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_init(void)
+{
+	pthread_mutexattr_t attr;
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&mame_mutex, &attr);
+	pthread_mutexattr_destroy(&attr);
+
+	if (pmoptions.start_paused) {
+		is_paused = 1;
+		printf("Remote Debugger: paused on start\n");
+	}
+	should_quit = 0;
+	step_requested = 0;
+	breakpoint_count = 0;
+	watchpoint_count = 0;
+	msg_head = msg_count = 0;
+	event_head = event_tail = 0;
+	trace_head = trace_count = 0;
+	trace_addr_count = 0;
+	callstack_ptr = 0;
+	pulse_count = 0;
+	monitor_count = 0;
+	action_head = action_count = 0;
+	instrument_count = 0;
+	scan_size = 0;
+	dmd_recording = 0;
+	dmd_rec_head = dmd_rec_count = 0;
+	memset(savestates, 0, sizeof(savestates));
+	exec_trace_enabled = 0;
+	exec_trace_head = exec_trace_count = 0;
+	coverage_enabled = 0;
+	coverage_count = 0;
+	tracepoint_count = 0;
+	tp_head = tp_count = 0;
+	remote_debug_ready = 1;
+	http_server_start(pmoptions.http_port, api_handler, remote_debug_next_event);
+}
+
+void remote_debug_exit(void)
+{
+	remote_debug_ready = 0;
+	/* http_server_stop() joins the server thread, so no handler can hold
+	 * the mutex once it returns and destroying the mutex is safe. */
+	http_server_stop();
+	if (dmd_rec) {
+		free(dmd_rec);
+		dmd_rec = NULL;
+	}
+	if (coverage_bitmap) {
+		free(coverage_bitmap);
+		coverage_bitmap = NULL;
+	}
+	pthread_mutex_destroy(&mame_mutex);
+}
+
+/* ------------------------------------------------------------------ */
+/* Execution control                                                  */
+/* ------------------------------------------------------------------ */
+
+int remote_debug_is_paused(void)
+{
+	if (should_quit)
+		return 0;
+	if (step_requested) {
+		step_requested = 0;
+		return 0;
+	}
+	if (is_paused)
+		usleep(10000);
+	return is_paused;
+}
+
+void remote_debug_set_paused(int paused)
+{
+	int was = is_paused;
+	is_paused = paused ? 1 : 0;
+	if (was != is_paused)
+		publish_event("{\"event\": \"%s\", \"reason\": \"user\"}",
+		              is_paused ? "halt" : "resume");
+}
+
+void remote_debug_step(void)
+{
+	is_paused = 1;
+	step_requested = 1;
+	publish_event("{\"event\": \"step\"}");
+}
+
+void remote_debug_quit(void)
+{
+	printf("Remote Debugger: quit requested\n");
+	should_quit = 1;
+	publish_event("{\"event\": \"quit\"}");
+}
+
+int remote_debug_should_quit(void)
+{
+	return should_quit;
+}
+
+/* ------------------------------------------------------------------ */
+/* Breakpoints                                                        */
+/* ------------------------------------------------------------------ */
+
+/* Resolve an M6809 register name for breakpoint conditions. */
+static int resolve_cond_register(const char *name, int len)
+{
+	if (len == 1) {
+		switch (name[0]) {
+			case 'A': return M6809_A;
+			case 'B': return M6809_B;
+			case 'X': return M6809_X;
+			case 'Y': return M6809_Y;
+			case 'U': return M6809_U;
+			case 'S': return M6809_S;
+			default: break;
+		}
+	}
+	else if (len == 2) {
+		if (strncmp(name, "PC", 2) == 0) return M6809_PC;
+		if (strncmp(name, "SP", 2) == 0) return M6809_S;
+		if (strncmp(name, "CC", 2) == 0) return M6809_CC;
+		if (strncmp(name, "DP", 2) == 0) return M6809_DP;
+	}
+	return -1;
+}
+
+/* Parse "REG==HEXVAL" style conditions. Returns 0 on success. */
+static int parse_condition(const char *cond, int *op, int *reg, UINT32 *val)
+{
+	static const struct { const char *sym; int op; } ops[] = {
+		{"==", COND_EQ}, {"!=", COND_NE}, {"<=", COND_LE},
+		{">=", COND_GE}, {"<", COND_LT}, {">", COND_GT}
+	};
+	size_t i;
+
+	*op = COND_NONE;
+	if (!cond || !cond[0])
+		return 0;
+	for (i = 0; i < sizeof(ops) / sizeof(ops[0]); i++) {
+		const char *p = strstr(cond, ops[i].sym);
+		if (p && p > cond) {
+			int r = resolve_cond_register(cond, (int)(p - cond));
+			const char *v = p + strlen(ops[i].sym);
+			char *end = NULL;
+			UINT32 value;
+			if (r < 0 || !*v)
+				return -1;
+			value = (UINT32)strtoul(v, &end, 16);
+			if (end == v)
+				return -1;
+			*op = ops[i].op;
+			*reg = r;
+			*val = value;
+			return 0;
+		}
+	}
+	return -1;
+}
+
+static int cond_matches(const breakpoint_t *bp)
+{
+	UINT32 v;
+	if (bp->cond_op == COND_NONE)
+		return 1;
+	v = activecpu_get_reg(bp->cond_reg);
+	switch (bp->cond_op) {
+		case COND_EQ: return v == bp->cond_val;
+		case COND_NE: return v != bp->cond_val;
+		case COND_LT: return v <  bp->cond_val;
+		case COND_GT: return v >  bp->cond_val;
+		case COND_LE: return v <= bp->cond_val;
+		case COND_GE: return v >= bp->cond_val;
+		default:      return 1;
+	}
+}
+
+/* Internal add; temp breakpoints are silent. */
+static int breakpoint_add_internal(UINT32 adr, int bank, int temp,
+                                   const char *cond, UINT32 ignore)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (breakpoint_count < MAX_POINTS) {
+		breakpoint_t *bp = &breakpoints[breakpoint_count];
+		memset(bp, 0, sizeof(*bp));
+		bp->adr = adr;
+		bp->bank = bank;
+		bp->enabled = 1;
+		bp->temp = temp;
+		bp->ignore_count = ignore;
+		if (parse_condition(cond, &bp->cond_op, &bp->cond_reg, &bp->cond_val) == 0) {
+			if (bp->cond_op != COND_NONE) {
+				strncpy(bp->cond_str, cond, sizeof(bp->cond_str) - 1);
+				bp->cond_str[sizeof(bp->cond_str) - 1] = 0;
+			}
+			breakpoint_count++;
+			result = 0;
+			if (!temp) {
+				char b[MSG_LEN];
+				if (bank != -1)
+					snprintf(b, sizeof(b), "BP added at %02X:%04X", bank, adr);
+				else
+					snprintf(b, sizeof(b), "BP added at %04X", adr);
+				remote_debug_add_message(b);
+			}
+		}
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, const char *cond, UINT32 ignore)
+{
+	return breakpoint_add_internal(adr, bank, 0, cond, ignore);
+}
+
+void remote_debug_breakpoint_add(UINT32 adr)
+{
+	breakpoint_add_internal(adr, -1, 0, NULL, 0);
+}
+
+void remote_debug_breakpoint_add_banked(UINT32 adr, int bank)
+{
+	breakpoint_add_internal(adr, bank, 0, NULL, 0);
+}
+
+void remote_debug_breakpoint_clear(void)
+{
+	remote_debug_lock();
+	breakpoint_count = 0;
+	remote_debug_unlock();
+	remote_debug_add_message("Breakpoints cleared");
+}
+
+void remote_debug_breakpoint_toggle(int index)
+{
+	remote_debug_lock();
+	if (index >= 0 && index < breakpoint_count)
+		breakpoints[index].enabled = !breakpoints[index].enabled;
+	remote_debug_unlock();
+}
+
+void remote_debug_breakpoint_delete(int index)
+{
+	int i;
+	remote_debug_lock();
+	if (index >= 0 && index < breakpoint_count) {
+		for (i = index; i < breakpoint_count - 1; i++)
+			breakpoints[i] = breakpoints[i + 1];
+		breakpoint_count--;
+	}
+	remote_debug_unlock();
+}
+
+/* Per-instruction hook. Runs on the emulator thread which holds the
+ * debugger lock for the whole timeslice (see cpuexec.c), so plain reads
+ * of the breakpoint table are safe here without locking again. */
+/* Effective address for the coverage bitmap: banked-window code is indexed
+ * per bank so different banks at the same CPU address are distinguished. */
+static UINT32 coverage_index(UINT32 pc, int bank)
+{
+	if (bank >= 0 && pc >= 0x4000 && pc < 0x8000)
+		return 0x10000 + (UINT32)bank * 0x4000 + (pc - 0x4000);
+	return pc & 0xFFFF;
+}
+
+void remote_debug_breakpoint_hook(void)
+{
+	UINT32 pc;
+	int current_bank, i;
+
+	if (breakpoint_count == 0 && instrument_count == 0 && tracepoint_count == 0
+			&& !exec_trace_enabled && !coverage_enabled)
+		return;
+	pc = activecpu_get_reg(REG_PC);
+	current_bank = wpc_get_bank();
+
+	/* execution trace: record this instruction in the ring buffer */
+	if (exec_trace_enabled) {
+		exec_trace_t *e = &exec_trace[exec_trace_head];
+		e->pc = (UINT16)pc;
+		e->bank = (INT16)current_bank;
+		e->a = (UINT8)activecpu_get_reg(M6809_A);
+		e->b = (UINT8)activecpu_get_reg(M6809_B);
+		e->x = (UINT16)activecpu_get_reg(M6809_X);
+		exec_trace_head = (exec_trace_head + 1) % EXEC_TRACE_SIZE;
+		if (exec_trace_count < EXEC_TRACE_SIZE)
+			exec_trace_count++;
+	}
+
+	/* coverage: mark this address as executed */
+	if (coverage_enabled && coverage_bitmap) {
+		UINT32 idx = coverage_index(pc, current_bank);
+		if (idx < coverage_bits) {
+			UINT8 mask = (UINT8)(1 << (idx & 7));
+			if (!(coverage_bitmap[idx >> 3] & mask)) {
+				coverage_bitmap[idx >> 3] |= mask;
+				coverage_count++;
+			}
+		}
+	}
+
+	/* tracepoints: log a register snapshot and continue (no halt) */
+	for (i = 0; i < tracepoint_count; i++) {
+		if (tracepoints[i].addr == pc
+				&& (tracepoints[i].bank == -1 || tracepoints[i].bank == current_bank)) {
+			tp_log_t *t = &tp_log[tp_head];
+			tracepoints[i].hits++;
+			t->pc = pc;
+			t->bank = current_bank;
+			t->a = (UINT8)activecpu_get_reg(M6809_A);
+			t->b = (UINT8)activecpu_get_reg(M6809_B);
+			t->x = (UINT16)activecpu_get_reg(M6809_X);
+			t->y = (UINT16)activecpu_get_reg(M6809_Y);
+			t->u = (UINT16)activecpu_get_reg(M6809_U);
+			t->s = (UINT16)activecpu_get_reg(REG_SP);
+			t->dp = (UINT8)activecpu_get_reg(M6809_DP);
+			t->cc = (UINT8)activecpu_get_reg(M6809_CC);
+			tp_head = (tp_head + 1) % TP_LOG_SIZE;
+			if (tp_count < TP_LOG_SIZE)
+				tp_count++;
+		}
+	}
+
+	/* code instrumentation: count passes over marked addresses */
+	for (i = 0; i < instrument_count; i++) {
+		if (instruments[i].addr == pc
+				&& (instruments[i].bank == -1 || instruments[i].bank == current_bank))
+			instruments[i].count++;
+	}
+
+	for (i = 0; i < breakpoint_count; i++) {
+		breakpoint_t *bp = &breakpoints[i];
+		if (!bp->enabled || pc != bp->adr)
+			continue;
+		if (bp->bank != -1 && current_bank != bp->bank)
+			continue;
+		if (!cond_matches(bp))
+			continue;
+		bp->hit_count++;
+		if (!bp->temp && bp->hit_count <= bp->ignore_count)
+			continue;
+
+		is_paused = 1;
+		activecpu_abort_timeslice();
+		{
+			char b[MSG_LEN];
+			if (current_bank != -1)
+				snprintf(b, sizeof(b), "Halt: BP at %02X:%04X", current_bank, pc);
+			else
+				snprintf(b, sizeof(b), "Halt: BP at %04X", pc);
+			if (bp->temp) {
+				int j;
+				for (j = i; j < breakpoint_count - 1; j++)
+					breakpoints[j] = breakpoints[j + 1];
+				breakpoint_count--;
+			}
+			remote_debug_add_message(b);
+			publish_event("{\"event\": \"halt\", \"reason\": \"bp\", \"pc\": %u, \"bank\": %d}",
+			              pc, current_bank);
+			printf("Remote Debugger: %s\n", b);
+		}
+		break;
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* Watchpoints and memory access trace                                */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_watchpoint_add(UINT32 adr, int len, int mode, int bank,
+                                 int cond_op, UINT8 cond_val)
+{
+	remote_debug_lock();
+	if (watchpoint_count < MAX_POINTS) {
+		char b[MSG_LEN];
+		watchpoints[watchpoint_count].adr = adr;
+		watchpoints[watchpoint_count].len = (len > 0) ? len : 1;
+		watchpoints[watchpoint_count].mode = mode;
+		watchpoints[watchpoint_count].bank = bank;
+		watchpoints[watchpoint_count].cond_op = cond_op;
+		watchpoints[watchpoint_count].cond_val = cond_val;
+		watchpoints[watchpoint_count].enabled = 1;
+		watchpoint_count++;
+		if (bank != -1)
+			snprintf(b, sizeof(b), "WP added at %02X:%04X len %d", bank, adr, (len > 0) ? len : 1);
+		else
+			snprintf(b, sizeof(b), "WP added at %04X len %d", adr, (len > 0) ? len : 1);
+		remote_debug_unlock();
+		remote_debug_add_message(b);
+		return;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_watchpoint_clear(void)
+{
+	remote_debug_lock();
+	watchpoint_count = 0;
+	remote_debug_unlock();
+	remote_debug_add_message("Watchpoints cleared");
+}
+
+void remote_debug_watchpoint_toggle(int index)
+{
+	remote_debug_lock();
+	if (index >= 0 && index < watchpoint_count)
+		watchpoints[index].enabled = !watchpoints[index].enabled;
+	remote_debug_unlock();
+}
+
+void remote_debug_watchpoint_delete(int index)
+{
+	int i;
+	remote_debug_lock();
+	if (index >= 0 && index < watchpoint_count) {
+		for (i = index; i < watchpoint_count - 1; i++)
+			watchpoints[i] = watchpoints[i + 1];
+		watchpoint_count--;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_trace_add(UINT32 adr, int bank)
+{
+	remote_debug_lock();
+	if (trace_addr_count < TRACE_ADDR_MAX) {
+		trace_addrs[trace_addr_count] = adr;
+		trace_addr_banks[trace_addr_count] = bank;
+		trace_addr_count++;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_trace_clear(void)
+{
+	remote_debug_lock();
+	trace_addr_count = 0;
+	trace_head = 0;
+	trace_count = 0;
+	remote_debug_unlock();
+}
+
+/* Memory access hook; like remote_debug_breakpoint_hook() this runs with
+ * the debugger lock effectively held by the emulator thread. */
+void remote_debug_memref(UINT32 adr, int length, int write)
+{
+	int i, active_cpu, current_bank;
+
+	if (watchpoint_count == 0 && trace_addr_count == 0)
+		return;
+	active_cpu = cpu_getactivecpu();
+	if (active_cpu < 0)
+		return;
+	current_bank = wpc_get_bank();
+
+	for (i = 0; i < watchpoint_count; i++) {
+		const watchpoint_t *wp = &watchpoints[i];
+		int hit;
+		if (!wp->enabled)
+			continue;
+		/* ranges [adr, adr+length) and [wp->adr, wp->adr+wp->len) overlap? */
+		if (!(adr < wp->adr + (UINT32)wp->len && wp->adr < adr + (UINT32)length))
+			continue;
+		/* bank filter (only meaningful for the 0x4000-0x7FFF window) */
+		if (wp->bank != -1 && current_bank != wp->bank)
+			continue;
+		hit = (wp->mode == REMOTE_DEBUG_WP_RW)
+		   || (wp->mode == REMOTE_DEBUG_WP_READ && !write)
+		   || (wp->mode == REMOTE_DEBUG_WP_WRITE && write);
+		/* optional value condition: only halt when the byte at the
+		 * watched address satisfies the comparison */
+		if (hit && wp->cond_op != COND_NONE) {
+			UINT8 v = cpunum_read_byte(active_cpu, wp->adr);
+			int ok;
+			switch (wp->cond_op) {
+				case COND_EQ: ok = (v == wp->cond_val); break;
+				case COND_NE: ok = (v != wp->cond_val); break;
+				case COND_LT: ok = (v <  wp->cond_val); break;
+				case COND_GT: ok = (v >  wp->cond_val); break;
+				case COND_LE: ok = (v <= wp->cond_val); break;
+				case COND_GE: ok = (v >= wp->cond_val); break;
+				default:      ok = 1;                   break;
+			}
+			if (!ok)
+				hit = 0;
+		}
+		if (hit) {
+			UINT32 pc = activecpu_get_reg(REG_PC);
+			char b[MSG_LEN];
+			is_paused = 1;
+			activecpu_abort_timeslice();
+			snprintf(b, sizeof(b), "Halt: WP %s at %04X (PC=%04X, Bank=%02X)",
+			         write ? "write" : "read", adr, pc, current_bank);
+			remote_debug_add_message(b);
+			publish_event("{\"event\": \"halt\", \"reason\": \"wp\", \"addr\": %u, \"pc\": %u, \"bank\": %d}",
+			              adr, pc, current_bank);
+			printf("Remote Debugger: %s\n", b);
+		}
+	}
+
+	for (i = 0; i < trace_addr_count; i++) {
+		if (trace_addr_banks[i] != -1 && current_bank != trace_addr_banks[i])
+			continue;
+		if (adr < trace_addrs[i] + 1 && trace_addrs[i] < adr + (UINT32)length) {
+			trace_entry_t *e = &trace_log[trace_head];
+			e->adr = adr;
+			e->length = length;
+			e->write = write;
+			e->cpunum = active_cpu;
+			e->pc = activecpu_get_reg(REG_PC);
+			e->bank = current_bank;
+			trace_head = (trace_head + 1) % TRACE_LOG_SIZE;
+			if (trace_count < TRACE_LOG_SIZE)
+				trace_count++;
+			break;
+		}
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* JSON dumps                                                         */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_get_points(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"breakpoints\": [");
+	for (i = 0; i < breakpoint_count; i++) {
+		const breakpoint_t *bp = &breakpoints[i];
+		char esc[64];
+		sb_appendf(&sb,
+			"%s{\"idx\": %d, \"addr\": %u, \"bank\": %d, \"enabled\": %d, "
+			"\"temp\": %d, \"cond\": \"%s\", \"hits\": %u, \"ignore\": %u}",
+			(i > 0) ? "," : "", i, bp->adr, bp->bank, bp->enabled, bp->temp,
+			remote_debug_json_escape(esc, (int)sizeof(esc), bp->cond_str),
+			bp->hit_count, bp->ignore_count);
+	}
+	sb_appendf(&sb, "], \"watchpoints\": [");
+	for (i = 0; i < watchpoint_count; i++) {
+		const watchpoint_t *wp = &watchpoints[i];
+		static const char *opname[] = {"", "==", "!=", "<", ">", "<=", ">="};
+		char cond[16];
+		if (wp->cond_op != COND_NONE)
+			snprintf(cond, sizeof(cond), "%s%02X", opname[wp->cond_op], wp->cond_val);
+		else
+			cond[0] = 0;
+		sb_appendf(&sb,
+			"%s{\"idx\": %d, \"addr\": %u, \"len\": %d, \"mode\": %d, \"bank\": %d, \"cond\": \"%s\", \"enabled\": %d}",
+			(i > 0) ? "," : "", i, wp->adr, wp->len, wp->mode, wp->bank, cond, wp->enabled);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_messages(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"messages\": [");
+	for (i = 0; i < msg_count; i++) {
+		int idx = (msg_head - msg_count + i + MSG_QUEUE_SIZE) % MSG_QUEUE_SIZE;
+		char esc[2 * MSG_LEN];
+		sb_appendf(&sb, "%s\"%s\"", (i > 0) ? "," : "",
+		           remote_debug_json_escape(esc, (int)sizeof(esc), msg_queue[idx]));
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_callstack(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"stack\": [");
+	for (i = 0; i < callstack_ptr; i++) {
+		const callstack_entry_t *e = &callstack[i];
+		sb_appendf(&sb,
+			"%s{\"caller\": %u, \"receiver\": %u, \"bank\": %d, \"pc\": %d, "
+			"\"u\": %d, \"s\": %d, \"x\": %d, \"y\": %d, \"a\": %d, \"b\": %d, "
+			"\"dp\": %d, \"cc\": %d}",
+			(i > 0) ? "," : "", e->caller, e->receiver, e->bank, e->pc,
+			e->u, e->s, e->x, e->y, e->a, e->b, e->dp, e->cc);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_trace(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"watched\": [");
+	for (i = 0; i < trace_addr_count; i++)
+		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d}",
+		           (i > 0) ? "," : "", trace_addrs[i], trace_addr_banks[i]);
+	sb_appendf(&sb, "], \"logs\": [");
+	for (i = 0; i < trace_count; i++) {
+		int idx = (trace_head - trace_count + i + TRACE_LOG_SIZE) % TRACE_LOG_SIZE;
+		const trace_entry_t *e = &trace_log[idx];
+		sb_appendf(&sb,
+			"%s{\"cpu\": %d, \"pc\": %u, \"adr\": %u, \"len\": %d, \"write\": %d, \"bank\": %d}",
+			(i > 0) ? "," : "", e->cpunum, e->pc, e->adr, e->length, e->write, e->bank);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ------------------------------------------------------------------ */
+/* Memory / register operations                                       */
+/* ------------------------------------------------------------------ */
+
+/* Write one byte. Debugger writes into the WPC RAM range go directly to
+ * the RAM array so the WPC memory protection (wpc_ram_w) cannot silently
+ * discard them; everything else goes through the CPU's memory map. */
+static void debug_write_byte(int cpu_idx, UINT32 addr, UINT8 val)
+{
+	if (cpu_idx == 0 && wpc_ram && addr < 0x3000)
+		wpc_ram[addr] = val;
+	else
+		cpunum_write_byte(cpu_idx, addr, val);
+}
+
+void remote_debug_memory_fill(int cpu_idx, UINT32 addr, int size, UINT8 val)
+{
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu()) {
+		char b[MSG_LEN];
+		int i;
+		for (i = 0; i < size; i++)
+			debug_write_byte(cpu_idx, addr + (UINT32)i, val);
+		snprintf(b, sizeof(b), "Memory fill: %04X-%04X with %02X",
+		         addr, addr + (UINT32)size - 1, val);
+		remote_debug_add_message(b);
+	}
+	remote_debug_unlock();
+}
+
+int remote_debug_memory_write_block(int cpu_idx, UINT32 addr, const UINT8 *data, int len)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu() && len > 0) {
+		int i;
+		for (i = 0; i < len; i++)
+			debug_write_byte(cpu_idx, addr + (UINT32)i, data[i]);
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+int remote_debug_memory_find(int cpu_idx, UINT32 addr, int size,
+                             const UINT8 *pattern, int pat_len, UINT32 *found_addr, int bank)
+{
+	int result = 0;
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu()
+			&& pat_len > 0 && size > 0 && pat_len <= size) {
+		UINT32 a;
+		for (a = addr; a <= addr + (UINT32)(size - pat_len); a++) {
+			int i, match = 1;
+			for (i = 0; i < pat_len; i++) {
+				if (remote_debug_read_byte(cpu_idx, a + (UINT32)i, bank) != pattern[i]) {
+					match = 0;
+					break;
+				}
+			}
+			if (match) {
+				*found_addr = a;
+				result = 1;
+				break;
+			}
+		}
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+void remote_debug_set_register(int cpu_idx, int reg, UINT32 val)
+{
+	remote_debug_lock();
+	if (Machine && cpu_idx >= 0 && cpu_idx < cpu_gettotalcpu()) {
+		char b[MSG_LEN];
+		/* switch context so the write reaches the right CPU core */
+		cpuintrf_push_context(cpu_idx);
+		activecpu_set_reg(reg, val);
+		cpuintrf_pop_context();
+		snprintf(b, sizeof(b), "Set reg: CPU %d, reg %d to %04X", cpu_idx, reg, val);
+		remote_debug_add_message(b);
+	}
+	remote_debug_unlock();
+}
+
+/* ------------------------------------------------------------------ */
+/* Step over / step out / run to                                      */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_step_over(void)
+{
+	remote_debug_lock();
+	if (Machine && cpu_gettotalcpu() > 0) {
+		/* While paused there is no active CPU context (the HTTP thread
+		 * calls this between timeslices), so push the main CPU. */
+		int need_ctx = (cpu_getactivecpu() < 0);
+		UINT32 pc;
+		char dasm[64];
+		int size;
+		if (need_ctx)
+			cpuintrf_push_context(0);
+		pc = activecpu_get_reg(REG_PC);
+		activecpu_set_op_base(pc);
+		size = (int)activecpu_dasm(dasm, pc);
+		if (need_ctx)
+			cpuintrf_pop_context();
+		if (size > 0) {
+			breakpoint_add_internal(pc + (UINT32)size, -1, 1, NULL, 0);
+			is_paused = 0;
+			remote_debug_add_message("Stepping over...");
+		}
+		else {
+			remote_debug_step();
+		}
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_step_out(void)
+{
+	remote_debug_lock();
+	if (callstack_ptr > 0) {
+		const callstack_entry_t *e = &callstack[callstack_ptr - 1];
+		char b[MSG_LEN];
+		breakpoint_add_internal(e->pc, e->bank, 1, NULL, 0);
+		is_paused = 0;
+		snprintf(b, sizeof(b), "Stepping out to %04X...", e->pc);
+		remote_debug_add_message(b);
+	}
+	else {
+		remote_debug_add_message("Step out: callstack is empty, stepping instead");
+		remote_debug_step();
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_run_to(UINT32 addr, int bank)
+{
+	char b[MSG_LEN];
+	remote_debug_lock();
+	breakpoint_add_internal(addr, bank, 1, NULL, 0);
+	is_paused = 0;
+	remote_debug_unlock();
+	if (bank != -1)
+		snprintf(b, sizeof(b), "Running to %02X:%04X...", bank, addr);
+	else
+		snprintf(b, sizeof(b), "Running to %04X...", addr);
+	remote_debug_add_message(b);
+}
+
+/* ------------------------------------------------------------------ */
+/* Callstack hooks                                                    */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_push_call(UINT32 caller, UINT32 receiver)
+{
+	if (!remote_debug_ready)
+		return;
+	remote_debug_lock();
+	if (callstack_ptr < CALLSTACK_SIZE) {
+		callstack_entry_t *e = &callstack[callstack_ptr++];
+		e->caller = caller;
+		e->receiver = receiver;
+		e->bank = wpc_get_bank();
+		e->pc = (UINT16)activecpu_get_reg(REG_PC);  /* return address */
+		e->u = (UINT16)activecpu_get_reg(M6809_U);
+		e->s = (UINT16)activecpu_get_reg(REG_SP);
+		e->x = (UINT16)activecpu_get_reg(M6809_X);
+		e->y = (UINT16)activecpu_get_reg(M6809_Y);
+		e->a = (UINT8)activecpu_get_reg(M6809_A);
+		e->b = (UINT8)activecpu_get_reg(M6809_B);
+		e->dp = (UINT8)activecpu_get_reg(M6809_DP);
+		e->cc = (UINT8)activecpu_get_reg(M6809_CC);
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_pop_call(void)
+{
+	if (!remote_debug_ready)
+		return;
+	remote_debug_lock();
+	if (callstack_ptr > 0)
+		callstack_ptr--;
+	remote_debug_unlock();
+}
+
+void remote_debug_reset_callstack(void)
+{
+	if (!remote_debug_ready)
+		return;
+	remote_debug_lock();
+	callstack_ptr = 0;
+	remote_debug_unlock();
+}
+
+/* ------------------------------------------------------------------ */
+/* Display capture                                                    */
+/* ------------------------------------------------------------------ */
+
+static struct mame_display *last_display = NULL;
+
+void remote_debug_frame_update(struct mame_display *display)
+{
+	remote_debug_lock();
+	last_display = display;
+	/* re-assert held switch pulses (the input port clears the coin-door
+	 * column each frame) and expire finished ones */
+	pulse_tick(1);
+	remote_debug_unlock();
+	/* sample monitored objects and record DMD frames once per frame */
+	remote_debug_monitor_sample();
+	remote_debug_dmdrec_sample();
+}
+
+void remote_debug_get_screenshot_info(int *w, int *h)
+{
+	remote_debug_lock();
+	if (last_display && last_display->game_bitmap) {
+		*w = last_display->game_bitmap->width;
+		*h = last_display->game_bitmap->height;
+	}
+	else {
+		*w = 0;
+		*h = 0;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_get_raw_screenshot(char **buffer, int *len)
+{
+	remote_debug_lock();
+	if (last_display && last_display->game_bitmap) {
+		struct mame_bitmap *bm = last_display->game_bitmap;
+		int width = bm->width;
+		int height = bm->height;
+		int x, y;
+		char *p;
+		*len = width * height * 3;
+		*buffer = malloc((size_t)*len);
+		p = *buffer;
+		if (p) {
+			for (y = 0; y < height; y++) {
+				for (x = 0; x < width; x++) {
+					UINT32 c;
+					if (bm->depth == 32) {
+						c = ((UINT32 **)bm->line)[y][x];
+					}
+					else {
+						rgb_t r;
+						if (bm->depth == 16)
+							c = ((UINT16 **)bm->line)[y][x];
+						else
+							c = ((UINT8 **)bm->line)[y][x];
+						r = last_display->game_palette[c];
+						c = (UINT32)r;
+					}
+					*p++ = (char)((c >> 16) & 0xFF);
+					*p++ = (char)((c >> 8) & 0xFF);
+					*p++ = (char)(c & 0xFF);
+				}
+			}
+		}
+		else {
+			*len = 0;
+		}
+	}
+	else {
+		*buffer = NULL;
+		*len = 0;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_get_screenshot(char **buffer, int *len, char *content_type)
+{
+	char *raw = NULL;
+	int raw_len = 0;
+	int w, h;
+	remote_debug_lock();
+	remote_debug_get_screenshot_info(&w, &h);
+	remote_debug_get_raw_screenshot(&raw, &raw_len);
+	remote_debug_unlock();
+	if (raw) {
+		char head[64];
+		int hlen = snprintf(head, sizeof(head), "P6\n%d %d\n255\n", w, h);
+		*buffer = malloc((size_t)(raw_len + hlen));
+		if (*buffer) {
+			memcpy(*buffer, head, (size_t)hlen);
+			memcpy(*buffer + hlen, raw, (size_t)raw_len);
+			*len = raw_len + hlen;
+			strcpy(content_type, "image/x-portable-pixmap");
+		}
+		else {
+			*len = 0;
+		}
+		free(raw);
+	}
+	else {
+		*buffer = NULL;
+		*len = 0;
+	}
+}
+
+/* Provided by src/wpc/core.c */
+extern void core_get_dmd_data(int layout_idx, float **pixels, int *width, int *height);
+
+/* Convert the float DMD luminance plane to one byte per pixel. */
+static UINT8 *dmd_to_bytes(const float *px, int count)
+{
+	UINT8 *out = malloc((size_t)count);
+	int i;
+	if (!out)
+		return NULL;
+	for (i = 0; i < count; i++) {
+		float v = px[i];
+		if (v < 0.0f)
+			v = 0.0f;
+		if (v > 1.0f)
+			v = 1.0f;
+		out[i] = (UINT8)(v * 255.0f);
+	}
+	return out;
+}
+
+void remote_debug_get_dmd_screenshot(char **buffer, int *len, char *content_type)
+{
+	float *px;
+	int w, h;
+	remote_debug_lock();
+	core_get_dmd_data(0, &px, &w, &h);
+	if (px && w > 0 && h > 0) {
+		*buffer = (char *)dmd_to_bytes(px, w * h);
+		*len = *buffer ? w * h : 0;
+		strcpy(content_type, "application/octet-stream");
+	}
+	else {
+		*buffer = NULL;
+		*len = 0;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_get_dmd_pnm(char **buffer, int *len, char *content_type)
+{
+	float *px;
+	int w, h;
+	remote_debug_lock();
+	core_get_dmd_data(0, &px, &w, &h);
+	if (px && w > 0 && h > 0) {
+		char head[64];
+		int hlen = snprintf(head, sizeof(head), "P5\n%d %d\n255\n", w, h);
+		UINT8 *pixels = dmd_to_bytes(px, w * h);
+		if (pixels) {
+			*buffer = malloc((size_t)(w * h + hlen));
+			if (*buffer) {
+				memcpy(*buffer, head, (size_t)hlen);
+				memcpy(*buffer + hlen, pixels, (size_t)(w * h));
+				*len = w * h + hlen;
+				strcpy(content_type, "image/x-portable-pixmap");
+			}
+			else {
+				*len = 0;
+			}
+			free(pixels);
+		}
+		else {
+			*buffer = NULL;
+			*len = 0;
+		}
+	}
+	else {
+		*buffer = NULL;
+		*len = 0;
+	}
+	remote_debug_unlock();
+}
+
+/* ================================================================== */
+/* Playfield objects: switches, lamps, solenoids                      */
+/* ================================================================== */
+
+/* Read the on/off state of a switch/lamp/solenoid by number.
+ * The caller must hold the debugger lock. */
+static int object_state(int type, int id)
+{
+	if (!Machine)
+		return 0;
+	if (type == REMOTE_DEBUG_OBJ_SWITCH)
+		return core_getSw(id) ? 1 : 0;
+	if (type == REMOTE_DEBUG_OBJ_LAMP) {
+		int col = id / 10, row = id % 10 - 1;
+		if (col < 0 || col >= CORE_MAXLAMPCOL || row < 0 || row > 7)
+			return 0;
+		return (coreGlobals.lampMatrix[col] >> row) & 1;
+	}
+	if (type == REMOTE_DEBUG_OBJ_SOL)
+		return core_getSol(id) ? 1 : 0;
+	return 0;
+}
+
+/* Standard WPC name for a switch number, or "" if none is known.
+ * Covers the coin-door column and the flipper column plus the game's
+ * dedicated start/tilt/slam/coin-door/shooter switches. */
+static const char *switch_name(int num)
+{
+	static const char *coindoor[8] = {
+		"Coin 1", "Coin 2", "Coin 3", "Coin 4",
+		"Enter", "Up", "Down", "Escape"
+	};
+	static const char *flippers[8] = {
+		"L.R Flipper EOS", "L.R Flipper", "L.L Flipper EOS", "L.L Flipper",
+		"U.R Flipper EOS", "U.R Flipper", "U.L Flipper EOS", "U.L Flipper"
+	};
+	if (num >= 1 && num <= 8)
+		return coindoor[num - 1];
+	if (num >= CORE_FLIPPERSWCOL * 10 + 1 && num <= CORE_FLIPPERSWCOL * 10 + 8)
+		return flippers[num - (CORE_FLIPPERSWCOL * 10 + 1)];
+	if (core_gameData) {
+		if (num == core_gameData->wpc.comSw.start)    return "Start";
+		if (num == core_gameData->wpc.comSw.tilt)     return "Tilt";
+		if (num == core_gameData->wpc.comSw.sTilt)    return "Slam Tilt";
+		if (num == core_gameData->wpc.comSw.coinDoor) return "Coin Door";
+		if (num == core_gameData->wpc.comSw.shooter)  return "Shooter";
+	}
+	return "";
+}
+
+/* Emit switches of one column as JSON objects; returns updated first flag. */
+static int emit_switch_col(strbuf_t *sb, int col, int first)
+{
+	int row;
+	for (row = 0; row < 8; row++) {
+		int num = col * 10 + row + 1;
+		char esc[64];
+		sb_appendf(sb,
+			"%s{\"num\": %d, \"col\": %d, \"row\": %d, \"active\": %d, \"name\": \"%s\"}",
+			first ? "" : ",", num, col, row + 1, object_state(REMOTE_DEBUG_OBJ_SWITCH, num),
+			remote_debug_json_escape(esc, (int)sizeof(esc), switch_name(num)));
+		first = 0;
+	}
+	return first;
+}
+
+void remote_debug_get_switches(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int first = 1, col, custom;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"switches\": [");
+	if (Machine) {
+		/* coin door (col 0), playfield matrix (col 1-8), flippers (col 11) */
+		first = emit_switch_col(&sb, 0, first);
+		for (col = 1; col <= 8; col++)
+			first = emit_switch_col(&sb, col, first);
+		first = emit_switch_col(&sb, CORE_FLIPPERSWCOL, first);
+		/* game-specific custom columns */
+		custom = core_gameData ? core_gameData->hw.swCol : 0;
+		for (col = 0; col < custom; col++)
+			first = emit_switch_col(&sb, CORE_CUSTSWCOL + col, first);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_lamps(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int first = 1, col, row, cols;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"lamps\": [");
+	if (Machine) {
+		cols = 8 + (core_gameData ? core_gameData->hw.lampCol : 0);
+		if (cols > CORE_MAXLAMPCOL)
+			cols = CORE_MAXLAMPCOL;
+		for (col = 0; col < cols; col++) {
+			for (row = 0; row < 8; row++) {
+				int num = col * 10 + row + 1;
+				sb_appendf(&sb,
+					"%s{\"num\": %d, \"col\": %d, \"row\": %d, \"active\": %d}",
+					first ? "" : ",", num, col, row + 1,
+					(coreGlobals.lampMatrix[col] >> row) & 1);
+				first = 0;
+			}
+		}
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_solenoids(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int first = 1, n, count;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"solenoids\": [");
+	if (Machine) {
+		count = CORE_FIRSTCUSTSOL - 1 + (core_gameData ? core_gameData->hw.custSol : 0);
+		if (count < 1 || count > CORE_MAXSOL)
+			count = CORE_FIRSTCUSTSOL - 1;
+		for (n = 1; n <= count; n++) {
+			sb_appendf(&sb, "%s{\"num\": %d, \"active\": %d}",
+			           first ? "" : ",", n, core_getSol(n) ? 1 : 0);
+			first = 0;
+		}
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Timed switch pulses                                                */
+/* ================================================================== */
+
+/* Advance timed pulses. reassert!=0 also re-applies the held value (needed
+ * on the emulator thread because the coin-door column is overwritten by the
+ * input port every frame). Expired pulses restore their off value.
+ * The caller must hold the debugger lock. */
+static void pulse_tick(int reassert)
+{
+	UINT32 now = monotonic_ms();
+	int i;
+	if (!Machine)
+		return;
+	for (i = 0; i < pulse_count; ) {
+		/* signed diff handles UINT32 wraparound */
+		if ((INT32)(now - pulses[i].expiry) >= 0) {
+			core_setSw(pulses[i].sw, pulses[i].offval);
+			pulses[i] = pulses[pulse_count - 1];
+			pulse_count--;
+		}
+		else {
+			if (reassert)
+				core_setSw(pulses[i].sw, pulses[i].heldval);
+			i++;
+		}
+	}
+}
+
+/* Expire pulses from the HTTP thread so they end even while paused (when
+ * no frames are produced and the emulator-side re-assert does not run). */
+static void service_pulses(void)
+{
+	if (pulse_count == 0)
+		return;
+	remote_debug_lock();
+	pulse_tick(0);
+	remote_debug_unlock();
+}
+
+int remote_debug_set_switch(int sw, int val, int pulse_ms)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (coreData) {
+		int on = val ? 1 : 0;
+		core_setSw(sw, on);
+		if (pulse_ms > 0 && pulse_count < PULSE_MAX) {
+			pulses[pulse_count].sw = sw;
+			pulses[pulse_count].heldval = on;
+			pulses[pulse_count].offval = on ? 0 : 1;
+			pulses[pulse_count].expiry = monotonic_ms() + (UINT32)pulse_ms;
+			pulse_count++;
+		}
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+/* ================================================================== */
+/* Object monitoring / action log                                     */
+/* ================================================================== */
+
+static const char *obj_type_name(int type)
+{
+	switch (type) {
+		case REMOTE_DEBUG_OBJ_SWITCH: return "switch";
+		case REMOTE_DEBUG_OBJ_LAMP:   return "lamp";
+		case REMOTE_DEBUG_OBJ_SOL:    return "sol";
+		default:                      return "?";
+	}
+}
+
+int remote_debug_monitor_add(int obj_type, int id, int brk)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (monitor_count < MONITOR_MAX) {
+		monitors[monitor_count].type = obj_type;
+		monitors[monitor_count].id = id;
+		monitors[monitor_count].last = object_state(obj_type, id);
+		monitors[monitor_count].brk = brk;
+		monitor_count++;
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+void remote_debug_monitor_clear(void)
+{
+	remote_debug_lock();
+	monitor_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_action_log_clear(void)
+{
+	remote_debug_lock();
+	action_head = 0;
+	action_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_monitor_sample(void)
+{
+	int i;
+	if (monitor_count == 0)
+		return;
+	remote_debug_lock();
+	for (i = 0; i < monitor_count; i++) {
+		int cur = object_state(monitors[i].type, monitors[i].id);
+		if (cur != monitors[i].last) {
+			action_t *a = &action_log[action_head];
+			a->type = monitors[i].type;
+			a->id = monitors[i].id;
+			a->val = cur;
+			a->time = monotonic_ms();
+			action_head = (action_head + 1) % ACTION_LOG_SIZE;
+			if (action_count < ACTION_LOG_SIZE)
+				action_count++;
+			monitors[i].last = cur;
+			publish_event("{\"event\": \"action\", \"type\": \"%s\", \"id\": %d, \"val\": %d}",
+			              obj_type_name(monitors[i].type), monitors[i].id, cur);
+			if (monitors[i].brk) {
+				is_paused = 1;
+				publish_event("{\"event\": \"halt\", \"reason\": \"monitor\", \"type\": \"%s\", \"id\": %d, \"val\": %d}",
+				              obj_type_name(monitors[i].type), monitors[i].id, cur);
+			}
+		}
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_get_monitors(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 2048);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"monitors\": [");
+	for (i = 0; i < monitor_count; i++)
+		sb_appendf(&sb, "%s{\"type\": \"%s\", \"id\": %d, \"state\": %d, \"break\": %d}",
+		           (i > 0) ? "," : "", obj_type_name(monitors[i].type),
+		           monitors[i].id, monitors[i].last, monitors[i].brk);
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+void remote_debug_get_action_log(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 8192);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"actions\": [");
+	for (i = 0; i < action_count; i++) {
+		int idx = (action_head - action_count + i + ACTION_LOG_SIZE) % ACTION_LOG_SIZE;
+		const action_t *a = &action_log[idx];
+		sb_appendf(&sb, "%s{\"type\": \"%s\", \"id\": %d, \"val\": %d, \"t\": %u}",
+		           (i > 0) ? "," : "", obj_type_name(a->type), a->id, a->val, a->time);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Code instrumentation (PC hit counting)                             */
+/* ================================================================== */
+
+int remote_debug_instrument_add(UINT32 addr, int bank)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (instrument_count < INSTRUMENT_MAX) {
+		instruments[instrument_count].addr = addr;
+		instruments[instrument_count].bank = bank;
+		instruments[instrument_count].count = 0;
+		instrument_count++;
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+void remote_debug_instrument_clear(void)
+{
+	remote_debug_lock();
+	instrument_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_get_instrumentation(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"points\": [");
+	for (i = 0; i < instrument_count; i++)
+		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"count\": %u}",
+		           (i > 0) ? "," : "", instruments[i].addr,
+		           instruments[i].bank, instruments[i].count);
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Memory value scan                                                  */
+/* ================================================================== */
+
+int remote_debug_scan_new(int cpu, UINT32 addr, int size)
+{
+	int i;
+	if (size < 1 || size > SCAN_MAX)
+		return -1;
+	remote_debug_lock();
+	if (!Machine || cpu < 0 || cpu >= cpu_gettotalcpu()) {
+		remote_debug_unlock();
+		return -1;
+	}
+	scan_cpu = cpu;
+	scan_base = addr;
+	scan_size = size;
+	for (i = 0; i < size; i++) {
+		scan_snapshot[i] = cpunum_read_byte(cpu, addr + (UINT32)i);
+		scan_candidate[i] = 1;
+	}
+	remote_debug_unlock();
+	return size;
+}
+
+int remote_debug_scan_filter(int op, UINT8 val)
+{
+	int i, remaining = 0;
+	remote_debug_lock();
+	if (scan_size == 0 || !Machine) {
+		remote_debug_unlock();
+		return -1;
+	}
+	for (i = 0; i < scan_size; i++) {
+		UINT8 cur, old;
+		int keep;
+		if (!scan_candidate[i])
+			continue;
+		cur = cpunum_read_byte(scan_cpu, scan_base + (UINT32)i);
+		old = scan_snapshot[i];
+		switch (op) {
+			case REMOTE_DEBUG_SCAN_EQ:        keep = (cur == val); break;
+			case REMOTE_DEBUG_SCAN_NE:        keep = (cur != val); break;
+			case REMOTE_DEBUG_SCAN_CHANGED:   keep = (cur != old); break;
+			case REMOTE_DEBUG_SCAN_UNCHANGED: keep = (cur == old); break;
+			case REMOTE_DEBUG_SCAN_INC:       keep = (cur > old);  break;
+			case REMOTE_DEBUG_SCAN_DEC:       keep = (cur < old);  break;
+			default:                          keep = 1;            break;
+		}
+		scan_candidate[i] = (UINT8)keep;
+		scan_snapshot[i] = cur;
+		if (keep)
+			remaining++;
+	}
+	remote_debug_unlock();
+	return remaining;
+}
+
+void remote_debug_get_scan(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i, emitted = 0, total = 0;
+	sb_init(&sb, 8192);
+	remote_debug_lock();
+	for (i = 0; i < scan_size; i++)
+		if (scan_candidate[i])
+			total++;
+	sb_appendf(&sb, "{\"count\": %d, \"results\": [", total);
+	for (i = 0; i < scan_size && emitted < 256; i++) {
+		if (!scan_candidate[i])
+			continue;
+		sb_appendf(&sb, "%s{\"addr\": %u, \"val\": %u}",
+		           (emitted > 0) ? "," : "", scan_base + (UINT32)i,
+		           Machine ? (unsigned)cpunum_read_byte(scan_cpu, scan_base + (UINT32)i) : 0);
+		emitted++;
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Lightweight game-state checkpoints                                 */
+/* ================================================================== */
+
+/* Find an existing slot by name, or -1. Caller holds the lock. */
+static int savestate_find(const char *name)
+{
+	int i;
+	for (i = 0; i < SAVESTATE_SLOTS; i++)
+		if (savestates[i].used && strcmp(savestates[i].name, name) == 0)
+			return i;
+	return -1;
+}
+
+int remote_debug_savestate_save(const char *slot)
+{
+	int idx, i;
+	savestate_t *s;
+	if (!slot || !slot[0])
+		return -1;
+	remote_debug_lock();
+	if (!Machine || !wpc_ram) {
+		remote_debug_unlock();
+		return -1;
+	}
+	idx = savestate_find(slot);
+	if (idx < 0) {
+		for (i = 0; i < SAVESTATE_SLOTS; i++)
+			if (!savestates[i].used) { idx = i; break; }
+	}
+	if (idx < 0) {
+		remote_debug_unlock();
+		return -1;   /* all slots occupied */
+	}
+	s = &savestates[idx];
+	memset(s, 0, sizeof(*s));
+	strncpy(s->name, slot, sizeof(s->name) - 1);
+	s->used = 1;
+	s->ramlen = SAVESTATE_RAM;
+	memcpy(s->ram, wpc_ram, SAVESTATE_RAM);
+	cpuintrf_push_context(0);
+	s->pc = (UINT16)activecpu_get_reg(M6809_PC);
+	s->s  = (UINT16)activecpu_get_reg(M6809_S);
+	s->u  = (UINT16)activecpu_get_reg(M6809_U);
+	s->x  = (UINT16)activecpu_get_reg(M6809_X);
+	s->y  = (UINT16)activecpu_get_reg(M6809_Y);
+	s->a  = (UINT8)activecpu_get_reg(M6809_A);
+	s->b  = (UINT8)activecpu_get_reg(M6809_B);
+	s->dp = (UINT8)activecpu_get_reg(M6809_DP);
+	s->cc = (UINT8)activecpu_get_reg(M6809_CC);
+	cpuintrf_pop_context();
+	remote_debug_unlock();
+	{
+		char b[MSG_LEN];
+		snprintf(b, sizeof(b), "State saved to slot '%s'", slot);
+		remote_debug_add_message(b);
+	}
+	return 0;
+}
+
+int remote_debug_savestate_load(const char *slot)
+{
+	int idx, i;
+	const savestate_t *s;
+	if (!slot || !slot[0])
+		return -1;
+	remote_debug_lock();
+	if (!Machine || !wpc_ram) {
+		remote_debug_unlock();
+		return -1;
+	}
+	idx = savestate_find(slot);
+	if (idx < 0) {
+		remote_debug_unlock();
+		return -1;
+	}
+	s = &savestates[idx];
+	for (i = 0; i < s->ramlen; i++)
+		wpc_ram[i] = s->ram[i];
+	cpuintrf_push_context(0);
+	activecpu_set_reg(M6809_PC, s->pc);
+	activecpu_set_reg(M6809_S,  s->s);
+	activecpu_set_reg(M6809_U,  s->u);
+	activecpu_set_reg(M6809_X,  s->x);
+	activecpu_set_reg(M6809_Y,  s->y);
+	activecpu_set_reg(M6809_A,  s->a);
+	activecpu_set_reg(M6809_B,  s->b);
+	activecpu_set_reg(M6809_DP, s->dp);
+	activecpu_set_reg(M6809_CC, s->cc);
+	cpuintrf_pop_context();
+	remote_debug_unlock();
+	{
+		char b[MSG_LEN];
+		snprintf(b, sizeof(b), "State loaded from slot '%s'", slot);
+		remote_debug_add_message(b);
+	}
+	return 0;
+}
+
+void remote_debug_savestate_delete(const char *slot)
+{
+	int idx;
+	remote_debug_lock();
+	idx = savestate_find(slot);
+	if (idx >= 0)
+		savestates[idx].used = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_get_savestates(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i, first = 1;
+	sb_init(&sb, 1024);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"slots\": [");
+	for (i = 0; i < SAVESTATE_SLOTS; i++) {
+		if (savestates[i].used) {
+			char esc[64];
+			sb_appendf(&sb, "%s{\"name\": \"%s\", \"pc\": %u}", first ? "" : ",",
+			           remote_debug_json_escape(esc, (int)sizeof(esc), savestates[i].name),
+			           savestates[i].pc);
+			first = 0;
+		}
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* DMD frame recorder                                                 */
+/* ================================================================== */
+
+void remote_debug_dmdrec_start(void)
+{
+	remote_debug_lock();
+	if (!dmd_rec)
+		dmd_rec = malloc(sizeof(dmd_frame_t) * DMD_REC_FRAMES);
+	if (dmd_rec)
+		dmd_recording = 1;
+	remote_debug_unlock();
+}
+
+void remote_debug_dmdrec_stop(void)
+{
+	dmd_recording = 0;
+}
+
+void remote_debug_dmdrec_clear(void)
+{
+	remote_debug_lock();
+	dmd_rec_head = 0;
+	dmd_rec_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_dmdrec_sample(void)
+{
+	float *px;
+	int w, h, n, i;
+	if (!dmd_recording || !dmd_rec)
+		return;
+	remote_debug_lock();
+	core_get_dmd_data(0, &px, &w, &h);
+	n = w * h;
+	if (px && n > 0 && n <= DMD_REC_PIX) {
+		dmd_frame_t *f = &dmd_rec[dmd_rec_head];
+		dmd_rec_w = w;
+		dmd_rec_h = h;
+		for (i = 0; i < n; i++) {
+			float v = px[i];
+			if (v < 0.0f) v = 0.0f;
+			if (v > 1.0f) v = 1.0f;
+			f->pix[i] = (UINT8)(v * 255.0f);
+		}
+		f->t = monotonic_ms();
+		dmd_rec_head = (dmd_rec_head + 1) % DMD_REC_FRAMES;
+		if (dmd_rec_count < DMD_REC_FRAMES)
+			dmd_rec_count++;
+	}
+	remote_debug_unlock();
+}
+
+void remote_debug_get_dmdrec_info(char **buffer, int *len)
+{
+	char res[192];
+	remote_debug_lock();
+	*len = snprintf(res, sizeof(res),
+		"{\"recording\": %d, \"count\": %d, \"width\": %d, \"height\": %d, \"capacity\": %d}",
+		(int)dmd_recording, dmd_rec_count, dmd_rec_w, dmd_rec_h, DMD_REC_FRAMES);
+	remote_debug_unlock();
+	*buffer = strdup(res);
+	if (!*buffer)
+		*len = 0;
+}
+
+/* Append a little-endian UINT32 to a byte buffer. */
+static void put_u32le(UINT8 *p, UINT32 v)
+{
+	p[0] = (UINT8)(v & 0xFF);
+	p[1] = (UINT8)((v >> 8) & 0xFF);
+	p[2] = (UINT8)((v >> 16) & 0xFF);
+	p[3] = (UINT8)((v >> 24) & 0xFF);
+}
+
+void remote_debug_get_dmdrec_data(char **buffer, int *len)
+{
+	int frame_bytes, total, i;
+	UINT8 *out, *p;
+	remote_debug_lock();
+	frame_bytes = dmd_rec_w * dmd_rec_h;
+	if (!dmd_rec || dmd_rec_count == 0 || frame_bytes <= 0) {
+		remote_debug_unlock();
+		*buffer = NULL;
+		*len = 0;
+		return;
+	}
+	/* header: count,w,h (12 bytes) + per frame: t (4) + pixels */
+	total = 12 + dmd_rec_count * (4 + frame_bytes);
+	out = malloc((size_t)total);
+	if (!out) {
+		remote_debug_unlock();
+		*buffer = NULL;
+		*len = 0;
+		return;
+	}
+	p = out;
+	put_u32le(p, (UINT32)dmd_rec_count); p += 4;
+	put_u32le(p, (UINT32)dmd_rec_w);     p += 4;
+	put_u32le(p, (UINT32)dmd_rec_h);     p += 4;
+	for (i = 0; i < dmd_rec_count; i++) {
+		int idx = (dmd_rec_head - dmd_rec_count + i + DMD_REC_FRAMES) % DMD_REC_FRAMES;
+		const dmd_frame_t *f = &dmd_rec[idx];
+		put_u32le(p, f->t); p += 4;
+		memcpy(p, f->pix, (size_t)frame_bytes);
+		p += frame_bytes;
+	}
+	remote_debug_unlock();
+	*buffer = (char *)out;
+	*len = total;
+}
+
+/* ================================================================== */
+/* Execution trace                                                    */
+/* ================================================================== */
+
+void remote_debug_exectrace_start(void)  { exec_trace_enabled = 1; }
+void remote_debug_exectrace_stop(void)   { exec_trace_enabled = 0; }
+
+void remote_debug_exectrace_clear(void)
+{
+	remote_debug_lock();
+	exec_trace_head = 0;
+	exec_trace_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_get_exectrace(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 65536);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"enabled\": %d, \"count\": %d, \"capacity\": %d, \"trace\": [",
+	           (int)exec_trace_enabled, exec_trace_count, EXEC_TRACE_SIZE);
+	for (i = 0; i < exec_trace_count; i++) {
+		int idx = (exec_trace_head - exec_trace_count + i + EXEC_TRACE_SIZE) % EXEC_TRACE_SIZE;
+		const exec_trace_t *e = &exec_trace[idx];
+		sb_appendf(&sb, "%s{\"pc\": %u, \"bank\": %d, \"a\": %u, \"b\": %u, \"x\": %u}",
+		           (i > 0) ? "," : "", e->pc, e->bank, e->a, e->b, e->x);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Coverage map                                                       */
+/* ================================================================== */
+
+void remote_debug_coverage_start(void)
+{
+	remote_debug_lock();
+	if (!coverage_bitmap) {
+		UINT32 nbanks = 0;
+		if (wpc_ram) {
+			int romlen = memory_region_length(WPC_ROMREGION);
+			if (romlen > 0)
+				nbanks = (UINT32)romlen / 0x4000;
+		}
+		coverage_bits = 0x10000 + nbanks * 0x4000;
+		coverage_bitmap = calloc((coverage_bits + 7) / 8, 1);
+		if (!coverage_bitmap)
+			coverage_bits = 0;
+		coverage_count = 0;
+	}
+	if (coverage_bitmap)
+		coverage_enabled = 1;
+	remote_debug_unlock();
+}
+
+void remote_debug_coverage_stop(void) { coverage_enabled = 0; }
+
+void remote_debug_coverage_clear(void)
+{
+	remote_debug_lock();
+	if (coverage_bitmap)
+		memset(coverage_bitmap, 0, (coverage_bits + 7) / 8);
+	coverage_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_get_coverage_info(char **buffer, int *len)
+{
+	char res[192];
+	remote_debug_lock();
+	*len = snprintf(res, sizeof(res),
+		"{\"enabled\": %d, \"executed\": %u, \"addressable\": %u}",
+		(int)coverage_enabled, coverage_count, coverage_bits);
+	remote_debug_unlock();
+	*buffer = strdup(res);
+	if (!*buffer)
+		*len = 0;
+}
+
+/* Per-address executed flags for a window (like a memory read of 0/1). */
+void remote_debug_get_coverage_region(char **buffer, int *len, UINT32 addr, int size, int bank)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, (size_t)size * 2 + 256);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"addr\": %u, \"bank\": %d, \"executed\": [", addr, bank);
+	for (i = 0; i < size; i++) {
+		int hit = 0;
+		if (coverage_bitmap) {
+			UINT32 idx = coverage_index(addr + (UINT32)i, bank);
+			if (idx < coverage_bits)
+				hit = (coverage_bitmap[idx >> 3] >> (idx & 7)) & 1;
+		}
+		sb_appendf(&sb, "%s%d", (i > 0) ? "," : "", hit);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Tracepoints (log-and-continue)                                     */
+/* ================================================================== */
+
+int remote_debug_tracepoint_add(UINT32 addr, int bank)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (tracepoint_count < MAX_POINTS) {
+		tracepoints[tracepoint_count].addr = addr;
+		tracepoints[tracepoint_count].bank = bank;
+		tracepoints[tracepoint_count].hits = 0;
+		tracepoint_count++;
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+void remote_debug_tracepoint_clear(void)
+{
+	remote_debug_lock();
+	tracepoint_count = 0;
+	tp_head = 0;
+	tp_count = 0;
+	remote_debug_unlock();
+}
+
+void remote_debug_get_tracepoints(char **buffer, int *len)
+{
+	strbuf_t sb;
+	int i;
+	sb_init(&sb, 4096);
+	remote_debug_lock();
+	sb_appendf(&sb, "{\"points\": [");
+	for (i = 0; i < tracepoint_count; i++)
+		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"hits\": %u}",
+		           (i > 0) ? "," : "", tracepoints[i].addr,
+		           tracepoints[i].bank, tracepoints[i].hits);
+	sb_appendf(&sb, "], \"log\": [");
+	for (i = 0; i < tp_count; i++) {
+		int idx = (tp_head - tp_count + i + TP_LOG_SIZE) % TP_LOG_SIZE;
+		const tp_log_t *t = &tp_log[idx];
+		sb_appendf(&sb,
+			"%s{\"pc\": %u, \"bank\": %d, \"a\": %u, \"b\": %u, \"x\": %u, "
+			"\"y\": %u, \"u\": %u, \"s\": %u, \"dp\": %u, \"cc\": %u}",
+			(i > 0) ? "," : "", t->pc, t->bank, t->a, t->b, t->x,
+			t->y, t->u, t->s, t->dp, t->cc);
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+/* ================================================================== */
+/* Save-state diff                                                    */
+/* ================================================================== */
+
+/* Diff the RAM of two save slots (or slot 'a' against the live RAM when
+ * 'b' is NULL/empty). Returns the differing offsets as JSON. */
+void remote_debug_savestate_diff(char **buffer, int *len, const char *a, const char *b)
+{
+	strbuf_t sb;
+	int ia, ib, i, first = 1, count = 0;
+	const UINT8 *ba = NULL, *bb = NULL;
+	UINT8 live[SAVESTATE_RAM];
+
+	sb_init(&sb, 8192);
+	remote_debug_lock();
+	ia = savestate_find(a);
+	if (ia >= 0)
+		ba = savestates[ia].ram;
+	if (b && b[0]) {
+		ib = savestate_find(b);
+		if (ib >= 0)
+			bb = savestates[ib].ram;
+	}
+	else if (Machine && wpc_ram) {
+		memcpy(live, wpc_ram, SAVESTATE_RAM);
+		bb = live;
+	}
+	if (ba && bb) {
+		for (i = 0; i < SAVESTATE_RAM; i++)
+			if (ba[i] != bb[i])
+				count++;
+	}
+	sb_appendf(&sb, "{\"a\": \"%s\", \"b\": \"%s\", \"count\": %d, \"diffs\": [",
+	           ba ? a : "", (b && b[0]) ? b : "(live)", ba && bb ? count : -1);
+	if (ba && bb) {
+		int emitted = 0;
+		for (i = 0; i < SAVESTATE_RAM && emitted < 1024; i++) {
+			if (ba[i] != bb[i]) {
+				sb_appendf(&sb, "%s{\"addr\": %d, \"a\": %u, \"b\": %u}",
+				           first ? "" : ",", i, ba[i], bb[i]);
+				first = 0;
+				emitted++;
+			}
+		}
+	}
+	sb_appendf(&sb, "]}");
+	remote_debug_unlock();
+	*buffer = sb.buf;
+	*len = sb.len;
+}
+
+#endif /* REMOTE_DEBUG */

--- a/src/remote_debug/remote_debug.h
+++ b/src/remote_debug/remote_debug.h
@@ -1,0 +1,364 @@
+// license:BSD-3-Clause
+
+/***************************************************************************
+ * PinMAME Remote Debugger - core                                          *
+ *                                                                         *
+ * Debugger state (breakpoints, watchpoints, callstack, trace, messages)   *
+ * and the glue between the emulator thread and the HTTP server thread.    *
+ *                                                                         *
+ * Threading model: the emulator thread holds the (recursive) debugger     *
+ * lock for the whole duration of a CPU timeslice (see cpuexec.c). The     *
+ * HTTP server thread takes the same lock around every access to emulator  *
+ * or debugger state, so all per-instruction hooks below run with the      *
+ * lock effectively held and do not lock themselves. Simple control flags  *
+ * (pause/step/quit) are volatile sig_atomic_t and are accessed lock-free. *
+ ***************************************************************************/
+#ifndef REMOTE_DEBUG_H
+#define REMOTE_DEBUG_H
+
+#include "driver.h"
+
+/* ------------------------------------------------------------------ */
+/* Lifecycle (called from mame.c)                                     */
+/* ------------------------------------------------------------------ */
+
+/* Initialize debugger state and start the HTTP server thread. */
+void remote_debug_init(void);
+
+/* Stop the HTTP server thread and release resources. */
+void remote_debug_exit(void);
+
+/* Set while the debugger is initialized; checked by the callstack hooks
+ * which may fire before init / after exit. */
+extern volatile int remote_debug_ready;
+
+/* ------------------------------------------------------------------ */
+/* Locking                                                            */
+/* ------------------------------------------------------------------ */
+
+/* Recursive lock serializing emulator thread and HTTP server thread. */
+void remote_debug_lock(void);
+void remote_debug_unlock(void);
+
+/* ------------------------------------------------------------------ */
+/* Execution control (hooks called from the emulator)                 */
+/* ------------------------------------------------------------------ */
+
+/* Nonzero while execution is paused; sleeps briefly when paused so the
+ * polling loop in cpuexec.c does not busy-wait. */
+int remote_debug_is_paused(void);
+
+/* Nonzero when the emulator should terminate. */
+int remote_debug_should_quit(void);
+
+/* Pause (1) or resume (0) execution. */
+void remote_debug_set_paused(int paused);
+
+/* Execute a single instruction, then pause again. */
+void remote_debug_step(void);
+
+/* Step over the instruction at PC (temporary breakpoint after it). */
+void remote_debug_step_over(void);
+
+/* Run until the current subroutine returns (temporary breakpoint at the
+ * return address recorded on the callstack). */
+void remote_debug_step_out(void);
+
+/* Resume until addr is reached (temporary breakpoint). bank -1 matches any
+ * bank; a specific bank only matters for the 0x4000-0x7FFF ROM window. */
+void remote_debug_run_to(UINT32 addr, int bank);
+
+/* Request emulator shutdown. */
+void remote_debug_quit(void);
+
+/* Per-instruction hook, called via CALL_MAME_DEBUG (see mamedbg.h);
+ * checks breakpoints and halts execution on a hit. */
+void remote_debug_breakpoint_hook(void);
+
+/* Memory access hook, called from the READ/WRITE macros in memory.c;
+ * checks watchpoints and records trace log entries. */
+void remote_debug_memref(UINT32 adr, int length, int write);
+
+/* ------------------------------------------------------------------ */
+/* Breakpoints / watchpoints                                          */
+/* ------------------------------------------------------------------ */
+
+/* Add a breakpoint. bank -1 matches any bank. cond is an optional
+ * condition of the form "REG==VAL", "REG!=VAL", "REG<VAL", "REG>VAL",
+ * "REG<=VAL", "REG>=VAL" with an M6809 register name and a hex value
+ * (NULL or "" for unconditional). ignore skips that many hits before
+ * halting. Returns 0 on success, -1 on a bad condition or full table. */
+int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, const char *cond, UINT32 ignore);
+
+void remote_debug_breakpoint_add(UINT32 adr);
+void remote_debug_breakpoint_add_banked(UINT32 adr, int bank);
+void remote_debug_breakpoint_clear(void);
+void remote_debug_breakpoint_toggle(int index);
+void remote_debug_breakpoint_delete(int index);
+
+/* Watchpoint modes. */
+#define REMOTE_DEBUG_WP_READ  1
+#define REMOTE_DEBUG_WP_WRITE 2
+#define REMOTE_DEBUG_WP_RW    3
+
+/* Add a watchpoint covering len bytes starting at adr (len >= 1). bank -1
+ * matches any bank; a specific bank only matters for 0x4000-0x7FFF.
+ * cond_op is COND_NONE for an unconditional watchpoint, or one of the
+ * REMOTE_DEBUG_COND_* codes to only halt when the byte at adr satisfies the
+ * comparison against cond_val. */
+void remote_debug_watchpoint_add(UINT32 adr, int len, int mode, int bank,
+                                 int cond_op, UINT8 cond_val);
+
+/* Value-condition operators (shared with breakpoints). */
+#define REMOTE_DEBUG_COND_NONE 0
+#define REMOTE_DEBUG_COND_EQ   1
+#define REMOTE_DEBUG_COND_NE   2
+#define REMOTE_DEBUG_COND_LT   3
+#define REMOTE_DEBUG_COND_GT   4
+#define REMOTE_DEBUG_COND_LE   5
+#define REMOTE_DEBUG_COND_GE   6
+void remote_debug_watchpoint_clear(void);
+void remote_debug_watchpoint_toggle(int index);
+void remote_debug_watchpoint_delete(int index);
+
+/* JSON list of all break- and watchpoints. *buffer is malloc()ed. */
+void remote_debug_get_points(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Callstack (hooks called from the M6809 core via m6809.h macros)    */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_push_call(UINT32 caller, UINT32 receiver);
+void remote_debug_pop_call(void);
+void remote_debug_reset_callstack(void);
+
+/* JSON dump of the callstack. *buffer is malloc()ed. */
+void remote_debug_get_callstack(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Memory access trace                                                */
+/* ------------------------------------------------------------------ */
+
+/* Add an address to the set of traced addresses; every access to a
+ * traced address is recorded in a ring buffer. bank -1 matches any bank;
+ * a specific bank only matters for the 0x4000-0x7FFF ROM window. */
+void remote_debug_trace_add(UINT32 adr, int bank);
+
+/* Clear the traced address set and the recorded log. */
+void remote_debug_trace_clear(void);
+
+/* JSON dump of traced addresses and the access log. *buffer is malloc()ed. */
+void remote_debug_get_trace(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Playfield objects: switches, lamps, solenoids                      */
+/* ------------------------------------------------------------------ */
+
+/* JSON arrays of switches / lamps / solenoids with number, matrix
+ * position, active state and (where known) a standard WPC name.
+ * *buffer is malloc()ed. */
+void remote_debug_get_switches(char **buffer, int *len);
+void remote_debug_get_lamps(char **buffer, int *len);
+void remote_debug_get_solenoids(char **buffer, int *len);
+
+/* Set a switch, optionally as a timed pulse: hold `val` for `pulse_ms`
+ * milliseconds (wall clock) then restore the opposite value. pulse_ms <= 0
+ * sets the level permanently. Returns 0 on success, -1 if the core is not
+ * ready. */
+int remote_debug_set_switch(int sw, int val, int pulse_ms);
+
+/* ------------------------------------------------------------------ */
+/* Object monitoring (change log)                                     */
+/* ------------------------------------------------------------------ */
+
+#define REMOTE_DEBUG_OBJ_SWITCH 0
+#define REMOTE_DEBUG_OBJ_LAMP   1
+#define REMOTE_DEBUG_OBJ_SOL    2
+
+/* Watch an object for state changes; each transition is appended to the
+ * action log with a timestamp. When brk is nonzero, execution is paused on
+ * the next frame after the object changes. Returns 0 on success, -1 on a
+ * full table. */
+int remote_debug_monitor_add(int obj_type, int id, int brk);
+void remote_debug_monitor_clear(void);
+
+/* JSON list of monitored objects. *buffer is malloc()ed. */
+void remote_debug_get_monitors(char **buffer, int *len);
+
+/* JSON action log of recorded state changes. *buffer is malloc()ed. */
+void remote_debug_get_action_log(char **buffer, int *len);
+void remote_debug_action_log_clear(void);
+
+/* Sample all monitored objects and log changes. Called from the frame
+ * hook (emulator thread). */
+void remote_debug_monitor_sample(void);
+
+/* ------------------------------------------------------------------ */
+/* Code instrumentation (PC hit counting)                             */
+/* ------------------------------------------------------------------ */
+
+/* Count how often execution passes a code address. bank -1 matches any
+ * bank. Returns 0 on success, -1 on a full table. */
+int remote_debug_instrument_add(UINT32 addr, int bank);
+void remote_debug_instrument_clear(void);
+
+/* JSON list of instrumented addresses with hit counts. *buffer malloc()ed. */
+void remote_debug_get_instrumentation(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Execution trace (ring buffer of executed instructions)             */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_exectrace_start(void);
+void remote_debug_exectrace_stop(void);
+void remote_debug_exectrace_clear(void);
+
+/* JSON of the recorded instruction ring (oldest to newest). malloc()ed. */
+void remote_debug_get_exectrace(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Coverage map (which addresses executed, per bank)                  */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_coverage_start(void);
+void remote_debug_coverage_stop(void);
+void remote_debug_coverage_clear(void);
+
+/* JSON summary {enabled, executed, addressable}. malloc()ed. */
+void remote_debug_get_coverage_info(char **buffer, int *len);
+
+/* JSON 0/1 executed flag per address over a window. malloc()ed. */
+void remote_debug_get_coverage_region(char **buffer, int *len, UINT32 addr, int size, int bank);
+
+/* ------------------------------------------------------------------ */
+/* Tracepoints (log a register snapshot and continue, no halt)        */
+/* ------------------------------------------------------------------ */
+
+/* Add a tracepoint at addr (bank -1 = any). Returns 0, -1 if full. */
+int remote_debug_tracepoint_add(UINT32 addr, int bank);
+void remote_debug_tracepoint_clear(void);
+
+/* JSON of tracepoints and their collected register-snapshot log. malloc()ed. */
+void remote_debug_get_tracepoints(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Memory value scan (cheat-engine style variable search)             */
+/* ------------------------------------------------------------------ */
+
+/* Take a fresh snapshot of [addr, addr+size); every byte becomes a scan
+ * candidate. Returns the candidate count, or -1 on error. */
+int remote_debug_scan_new(int cpu, UINT32 addr, int size);
+
+/* Filter scan candidates. op is one of the REMOTE_DEBUG_SCAN_* codes; val
+ * is used by EQ/NE only. Returns the remaining candidate count, or -1. */
+#define REMOTE_DEBUG_SCAN_EQ        0
+#define REMOTE_DEBUG_SCAN_NE        1
+#define REMOTE_DEBUG_SCAN_CHANGED   2
+#define REMOTE_DEBUG_SCAN_UNCHANGED 3
+#define REMOTE_DEBUG_SCAN_INC       4
+#define REMOTE_DEBUG_SCAN_DEC       5
+int remote_debug_scan_filter(int op, UINT8 val);
+
+/* JSON of current scan candidates (addresses + current values, capped).
+ * *buffer is malloc()ed. */
+void remote_debug_get_scan(char **buffer, int *len);
+
+/* ------------------------------------------------------------------ */
+/* Memory / register operations                                       */
+/* ------------------------------------------------------------------ */
+
+void remote_debug_memory_fill(int cpu, UINT32 addr, int size, UINT8 val);
+
+/* Write a block of bytes. Returns 0 on success, -1 on error. */
+int remote_debug_memory_write_block(int cpu, UINT32 addr, const UINT8 *data, int len);
+
+/* Search memory for a byte pattern. Returns 1 and sets *found_addr on a
+ * match, 0 otherwise. bank -1 reads through the current memory map; a
+ * specific bank reads the 0x4000-0x7FFF window from that WPC ROM bank. */
+int remote_debug_memory_find(int cpu, UINT32 addr, int size, const UINT8 *pattern, int pat_len, UINT32 *found_addr, int bank);
+
+/* Read a byte, optionally from a specific WPC ROM bank (see the .c file).
+ * Caller must hold the debugger lock. */
+UINT8 remote_debug_read_byte(int cpu, UINT32 addr, int bank);
+
+/* Set a CPU register (reg is a cpu core register id). */
+void remote_debug_set_register(int cpu, int reg, UINT32 val);
+
+/* ------------------------------------------------------------------ */
+/* Messages / events                                                  */
+/* ------------------------------------------------------------------ */
+
+/* Append a line to the message log (also published as an SSE event). */
+void remote_debug_add_message(const char *msg);
+
+/* JSON dump of the message log. *buffer is malloc()ed. */
+void remote_debug_get_messages(char **buffer, int *len);
+
+/* Pop the next pending SSE event into buf (NUL-terminated JSON object).
+ * Returns 1 if an event was copied, 0 if the queue is empty.
+ * Called by the HTTP server thread. */
+int remote_debug_next_event(char *buf, int maxlen);
+
+/* Copy src into dst as a JSON string body (without surrounding quotes),
+ * escaping backslash, quote and control characters. dst is always
+ * NUL-terminated; at most dstlen bytes are written. Returns dst. */
+char *remote_debug_json_escape(char *dst, int dstlen, const char *src);
+
+/* ------------------------------------------------------------------ */
+/* Save states                                                        */
+/* ------------------------------------------------------------------ */
+
+/* Lightweight checkpoint of the game state (WPC RAM + main CPU registers)
+ * into a named in-memory slot. This deliberately does not use MAME's full
+ * state-save machinery (which is incomplete/unstable for WPC/DCS); it
+ * captures exactly what is useful for reverse engineering and can be
+ * saved/restored reliably while paused. Returns 0 on success, -1 on error
+ * (bad name, no slot free, or unknown slot on load). */
+int remote_debug_savestate_save(const char *slot);
+int remote_debug_savestate_load(const char *slot);
+void remote_debug_savestate_delete(const char *slot);
+
+/* JSON list of occupied save slots. *buffer is malloc()ed. */
+void remote_debug_get_savestates(char **buffer, int *len);
+
+/* Diff the RAM of save slot a against slot b, or against the live RAM when
+ * b is NULL/empty. JSON {a, b, count, diffs:[{addr,a,b}...]}. malloc()ed. */
+void remote_debug_savestate_diff(char **buffer, int *len, const char *a, const char *b);
+
+/* ------------------------------------------------------------------ */
+/* DMD frame recorder                                                 */
+/* ------------------------------------------------------------------ */
+
+/* Start / stop / clear capturing DMD frames into a ring buffer (one frame
+ * per emulated video frame while recording). */
+void remote_debug_dmdrec_start(void);
+void remote_debug_dmdrec_stop(void);
+void remote_debug_dmdrec_clear(void);
+
+/* JSON recorder status: {recording, count, width, height, capacity}. */
+void remote_debug_get_dmdrec_info(char **buffer, int *len);
+
+/* Packed binary dump of all recorded frames:
+ *   u32 count, u32 width, u32 height, then per frame: u32 t_ms + w*h bytes.
+ * All integers little-endian. *buffer is malloc()ed. */
+void remote_debug_get_dmdrec_data(char **buffer, int *len);
+
+/* Capture one DMD frame if recording is active. Called from the frame hook
+ * (emulator thread). */
+void remote_debug_dmdrec_sample(void);
+
+/* ------------------------------------------------------------------ */
+/* Display capture                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Frame hook (called from the video backend) storing the most recent
+ * display for the screenshot endpoints. */
+void remote_debug_frame_update(struct mame_display *display);
+
+void remote_debug_get_screenshot_info(int *w, int *h);
+void remote_debug_get_raw_screenshot(char **buffer, int *len);
+void remote_debug_get_screenshot(char **buffer, int *len, char *content_type);
+void remote_debug_get_dmd_screenshot(char **buffer, int *len, char *content_type);
+void remote_debug_get_dmd_pnm(char **buffer, int *len, char *content_type);
+
+#endif /* REMOTE_DEBUG_H */

--- a/src/remote_debug/test_breakpoint.sh
+++ b/src/remote_debug/test_breakpoint.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+PORT=${PORT:-8926}
+ROM=${ROM:-taf_l7}
+BINARY=${BINARY:-../../xpinmamed.x11}
+ROMPATH=${ROMPATH:-$HOME/.pinmame}
+ADDR="0x8CBE"
+
+ROMPATH_ARGS=()
+[ -d "$ROMPATH" ] && ROMPATH_ARGS=(-rompath "$ROMPATH")
+
+echo "--------------------------------------------------"
+echo "PinMAME Breakpoint Test Script"
+echo "ROM: $ROM, Address: $ADDR, Port: $PORT"
+echo "--------------------------------------------------"
+
+# Kill any existing process
+killall -9 xpinmamed.x11 2>/dev/null
+
+echo "1. Starting PinMAME in background..."
+$BINARY -headless -startpaused -httpport $PORT -nosound "${ROMPATH_ARGS[@]}" $ROM > test_log.txt 2>&1 &
+PID=$!
+
+# Wait for init
+sleep 5
+
+if ! ps -p $PID > /dev/null; then
+    echo "ERROR: PinMAME failed to start. Log content:"
+    cat test_log.txt
+    exit 1
+fi
+
+echo "2. Setting breakpoint at $ADDR..."
+curl -s "http://localhost:$PORT/api/debugger/command?cmd=bp%20$ADDR"
+echo ""
+
+echo "3. Resuming emulation..."
+curl -s "http://localhost:$PORT/api/debugger/control?cmd=resume"
+echo ""
+
+echo "4. Waiting for breakpoint hit..."
+MAX_WAIT=20
+COUNT=0
+HIT=0
+
+while [ $COUNT -lt $MAX_WAIT ]; do
+    STATE=$(curl -s "http://localhost:$PORT/api/info")
+    MSGS=$(curl -s "http://localhost:$PORT/api/debugger/messages")
+    
+    PAUSED=$(echo $STATE | grep -o '"paused":1')
+    HALT_MSG=$(echo $MSGS | grep -o 'Halt:')
+    
+    if [ ! -z "$PAUSED" ] || [ ! -z "$HALT_MSG" ]; then
+        echo "SUCCESS: Breakpoint triggered!"
+        echo "Final State: $STATE"
+        echo "Messages: $MSGS"
+        HIT=1
+        break
+    fi
+    
+    echo "Still running... ($COUNT)"
+    sleep 1
+    ((COUNT++))
+done
+
+if [ $HIT -eq 0 ]; then
+    echo "FAILURE: Breakpoint was never hit."
+    kill -9 $PID 2>/dev/null
+    exit 1
+fi
+
+kill -9 $PID 2>/dev/null
+echo "Test complete."

--- a/src/remote_debug/test_suite.sh
+++ b/src/remote_debug/test_suite.sh
@@ -1,0 +1,349 @@
+#!/bin/bash
+# PinMAME Remote Debugger verification suite.
+#
+# Usage: ./test_suite.sh  (run from src/remote_debug)
+# Environment overrides:
+#   ROM      game to load             (default: taf_l7)
+#   ROMPATH  ROM search path          (default: ~/.pinmame if it exists)
+#   PORT     HTTP port                (default: 8944)
+#   BINARY   emulator binary          (default: ../../xpinmamed.x11)
+
+PORT=${PORT:-8944}
+ROM=${ROM:-taf_l7}
+BINARY=${BINARY:-../../xpinmamed.x11}
+ROMPATH=${ROMPATH:-$HOME/.pinmame}
+BASE="http://localhost:$PORT"
+
+ROMPATH_ARGS=()
+[ -d "$ROMPATH" ] && ROMPATH_ARGS=(-rompath "$ROMPATH")
+
+echo "=================================================="
+echo "PinMAME Remote Debugger Verification Suite"
+echo "=================================================="
+
+killall -9 "$(basename "$BINARY")" 2>/dev/null
+"$BINARY" -headless -startpaused -httpport "$PORT" -nosound "${ROMPATH_ARGS[@]}" "$ROM" > suite_log.txt 2>&1 &
+PID=$!
+sleep 5
+
+fail() {
+    echo "  [FAIL] $1"
+    shift
+    for line in "$@"; do echo "  $line"; done
+    kill -9 $PID 2>/dev/null
+    exit 1
+}
+
+assert_contains() {
+    if [[ "$1" == *"$2"* ]]; then echo "  [PASS] $3"; else fail "$3 (expected '$2')" "Body: $1"; fi
+}
+
+assert_status() {
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" "$1")
+    if [ "$code" == "$2" ]; then echo "  [PASS] $3"; else fail "$3 (expected HTTP $2, got $code)"; fi
+}
+
+echo "1. Info & core connectivity..."
+INFO=$(curl -s "$BASE/api/info")
+assert_contains "$INFO" "$ROM" "Game name"
+assert_contains "$INFO" '"wpc_bank":' "WPC bank field"
+assert_contains "$INFO" '"segments":' "Segments field"
+
+echo "2. HTTP status codes..."
+assert_status "$BASE/api/info" 200 "200 on /api/info"
+assert_status "$BASE/api/does/not/exist" 404 "404 on unknown route"
+assert_status "$BASE/api/debugger/control?cmd=bogus" 400 "400 on bad command"
+assert_status "$BASE/api/debugger/breakpoints?cmd=add" 400 "400 on missing addr"
+
+echo "3. Web UI and API doc..."
+UI=$(curl -s "$BASE/ui")
+assert_contains "$UI" "<title>PinMAME Remote Debugger</title>" "Web UI served"
+DOC=$(curl -s "$BASE/api/doc")
+assert_contains "$DOC" "/api/debugger/trace" "API doc lists routes"
+
+echo "4. Screenshot API..."
+S_INFO=$(curl -s "$BASE/api/screenshot/info")
+assert_contains "$S_INFO" '"width":' "Screenshot info"
+S_RAW_SIZE=$(curl -s "$BASE/api/screenshot/raw" | wc -c)
+[ "$S_RAW_SIZE" -gt 1000 ] && echo "  [PASS] Screenshot raw ($S_RAW_SIZE bytes)" || fail "Screenshot raw too small ($S_RAW_SIZE)"
+S_PNM_HEAD=$(curl -s "$BASE/api/screenshot/pnm" | head -n 1)
+assert_contains "$S_PNM_HEAD" "P6" "Screenshot PNM header"
+
+echo "5. SSE events..."
+curl -s --max-time 3 -N "$BASE/api/events" > sse_log.txt &
+SSE_PID=$!
+sleep 0.5
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 0.5
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+wait $SSE_PID 2>/dev/null
+SSE=$(cat sse_log.txt; rm -f sse_log.txt)
+assert_contains "$SSE" '"event": "resume"' "SSE resume event"
+assert_contains "$SSE" '"event": "halt"' "SSE halt event"
+
+echo "6. Resuming execution for boot..."
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+echo "  Waiting for boot (10s)..."
+sleep 10
+echo "  Setting breakpoint at 8CC1..."
+curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=8CC1" > /dev/null
+sleep 5
+POINTS=$(curl -s "$BASE/api/debugger/points" | tr -d ' ')
+assert_contains "$POINTS" '"hits":' "Breakpoint hit counter present"
+
+echo "7. DMD API (post-init)..."
+DMD_INFO=$(curl -s "$BASE/api/dmd/info")
+if [[ "$DMD_INFO" == *'"width": 128'* || "$DMD_INFO" == *'"width":128'* ]]; then
+    echo "  [PASS] DMD info"
+    DMD_RAW_SIZE=$(curl -s "$BASE/api/dmd/raw" | wc -c)
+    [ "$DMD_RAW_SIZE" -eq 4096 ] && echo "  [PASS] DMD raw (4096 bytes)" || fail "DMD raw size ($DMD_RAW_SIZE)"
+    DMD_PNM_HEAD=$(curl -s "$BASE/api/dmd/pnm" | head -n 1)
+    assert_contains "$DMD_PNM_HEAD" "P5" "DMD PNM header"
+else
+    echo "  [INFO] DMD not initialized yet (skipped)"
+fi
+
+echo "8. Memory operations..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+# fill: size is decimal now, addr/val hex
+curl -s "$BASE/api/debugger/memory/fill?addr=0100&size=16&val=AA&cpu=0" > /dev/null
+FIND=$(curl -s "$BASE/api/debugger/memory/find?addr=0000&pattern=AAAAAAAA&cpu=0" | tr -d ' ')
+assert_contains "$FIND" '"found":256' "Memory fill & find"
+# block write (bypasses WPC RAM protection)
+curl -s "$BASE/api/debugger/memory/write?addr=0110&data=DEADBEEF" > /dev/null
+MEM=$(curl -s "$BASE/api/debugger/memory?addr=0110&size=4" | tr -d ' ')
+assert_contains "$MEM" '"data":[222,173,190,239]' "Block memory write"
+
+echo "9. Register write API..."
+curl -s "$BASE/api/debugger/state/write?reg=5&val=42" > /dev/null
+STATE=$(curl -s "$BASE/api/debugger/state" | tr -d ' ')
+assert_contains "$STATE" '"b":66' "Register write by index (B=0x42)"
+curl -s "$BASE/api/debugger/state/write?reg=A&val=13" > /dev/null
+STATE=$(curl -s "$BASE/api/debugger/state" | tr -d ' ')
+assert_contains "$STATE" '"a":19' "Register write by name (A=0x13)"
+
+echo "10. Watchpoint with length..."
+curl -s "$BASE/api/debugger/watchpoints?cmd=add&addr=0120&len=8&mode=2" > /dev/null
+POINTS=$(curl -s "$BASE/api/debugger/points" | tr -d ' ')
+assert_contains "$POINTS" '"len":8' "Watchpoint length stored"
+curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+
+echo "11. Conditional breakpoint..."
+BP_COND=$(curl -s "$BASE/api/debugger/breakpoints?cmd=add&addr=9000&cond=A%3D%3DFF&ignore=3")
+assert_contains "$BP_COND" '"status": "ok"' "Conditional BP accepted"
+POINTS=$(curl -s "$BASE/api/debugger/points" | tr -d ' ')
+assert_contains "$POINTS" '"cond":"A==FF"' "Condition stored"
+assert_contains "$POINTS" '"ignore":3' "Ignore count stored"
+assert_status "$BASE/api/debugger/breakpoints?cmd=add&addr=9000&cond=ZZ==1" 400 "400 on bad condition"
+curl -s "$BASE/api/debugger/breakpoints?cmd=clear" > /dev/null
+
+echo "12. Memory trace..."
+curl -s "$BASE/api/debugger/trace?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/trace?cmd=add&addr=0100" > /dev/null
+TRACE=$(curl -s "$BASE/api/debugger/trace" | tr -d ' ')
+assert_contains "$TRACE" '"watched":[{"addr":256,"bank":-1}]' "Trace address registered"
+
+echo "12b. Bank-aware memory access..."
+# The 0x4000-0x7FFF window is bank-switched ROM; reading it with an explicit
+# bank must be independent of the current banking. The prime area (0x8000+)
+# and RAM (0x0000-0x3FFF) ignore the bank parameter.
+B00=$(curl -s "$BASE/api/debugger/memory?addr=5000&size=8&bank=00" | tr -d ' ')
+assert_contains "$B00" '"bank":0' "Read banked ROM (bank field echoed)"
+PRIME=$(curl -s "$BASE/api/debugger/memory?addr=8000&size=4" | tr -d ' ')
+PRIMEB=$(curl -s "$BASE/api/debugger/memory?addr=8000&size=4&bank=10" | tr -d ' ')
+DATA_A=$(echo "$PRIME" | grep -oE '"data":\[[0-9,]*\]')
+DATA_B=$(echo "$PRIMEB" | grep -oE '"data":\[[0-9,]*\]')
+[ "$DATA_A" == "$DATA_B" ] && echo "  [PASS] Prime area (0x8000) ignores bank" || fail "prime area differs with bank ($DATA_A vs $DATA_B)"
+WPB=$(curl -s "$BASE/api/debugger/watchpoints?cmd=add&addr=5120&len=2&mode=1&bank=20"; curl -s "$BASE/api/debugger/points" | tr -d ' ')
+assert_contains "$WPB" '"addr":20768,"len":2,"mode":1,"bank":32' "Banked watchpoint stored"
+curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+
+echo "13. Callstack API..."
+STACK=$(curl -s "$BASE/api/debugger/callstack")
+assert_contains "$STACK" '"stack":' "Callstack format"
+assert_contains "$STACK" '"bank":' "Callstack banking info"
+assert_contains "$STACK" '"pc":' "Callstack register context (PC)"
+assert_contains "$STACK" '"u":' "Callstack register context (U)"
+
+echo "14. Switch/lamp/solenoid query with names..."
+SW=$(curl -s "$BASE/api/switches" | tr -d ' ')
+assert_contains "$SW" '"num":1,"col":0,"row":1,"active":0,"name":"Coin1"' "Coin 1 named"
+assert_contains "$SW" '"name":"Enter"' "Enter (sw5) named"
+assert_contains "$SW" '"name":"Escape"' "Escape (sw8) named"
+LAMPS=$(curl -s "$BASE/api/lamps" | tr -d ' ')
+assert_contains "$LAMPS" '"num":11,"col":1,"row":1' "Lamp 11 present"
+SOL=$(curl -s "$BASE/api/solenoids" | tr -d ' ')
+assert_contains "$SOL" '"num":1,"active":' "Solenoid 1 present"
+
+echo "15. Switch pulse..."
+curl -s "$BASE/api/input?sw=1&val=1&pulse=200" > /dev/null
+SW1=$(curl -s "$BASE/api/switches" | tr -d ' ')
+assert_contains "$SW1" '"num":1,"col":0,"row":1,"active":1' "Switch on during pulse"
+sleep 0.5
+SW1=$(curl -s "$BASE/api/switches" | tr -d ' ')
+assert_contains "$SW1" '"num":1,"col":0,"row":1,"active":0' "Switch off after pulse"
+
+echo "16. Object monitoring & action log..."
+curl -s "$BASE/api/monitor?cmd=clear" > /dev/null
+curl -s "$BASE/api/monitor/log?cmd=clear" > /dev/null
+MON=$(curl -s "$BASE/api/monitor?cmd=add&type=lamp&id=11" | tr -d ' ')
+assert_contains "$MON" '"type":"lamp","id":11' "Monitor registered"
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 3
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+ALOG=$(curl -s "$BASE/api/monitor/log" | tr -d ' ')
+assert_contains "$ALOG" '"type":"lamp","id":11' "Action log captured lamp changes"
+
+echo "17. Code instrumentation / PC hit counting..."
+curl -s "$BASE/api/debugger/instrument?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/instrument?cmd=add&addr=8CC1" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 2
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+INSTR=$(curl -s "$BASE/api/debugger/instrument" | tr -d ' ')
+assert_contains "$INSTR" '"addr":36033' "Instrumented address listed"
+# count field must be present and > 0 is likely; at minimum the field exists
+assert_contains "$INSTR" '"count":' "Hit count field present"
+
+echo "18. Value scan (variable search)..."
+curl -s "$BASE/api/debugger/scan?cmd=new&addr=0100&size=256&cpu=0" > /dev/null
+curl -s "$BASE/api/debugger/memory/write?addr=0140&val=5A" > /dev/null
+SCAN=$(curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed" | tr -d ' ')
+assert_contains "$SCAN" '"addr":320' "Value scan isolates changed byte (0x140)"
+SCANEQ=$(curl -s "$BASE/api/debugger/scan?cmd=filter&op=eq&val=5A" | tr -d ' ')
+assert_contains "$SCANEQ" '"val":90' "Value scan eq filter"
+
+echo "19. Save states (RAM + CPU checkpoint)..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+curl -s "$BASE/api/debugger/memory/write?addr=0500&val=11" > /dev/null
+curl -s "$BASE/api/debugger/savestate?cmd=save&slot=cp1" > /dev/null
+SS=$(curl -s "$BASE/api/debugger/savestate" | tr -d ' ')
+assert_contains "$SS" '"name":"cp1"' "Save state slot listed"
+curl -s "$BASE/api/debugger/memory/write?addr=0500&val=99" > /dev/null
+curl -s "$BASE/api/debugger/savestate?cmd=load&slot=cp1" > /dev/null
+RESTORED=$(curl -s "$BASE/api/debugger/memory?addr=0500&size=1" | tr -d ' ')
+assert_contains "$RESTORED" '"data":[17]' "Save/load restores RAM byte"
+LOADMISS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/debugger/savestate?cmd=load&slot=nope")
+[ "$LOADMISS" == "404" ] && echo "  [PASS] 404 on unknown slot" || fail "unknown slot (expected 404, got $LOADMISS)"
+
+echo "20. DMD recorder..."
+curl -s "$BASE/api/debugger/dmdrec?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/dmdrec?cmd=start" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 2
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+REC=$(curl -s "$BASE/api/debugger/dmdrec?cmd=stop" | tr -d ' ')
+assert_contains "$REC" '"width":128' "DMD recorder captured frames"
+DATA_SIZE=$(curl -s "$BASE/api/debugger/dmdrec/data" | wc -c)
+[ "$DATA_SIZE" -gt 12 ] && echo "  [PASS] DMD recording blob ($DATA_SIZE bytes)" || fail "DMD blob too small ($DATA_SIZE)"
+
+echo "20b. Execution trace..."
+curl -s "$BASE/api/debugger/exectrace?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/exectrace?cmd=start" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 0.3
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+curl -s "$BASE/api/debugger/exectrace?cmd=stop" > /dev/null
+ET=$(curl -s "$BASE/api/debugger/exectrace" | tr -d ' ')
+assert_contains "$ET" '"pc":' "Execution trace recorded instructions"
+
+echo "20c. Code coverage..."
+curl -s "$BASE/api/debugger/coverage?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/coverage?cmd=start" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 0.5
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+curl -s "$BASE/api/debugger/coverage?cmd=stop" > /dev/null
+COV=$(curl -s "$BASE/api/debugger/coverage")
+EXEC=$(echo "$COV" | sed -n 's/.*"executed": *\([0-9]*\).*/\1/p')
+[ "$EXEC" -gt 0 ] && echo "  [PASS] Coverage recorded $EXEC addresses" || fail "coverage executed 0"
+COVR=$(curl -s "$BASE/api/debugger/coverage?addr=8000&size=8" | tr -d ' ')
+assert_contains "$COVR" '"executed":[' "Coverage region query"
+
+echo "20d. Tracepoints (log & continue)..."
+# resume, find a hot address from the trace, trace it, confirm it logs without halting
+curl -s "$BASE/api/debugger/exectrace?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/exectrace?cmd=start" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null
+sleep 0.2
+curl -s "$BASE/api/debugger/exectrace?cmd=stop" > /dev/null
+HOT=$(curl -s "$BASE/api/debugger/exectrace" | python3 -c "import json,sys;t=json.load(sys.stdin)['trace'];print('%X'%t[-1]['pc']) if t else print('8000')")
+curl -s "$BASE/api/debugger/tracepoints?cmd=clear" > /dev/null
+curl -s "$BASE/api/debugger/tracepoints?cmd=add&addr=$HOT" > /dev/null
+sleep 1
+TP=$(curl -s "$BASE/api/debugger/tracepoints" | tr -d ' ')
+assert_contains "$TP" '"hits":' "Tracepoint recorded hits"
+RUN=$(curl -s "$BASE/api/info" | tr -d ' ')
+assert_contains "$RUN" '"paused":0' "Tracepoint did not halt execution"
+
+echo "20e. Watchpoint value condition..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+# find a churning RAM byte
+curl -s "$BASE/api/debugger/scan?cmd=new&addr=0000&size=2048" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null; sleep 1
+curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed" > /dev/null; sleep 1
+CH=$(curl -s "$BASE/api/debugger/scan?cmd=filter&op=changed" | python3 -c "import json,sys;r=json.load(sys.stdin)['results'];print('%X'%r[0]['addr']) if r else print('')")
+curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+if [ -n "$CH" ]; then
+    # impossible condition: must NOT halt
+    curl -s "$BASE/api/debugger/watchpoints?cmd=add&addr=$CH&mode=2&cond=eq&val=FF" > /dev/null
+    curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null; sleep 1.5
+    P=$(curl -s "$BASE/api/info" | tr -d ' ')
+    assert_contains "$P" '"paused":0' "Value-cond WP (impossible) keeps running"
+    # achievable condition: must halt
+    curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+    curl -s "$BASE/api/debugger/watchpoints?cmd=add&addr=$CH&mode=2&cond=ne&val=FF" > /dev/null
+    curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null; sleep 1.5
+    P=$(curl -s "$BASE/api/info" | tr -d ' ')
+    assert_contains "$P" '"paused":1' "Value-cond WP (achievable) halts"
+    curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+else
+    echo "  [INFO] no churning byte found, skipped"
+fi
+
+echo "20f. Monitor break-on-change..."
+curl -s "$BASE/api/debugger/watchpoints?cmd=clear" > /dev/null
+curl -s "$BASE/api/monitor?cmd=clear" > /dev/null
+MB=$(curl -s "$BASE/api/monitor?cmd=add&type=lamp&id=11&break=1" | tr -d ' ')
+assert_contains "$MB" '"break":1' "Monitor break flag stored"
+curl -s "$BASE/api/debugger/control?cmd=resume" > /dev/null; sleep 3
+P=$(curl -s "$BASE/api/info" | tr -d ' ')
+assert_contains "$P" '"paused":1' "Monitor break halted on lamp change"
+curl -s "$BASE/api/monitor?cmd=clear" > /dev/null
+
+echo "20g. Save-state diff..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+curl -s "$BASE/api/debugger/memory/write?addr=0700&data=0102" > /dev/null
+curl -s "$BASE/api/debugger/savestate?cmd=save&slot=dref" > /dev/null
+curl -s "$BASE/api/debugger/memory/write?addr=0700&data=AABB" > /dev/null
+DIFF=$(curl -s "$BASE/api/debugger/savestate/diff?a=dref" | tr -d ' ')
+assert_contains "$DIFF" '"addr":1792,"a":1,"b":170' "Save-state diff finds changed byte"
+
+# These come last: forcing the PC to an arbitrary vector and single-stepping
+# leaves the CPU in a state that will fault if allowed to run on, so they must
+# not be followed by a resume before the process is killed.
+echo "21. Step out..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+STEPOUT=$(curl -s "$BASE/api/debugger/control?cmd=stepout")
+assert_contains "$STEPOUT" '"status": "ok"' "Step out accepted"
+
+echo "22. Live register context & stepping..."
+curl -s "$BASE/api/debugger/control?cmd=pause" > /dev/null
+curl -s "$BASE/api/debugger/state/write?reg=PC&val=FE3C" > /dev/null
+curl -s "$BASE/api/debugger/state/write?reg=A&val=01" > /dev/null
+curl -s "$BASE/api/debugger/control?cmd=step" > /dev/null
+sleep 1
+STATE_STEP=$(curl -s "$BASE/api/debugger/state" | tr -d ' ')
+if [[ "$STATE_STEP" == *'"pc":65084'* ]]; then
+    fail "Live register context: PC stayed at FE3C"
+else
+    echo "  [PASS] Live register context: PC moved from FE3C"
+fi
+
+echo "=================================================="
+echo "ALL TESTS PASSED"
+echo "=================================================="
+
+kill -9 $PID 2>/dev/null
+exit 0

--- a/src/remote_debug/ui.html
+++ b/src/remote_debug/ui.html
@@ -1,0 +1,1817 @@
+<!DOCTYPE html>
+<!-- license:BSD-3-Clause -->
+<html>
+<head>
+<meta charset="utf-8">
+<title>PinMAME Remote Debugger</title>
+<style>
+    /* ---------- base layout ---------- */
+    body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        background: #1a1a1a;
+        color: #e0e0e0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        overflow: hidden;
+    }
+    header {
+        background: #2d2d2d;
+        padding: 8px 16px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 2px solid #3d3d3d;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+    .main-container { display: flex; flex: 1; overflow: hidden; }
+    .sidebar {
+        width: 400px;
+        min-width: 320px;
+        background: #252526;
+        border-right: 1px solid #3d3d3d;
+        display: flex;
+        flex-direction: column;
+        overflow-y: auto;
+    }
+    .content { flex: 1; display: flex; flex-direction: column; padding: 10px; overflow-y: auto; background: #1e1e1e; }
+    .panel {
+        background: #2d2d2d;
+        border: 1px solid #3d3d3d;
+        border-radius: 4px;
+        margin-bottom: 10px;
+        padding: 12px;
+    }
+    .panel h2 {
+        margin-top: 0;
+        font-size: 0.9rem;
+        border-bottom: 1px solid #3d3d3d;
+        padding-bottom: 8px;
+        color: #4fc1ff;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+    }
+    .sidebar .panel { margin: 10px; }
+
+    /* ---------- controls ---------- */
+    .btn {
+        background: #0e639c; color: white; border: none; padding: 4px 10px;
+        cursor: pointer; border-radius: 2px; font-size: 0.8rem; margin-left: 2px;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn-danger { background: #a1260d; }
+    .btn-success { background: #388a34; }
+    .btn-cabinet {
+        background: #444; border: 1px solid #666; width: 60px; height: 30px;
+        margin: 2px; font-weight: bold; font-size: 0.7rem;
+    }
+    .btn-cabinet:active { background: #00ff00; color: #000; }
+    input, select {
+        background: #3c3c3c; border: 1px solid #3d3d3d; color: #fff; padding: 4px 8px;
+        border-radius: 2px; outline: none; font-family: 'Consolas', monospace;
+    }
+    input:focus { border-color: #4fc1ff; }
+    .tool-bar {
+        margin-bottom: 10px; display: flex; gap: 8px; align-items: center;
+        background: #252526; padding: 8px; border-radius: 4px; flex-wrap: wrap;
+    }
+
+    /* ---------- status / banners / toasts ---------- */
+    .status-tag {
+        padding: 3px 10px; border-radius: 12px; font-size: 0.75rem;
+        background: #444; margin-right: 8px; font-weight: bold;
+    }
+    .status-paused { background: #a1260d; color: white; }
+    .status-running { background: #388a34; color: white; }
+    .status-offline { background: #666; color: #ddd; }
+    #transport-tag { font-size: 0.65rem; color: #858585; margin-right: 12px; }
+    #offline-banner {
+        display: none; background: #a1260d; color: #fff; text-align: center;
+        padding: 4px; font-size: 0.8rem;
+    }
+    #toast-area { position: fixed; bottom: 12px; right: 12px; z-index: 99; }
+    .toast {
+        background: #a1260d; color: #fff; padding: 8px 14px; margin-top: 6px;
+        border-radius: 4px; font-size: 0.8rem; box-shadow: 0 2px 8px #000;
+        opacity: 0.95;
+    }
+    .toast-info { background: #0e639c; }
+
+    /* ---------- registers ---------- */
+    .reg-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 6px; font-family: 'Consolas', monospace; }
+    .reg-item {
+        background: #1e1e1e; padding: 4px 8px; border-radius: 2px; display: flex;
+        justify-content: space-between; border-left: 3px solid #4fc1ff; align-items: center;
+    }
+    .reg-label { color: #858585; font-size: 0.75rem; }
+    .reg-val { color: #dcdcaa; font-weight: bold; font-size: 0.85rem; cursor: pointer; }
+    .reg-val:hover { text-decoration: underline; }
+    .reg-dec { color: #6a9955; font-size: 0.7rem; margin-left: 5px; }
+    .flags-grid { display: flex; gap: 2px; font-family: 'Consolas', monospace; margin-top: 10px; }
+    .flag { flex: 1; text-align: center; background: #333; padding: 4px 0; border-radius: 2px; font-size: 0.75rem; color: #555; }
+    .flag.active { background: #388a34; color: #fff; font-weight: bold; }
+
+    /* ---------- tables ---------- */
+    .hex-table, .dasm-table, .trace-table {
+        font-family: 'Consolas', monospace; border-collapse: collapse; width: 100%;
+        font-size: 0.85rem; background: #1e1e1e;
+    }
+    .hex-table td, .dasm-table td, .trace-table td { padding: 3px 8px; border: 1px solid #2d2d2d; }
+    .trace-table th { padding: 3px 8px; color: #858585; text-align: left; font-weight: normal; border-bottom: 1px solid #3d3d3d; }
+    .addr-col { color: #858585; width: 70px; background: #252526; text-align: right; padding-right: 12px !important; }
+    .hex-byte { cursor: pointer; text-align: center; width: 30px; color: #9cdcfe; }
+    .hex-byte:hover { background: #333; }
+    .hex-changed { background: #5a3d10 !important; color: #ffb454; }
+    .hex-ascii { color: #6a9955; width: 120px; border-left: 2px solid #3d3d3d !important; font-size: 0.8rem; }
+    .hex-edit { width: 26px; padding: 1px 2px; text-align: center; }
+    .current-pc { background: #3e3e10 !important; }
+    .dasm-row { cursor: pointer; }
+    .dasm-row:hover { background: #2a2a2a; }
+
+    /* ---------- displays ---------- */
+    #dmd-canvas { background: #000; width: 100%; image-rendering: pixelated; border: 1px solid #444; }
+    #seg-canvas { background: #000; width: 100%; border: 1px solid #444; }
+
+    /* ---------- console / lists ---------- */
+    #console-log {
+        background: #000; color: #6a9955; font-family: 'Consolas', monospace;
+        font-size: 0.85rem; height: 120px; overflow-y: scroll; padding: 10px;
+        border: 1px solid #333; margin-top: 10px;
+    }
+    .console-line { margin-bottom: 2px; border-bottom: 1px solid #111; }
+    .matrix { display: grid; grid-template-columns: repeat(8, 1fr); gap: 2px; background: #333; padding: 4px; border-radius: 2px; }
+    .matrix-dot { width: 14px; height: 14px; background: #222; border-radius: 2px; border: 1px solid #444; }
+    .matrix-dot.active-lamp { background: #ffff00; box-shadow: 0 0 5px #ffff00; }
+    .matrix-dot.active-sw { background: #00ff00; }
+    .matrix-dot.active-sol { background: #ff0000; box-shadow: 0 0 5px #ff0000; }
+    .sw-clickable { cursor: pointer; }
+    .point-item, .watch-item {
+        display: flex; justify-content: space-between; align-items: center;
+        padding: 4px; border-bottom: 1px solid #333; font-size: 0.8rem;
+        font-family: 'Consolas', monospace;
+    }
+    .point-disabled { color: #666; text-decoration: line-through; }
+    .point-meta { color: #858585; font-size: 0.7rem; margin-left: 6px; }
+    .stack-item {
+        font-family: 'Consolas', monospace; font-size: 0.85rem; padding: 2px 8px;
+        border-left: 3px solid #6a9955; margin-bottom: 2px; background: #1e1e1e; cursor: pointer;
+    }
+    .stack-item:hover { background: #2d2d2d; }
+    .hint { font-size: 0.7rem; color: #858585; }
+    kbd {
+        background: #333; border: 1px solid #555; border-radius: 3px;
+        padding: 0 4px; font-size: 0.7rem; font-family: 'Consolas', monospace;
+    }
+</style>
+</head>
+
+<body>
+<div id="offline-banner">Connection to PinMAME lost &mdash; retrying &hellip;</div>
+<header>
+    <div>
+        <span style="color:#4fc1ff;font-weight:bold;font-size:1.1rem;">PinMAME Remote Debugger</span>
+        <span id="game-title" style="margin-left:15px;color:#aaa;font-size:0.9rem;">&hellip;</span>
+    </div>
+    <div>
+        <span id="transport-tag" title="Event transport: SSE push or HTTP polling">poll</span>
+        <span id="status-mode" class="status-tag status-offline">OFFLINE</span>
+        <button class="btn" onclick="Dbg.control('pause')" title="Pause (F8 toggles)">Pause</button>
+        <button class="btn" onclick="Dbg.control('resume')" title="Resume (F8 toggles)">Resume</button>
+        <button class="btn" onclick="Dbg.control('step')" title="Step into (F11)">Step</button>
+        <button class="btn btn-success" onclick="Dbg.control('stepover')" title="Step over (F10)">Over</button>
+        <button class="btn btn-success" onclick="Dbg.control('stepout')" title="Step out (Shift+F11)">Out</button>
+        <button class="btn btn-danger" onclick="Dbg.exitEmulator()" title="Terminate the emulator">Exit</button>
+    </div>
+</header>
+
+<div class="main-container">
+    <div class="sidebar">
+        <div id="display-panel" class="panel">
+            <h2 id="display-title">System Display</h2>
+            <div id="dmd-container"><canvas id="dmd-canvas"></canvas></div>
+            <div id="seg-container" style="display:none;"><canvas id="seg-canvas"></canvas></div>
+            <div style="margin-top:5px;" class="hint">
+                <span id="dmd-res">0x0</span> |
+                <input type="checkbox" id="auto-refresh-dmd" checked> Live
+            </div>
+        </div>
+        <div id="cpu-panels-container"></div>
+        <div class="panel">
+            <h2>Callstack</h2>
+            <div id="callstack-view" style="max-height:150px;overflow-y:auto;"></div>
+        </div>
+        <div class="panel">
+            <h2>Cabinet &amp; Service</h2>
+            <div id="cabinet-buttons" style="display:grid;grid-template-columns:repeat(4,1fr);gap:5px;"></div>
+            <div class="hint" style="margin-top:6px;">
+                Pulse: <input type="number" id="pulse-ms" value="150" min="0" max="5000" step="50" style="width:60px;"> ms
+                (0 = hold while pressed)
+            </div>
+        </div>
+        <div class="panel">
+            <h2>System Info</h2>
+            <div class="reg-item"><span class="reg-label">Active Bank</span><span id="wpc-bank" class="reg-val">?</span></div>
+            <div class="hint" style="margin-top:8px;">
+                Shortcuts: <kbd>F8</kbd> pause/resume &middot; <kbd>F10</kbd> step over &middot;
+                <kbd>F11</kbd> step into &middot; <kbd>Shift+F11</kbd> step out
+            </div>
+        </div>
+        <div class="panel">
+            <h2>Matrix Visualizer</h2>
+            <div class="hint" style="margin-bottom:5px;">Lamps (8x8)</div>
+            <div id="matrix-lamps" class="matrix"></div>
+            <div class="hint" style="margin:10px 0 5px 0;">Switches (8x8, click to toggle)</div>
+            <div id="matrix-sw" class="matrix"></div>
+            <div class="hint" style="margin:10px 0 5px 0;">Solenoids (32)</div>
+            <div id="matrix-sol" class="matrix"></div>
+            <div class="hint" style="margin:10px 0 5px 0;">Direct (8)</div>
+            <div id="matrix-ded" class="matrix"></div>
+        </div>
+    </div>
+
+    <div class="content">
+        <div class="panel" style="display:flex;flex-direction:column;height:360px;">
+            <h2>Disassembler</h2>
+            <div class="tool-bar">
+                Bank: <input type="text" id="dasm-bank" value="" style="width:40px;" placeholder="cur" title="ROM bank (hex), empty = current">
+                Addr: <input type="text" id="dasm-addr" value="0000" style="width:70px;" title="hex, 0x/$ prefix optional">
+                CPU: <input type="number" id="dasm-cpu" value="0" min="0" style="width:40px;">
+                <button class="btn" onclick="Dasm.refresh()">Go</button>
+                <button class="btn" onclick="Dasm.followPC()">Follow PC</button>
+                <label class="hint"><input type="checkbox" id="dasm-follow" checked> auto-follow on halt</label>
+            </div>
+            <div style="flex:1;overflow-y:auto;">
+                <table class="dasm-table" id="dasm-view"></table>
+            </div>
+        </div>
+
+        <div class="panel">
+            <h2>Control Center</h2>
+            <div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap;">
+                <div style="flex:1;min-width:340px;">
+                    <div style="margin-bottom:5px;">
+                        <input type="text" id="bp-bank" placeholder="bank" style="width:40px;" title="ROM bank (hex), optional">
+                        <input type="text" id="bp-addr" placeholder="addr" style="width:60px;" title="address (hex)">
+                        <input type="text" id="bp-cond" placeholder="cond e.g. A==7F" style="width:110px;"
+                               title="condition: M6809 register ==,!=,<,>,<=,>= hex value">
+                        <input type="text" id="bp-ignore" placeholder="ign" style="width:36px;" title="ignore first N hits">
+                        <button class="btn btn-success" onclick="Points.add('bp')">+BP</button>
+                    </div>
+                    <div style="margin-bottom:5px;">
+                        <input type="text" id="wp-bank" placeholder="bank" style="width:40px;" title="ROM bank (hex), optional (0x4000-0x7FFF only)">
+                        <input type="text" id="wp-addr" placeholder="addr" style="width:60px;" title="address (hex)">
+                        <input type="text" id="wp-len" placeholder="len" style="width:36px;" value="1" title="watched bytes (decimal)">
+                        <select id="wp-mode">
+                            <option value="1">R</option>
+                            <option value="2">W</option>
+                            <option value="3" selected>RW</option>
+                        </select>
+                        <select id="wp-cond" title="optional value condition on the watched byte">
+                            <option value="">any</option>
+                            <option value="eq">==</option>
+                            <option value="ne">!=</option>
+                            <option value="lt">&lt;</option>
+                            <option value="gt">&gt;</option>
+                            <option value="le">&le;</option>
+                            <option value="ge">&ge;</option>
+                        </select>
+                        <input type="text" id="wp-val" placeholder="val" style="width:36px;" title="value (hex) for the condition">
+                        <button class="btn btn-success" onclick="Points.add('wp')">+WP</button>
+                    </div>
+                    <div id="point-list" style="max-height:120px;overflow-y:auto;background:#111;"></div>
+                </div>
+                <div style="flex:1;min-width:280px;">
+                    <div style="display:flex;gap:5px;margin-bottom:10px;">
+                        <input type="text" id="cli-cmd" placeholder="Classic command (BP/BC/WP/WC/G/S/F/HELP)&hellip;" style="flex:1;">
+                        <button class="btn" onclick="Cli.run()">Exec</button>
+                    </div>
+                    <button class="btn btn-danger" onclick="Dbg.nvramClear()">Wipe NVRAM &amp; Reset</button>
+                    <button class="btn" onclick="Mem.nvramView()" title="Show WPC CMOS RAM in the hex editor">NVRAM View</button>
+                    <button class="btn" onclick="Dbg.nvramDownload()" title="Download the raw 8KB NVRAM dump">NVRAM Dump &darr;</button>
+                </div>
+            </div>
+            <div id="console-log"></div>
+        </div>
+
+        <div class="panel">
+            <h2>Memory Hex Editor &amp; Search</h2>
+            <div class="tool-bar">
+                Addr: <input type="text" id="mem-addr" value="0000" style="width:70px;" title="hex, 0x/$ prefix optional">
+                Size: <input type="number" id="mem-size" value="256" min="16" max="2048" step="16" style="width:60px;">
+                CPU: <input type="number" id="mem-cpu" value="0" min="0" style="width:40px;">
+                Bank: <input type="text" id="mem-bank" style="width:44px;" placeholder="cur" title="ROM bank (hex) for 0x4000-0x7FFF; empty = current">
+                <button class="btn" onclick="Mem.refresh()">Read</button>
+                <button class="btn" onclick="Mem.page(-1)" title="previous page">&#9650;</button>
+                <button class="btn" onclick="Mem.page(1)" title="next page">&#9660;</button>
+                <label class="hint"><input type="checkbox" id="mem-auto" checked> refresh on halt</label>
+                <span class="hint">click a byte to edit, Enter commits</span>
+            </div>
+            <div class="tool-bar" style="background:#2d2d2d;border:1px dashed #444;">
+                Search HEX: <input type="text" id="search-pat" placeholder="e.g. 414243" style="flex:1;">
+                <button class="btn btn-success" onclick="Mem.search()">Find</button>
+                <button class="btn" onclick="Mem.searchNext()" title="continue after last hit">Next</button>
+            </div>
+            <div id="hex-container" style="overflow-x:auto;background:#1e1e1e;max-height:220px;overflow-y:auto;">
+                <table class="hex-table" id="hex-view"></table>
+            </div>
+        </div>
+
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>Watches</h2>
+                <div class="tool-bar">
+                    Addr: <input type="text" id="watch-addr" style="width:70px;" placeholder="hex">
+                    Len: <input type="number" id="watch-len" value="4" min="1" max="16" style="width:44px;">
+                    <button class="btn btn-success" onclick="Watches.add()">+ Watch</button>
+                </div>
+                <div id="watch-list"></div>
+            </div>
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>Memory Trace</h2>
+                <div class="tool-bar">
+                    Addr: <input type="text" id="trace-addr" style="width:70px;" placeholder="hex">
+                    Bank: <input type="text" id="trace-bank" style="width:44px;" placeholder="any" title="ROM bank (hex), optional (0x4000-0x7FFF only)">
+                    <button class="btn btn-success" onclick="Trace.add()">+ Trace</button>
+                    <button class="btn btn-danger" onclick="Trace.clear()">Clear</button>
+                    <span class="hint">logs every access to traced addresses</span>
+                </div>
+                <div id="trace-watched" class="hint" style="margin-bottom:4px;"></div>
+                <div style="max-height:180px;overflow-y:auto;">
+                    <table class="trace-table" id="trace-view"></table>
+                </div>
+            </div>
+        </div>
+
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>Code Instrumentation (PC hits)</h2>
+                <div class="tool-bar">
+                    Addr: <input type="text" id="instr-addr" style="width:70px;" placeholder="hex">
+                    Bank: <input type="text" id="instr-bank" style="width:44px;" placeholder="any">
+                    <button class="btn btn-success" onclick="Instrument.add()">+ Mark</button>
+                    <button class="btn btn-danger" onclick="Instrument.clear()">Clear</button>
+                    <span class="hint">counts how often the CPU passes each address</span>
+                </div>
+                <div style="max-height:180px;overflow-y:auto;">
+                    <table class="trace-table" id="instr-view"></table>
+                </div>
+            </div>
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>Value Scan (variable search)</h2>
+                <div class="tool-bar">
+                    Addr: <input type="text" id="scan-addr" value="0000" style="width:60px;">
+                    Size: <input type="number" id="scan-size" value="2048" min="1" max="8192" style="width:60px;">
+                    CPU: <input type="number" id="scan-cpu" value="0" min="0" style="width:40px;">
+                    <button class="btn btn-success" onclick="Scan.newScan()">New</button>
+                </div>
+                <div class="tool-bar">
+                    <button class="btn" onclick="Scan.filter('changed')">Changed</button>
+                    <button class="btn" onclick="Scan.filter('unchanged')">Same</button>
+                    <button class="btn" onclick="Scan.filter('inc')">&gt; prev</button>
+                    <button class="btn" onclick="Scan.filter('dec')">&lt; prev</button>
+                    = <input type="text" id="scan-val" style="width:44px;" placeholder="hex">
+                    <button class="btn" onclick="Scan.filter('eq')">Equals</button>
+                    <span id="scan-count" class="hint">no scan</span>
+                </div>
+                <div style="max-height:150px;overflow-y:auto;">
+                    <table class="trace-table" id="scan-view"></table>
+                </div>
+            </div>
+        </div>
+
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>Save States (RAM + CPU)</h2>
+                <div class="tool-bar">
+                    Slot: <input type="text" id="ss-slot" value="cp1" style="width:90px;">
+                    <button class="btn btn-success" onclick="SaveState.save()">Save</button>
+                    <button class="btn" onclick="SaveState.load()">Load</button>
+                    <button class="btn" onclick="SaveState.diff()" title="diff this slot's RAM against the live RAM">Diff vs live</button>
+                    <span class="hint">checkpoint of WPC RAM + main CPU registers</span>
+                </div>
+                <div id="ss-list"></div>
+                <div id="ss-diff" style="max-height:130px;overflow-y:auto;"></div>
+            </div>
+            <div class="panel" style="flex:1;min-width:320px;">
+                <h2>DMD Recorder</h2>
+                <div class="tool-bar">
+                    <button class="btn btn-success" id="dmdrec-toggle" onclick="DmdRec.toggle()">Record</button>
+                    <button class="btn" onclick="DmdRec.loadFrames()">Load frames</button>
+                    <button class="btn btn-danger" onclick="DmdRec.clear()">Clear</button>
+                    <span id="dmdrec-status" class="hint">idle</span>
+                </div>
+                <canvas id="dmdrec-canvas" style="background:#000;width:100%;image-rendering:pixelated;border:1px solid #444;"></canvas>
+                <div class="tool-bar">
+                    <button class="btn" onclick="DmdRec.playToggle()" id="dmdrec-play">&#9654; Play</button>
+                    <input type="range" id="dmdrec-scrub" min="0" max="0" value="0" style="flex:1;">
+                    <span id="dmdrec-frame" class="hint">0 / 0</span>
+                </div>
+            </div>
+        </div>
+
+        <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            <div class="panel" style="flex:1;min-width:300px;">
+                <h2>Execution Trace</h2>
+                <div class="tool-bar">
+                    <button class="btn btn-success" id="et-toggle" onclick="ExecTrace.toggle()">Record</button>
+                    <button class="btn" onclick="ExecTrace.load()">Load</button>
+                    <button class="btn btn-danger" onclick="ExecTrace.clear()">Clear</button>
+                    <span id="et-status" class="hint">idle</span>
+                </div>
+                <div style="max-height:170px;overflow-y:auto;">
+                    <table class="trace-table" id="et-view"></table>
+                </div>
+            </div>
+            <div class="panel" style="flex:1;min-width:300px;">
+                <h2>Code Coverage</h2>
+                <div class="tool-bar">
+                    <button class="btn btn-success" id="cov-toggle" onclick="Coverage.toggle()">Record</button>
+                    <button class="btn btn-danger" onclick="Coverage.clear()">Clear</button>
+                    <label class="hint"><input type="checkbox" id="cov-overlay"> mark executed in disassembler</label>
+                    <span id="cov-status" class="hint">idle</span>
+                </div>
+                <div class="hint">Executed addresses are highlighted green in the disassembler when the overlay is on.</div>
+            </div>
+            <div class="panel" style="flex:1;min-width:300px;">
+                <h2>Tracepoints (log &amp; continue)</h2>
+                <div class="tool-bar">
+                    Addr: <input type="text" id="tp-addr" style="width:60px;" placeholder="hex">
+                    Bank: <input type="text" id="tp-bank" style="width:44px;" placeholder="any">
+                    <button class="btn btn-success" onclick="Tracepoints.add()">+ TP</button>
+                    <button class="btn btn-danger" onclick="Tracepoints.clear()">Clear</button>
+                </div>
+                <div id="tp-points" class="hint"></div>
+                <div style="max-height:150px;overflow-y:auto;">
+                    <table class="trace-table" id="tp-view"></table>
+                </div>
+            </div>
+        </div>
+
+        <div class="panel">
+            <h2>Object Monitor &amp; Action Log</h2>
+            <div class="tool-bar">
+                <select id="mon-type">
+                    <option value="sw">Switch</option>
+                    <option value="lamp">Lamp</option>
+                    <option value="sol">Solenoid</option>
+                </select>
+                Num: <input type="text" id="mon-id" style="width:60px;" placeholder="e.g. 11">
+                <label class="hint"><input type="checkbox" id="mon-break"> break on change</label>
+                <button class="btn btn-success" onclick="Monitor.add()">+ Monitor</button>
+                <button class="btn btn-danger" onclick="Monitor.clear()">Clear monitors</button>
+                <button class="btn btn-danger" onclick="Monitor.clearLog()">Clear log</button>
+                <span id="mon-list" class="hint"></span>
+            </div>
+            <div style="max-height:180px;overflow-y:auto;">
+                <table class="trace-table" id="action-view"></table>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="toast-area"></div>
+
+<script>
+'use strict';
+
+/* ================= utilities ================= */
+
+const Fmt = {
+    /* parse "1A2B", "0x1A2B" or "$1A2B" to a number (NaN when invalid) */
+    parseHex(s) {
+        if (typeof s !== 'string') return NaN;
+        s = s.trim();
+        if (s.startsWith('$')) s = s.substring(1);
+        else if (s.toLowerCase().startsWith('0x')) s = s.substring(2);
+        if (!/^[0-9a-fA-F]+$/.test(s)) return NaN;
+        return parseInt(s, 16);
+    },
+    hex(v, pad) { return v.toString(16).toUpperCase().padStart(pad || 4, '0'); },
+};
+
+const Toast = {
+    show(msg, info) {
+        const div = document.createElement('div');
+        div.className = 'toast' + (info ? ' toast-info' : '');
+        div.textContent = msg;
+        document.getElementById('toast-area').appendChild(div);
+        setTimeout(() => div.remove(), 4000);
+    },
+};
+
+/* ================= API access ================= */
+
+const Api = {
+    failures: 0,
+
+    async get(path) {
+        try {
+            const r = await fetch(path);
+            let data = null;
+            const ct = r.headers.get('Content-Type') || '';
+            if (ct.includes('json')) data = await r.json();
+            if (!r.ok) {
+                const msg = (data && data.message) ? data.message : ('HTTP ' + r.status);
+                throw new Error(msg + ' (' + path.split('?')[0] + ')');
+            }
+            this.setOnline(true);
+            return data;
+        } catch (e) {
+            if (e instanceof TypeError) { /* network error */
+                this.setOnline(false);
+            } else {
+                Toast.show(e.message);
+            }
+            throw e;
+        }
+    },
+
+    async getRaw(path) {
+        const r = await fetch(path);
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        this.setOnline(true);
+        return r.arrayBuffer();
+    },
+
+    setOnline(ok) {
+        if (ok) this.failures = 0; else this.failures++;
+        const offline = this.failures >= 2;
+        document.getElementById('offline-banner').style.display = offline ? 'block' : 'none';
+        if (offline) {
+            const tag = document.getElementById('status-mode');
+            tag.textContent = 'OFFLINE';
+            tag.className = 'status-tag status-offline';
+            State.online = false;
+        } else {
+            State.online = true;
+        }
+    },
+};
+
+/* ================= shared state ================= */
+
+const State = {
+    online: false,
+    paused: false,
+    lastPC: 0,
+    wpcBank: -1,
+    dmd: { w: 128, h: 32 },
+    switchStates: new Array(64).fill(false),
+    dedicatedStates: new Array(8).fill(false),
+    sseConnected: false,
+};
+
+/* refresh everything that matters after a halt/step */
+function refreshAfterHalt() {
+    Status.refresh();
+    Cpu.refresh();
+    Points.refresh();
+    Log.refresh();
+    Watches.refresh();
+    Trace.refresh();
+    if (document.getElementById('mem-auto').checked) Mem.refresh(true);
+}
+
+/* ================= SSE events with polling fallback ================= */
+
+const Events = {
+    source: null,
+
+    start() {
+        if (!window.EventSource) return;
+        this.source = new EventSource('/api/events');
+        this.source.onopen = () => {
+            State.sseConnected = true;
+            document.getElementById('transport-tag').textContent = 'sse';
+        };
+        this.source.onerror = () => {
+            /* EventSource reconnects on its own; poll harder meanwhile */
+            State.sseConnected = false;
+            document.getElementById('transport-tag').textContent = 'poll';
+        };
+        this.source.onmessage = (m) => {
+            let ev;
+            try { ev = JSON.parse(m.data); } catch (e) { return; }
+            switch (ev.event) {
+                case 'halt':
+                case 'step':
+                    refreshAfterHalt();
+                    break;
+                case 'resume':
+                    Status.refresh();
+                    break;
+                case 'message':
+                    Log.refresh();
+                    break;
+                case 'action':
+                    Monitor.refresh();
+                    break;
+                case 'quit':
+                    Api.failures = 2;      /* show the offline banner immediately */
+                    Api.setOnline(false);
+                    break;
+                default:
+                    break;
+            }
+        };
+    },
+};
+
+/* ================= adaptive polling scheduler =================
+ * Polls faster while running (values change continuously), slower when
+ * paused with SSE connected (events drive the UI), and backs off while
+ * offline. */
+const Poll = {
+    loop(fn, delayFn) {
+        const tick = async () => {
+            try { await fn(); } catch (e) { /* already reported */ }
+            setTimeout(tick, delayFn());
+        };
+        tick();
+    },
+
+    start() {
+        this.loop(() => { Status.refresh(); Cpu.refresh(); },
+            () => !State.online ? 5000 : (State.paused ? (State.sseConnected ? 4000 : 1500) : 1000));
+        this.loop(() => { Log.refresh(); Points.refresh(); },
+            () => !State.online ? 8000 : (State.sseConnected ? 10000 : 2000));
+        this.loop(() => Dmd.refresh(),
+            () => !State.online ? 5000 : (State.paused ? 2000 : 500));
+        this.loop(() => { if (!State.paused) { Watches.refresh(); Trace.refresh(); } },
+            () => !State.online ? 10000 : 3000);
+    },
+};
+
+/* ================= header / status ================= */
+
+const Dbg = {
+    async control(cmd) {
+        await Api.get('/api/debugger/control?cmd=' + cmd);
+        Status.refresh();
+        if (cmd === 'step') refreshAfterHalt();
+    },
+    async pulseSw(sw, val) {
+        await Api.get(`/api/input?sw=${sw}&val=${val}`);
+        Status.refresh();
+    },
+    /* cabinet button press: timed pulse if pulse-ms > 0, else set level */
+    async press(sw) {
+        const ms = parseInt(document.getElementById('pulse-ms').value, 10) || 0;
+        if (ms > 0) await Api.get(`/api/input?sw=${sw}&val=1&pulse=${ms}`);
+        else await Api.get(`/api/input?sw=${sw}&val=1`);
+        Status.refresh();
+    },
+    async release(sw) {
+        const ms = parseInt(document.getElementById('pulse-ms').value, 10) || 0;
+        if (ms === 0) { await Api.get(`/api/input?sw=${sw}&val=0`); Status.refresh(); }
+    },
+    async nvramClear() {
+        if (!confirm('Wipe NVRAM and reset the machine?')) return;
+        await Api.get('/api/debugger/nvram?cmd=clear');
+        Toast.show('NVRAM cleared', true);
+    },
+    async nvramDownload() {
+        try {
+            const buf = await Api.getRaw('/api/debugger/nvram/dump');
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(new Blob([buf], { type: 'application/octet-stream' }));
+            a.download = 'nvram.bin';
+            a.click();
+            URL.revokeObjectURL(a.href);
+        } catch (e) { Toast.show('NVRAM dump failed: ' + e.message); }
+    },
+    exitEmulator() {
+        if (!confirm('Exit the emulator?')) return;
+        fetch('/api/debugger/control?cmd=exit').catch(() => {});
+        document.body.innerHTML = '<h1 style="margin:40px;font-family:sans-serif;color:#ccc;">Emulator terminated.</h1>';
+    },
+};
+
+const Status = {
+    async refresh() {
+        const data = await Api.get('/api/info');
+        document.getElementById('game-title').textContent = data.game + ' — ' + data.description;
+        document.getElementById('wpc-bank').textContent = data.wpc_bank === -1 ? 'N/A' : '0x' + Fmt.hex(data.wpc_bank, 2);
+        State.wpcBank = data.wpc_bank;
+        State.paused = !!data.paused;
+        const tag = document.getElementById('status-mode');
+        tag.textContent = State.paused ? 'PAUSED' : 'RUNNING';
+        tag.className = 'status-tag ' + (State.paused ? 'status-paused' : 'status-running');
+
+        /* alphanumeric games show the segment display instead of the DMD */
+        if (data.segments && data.segments.replace(/0/g, '') !== '') {
+            document.getElementById('seg-container').style.display = 'block';
+            document.getElementById('dmd-container').style.display = 'none';
+            Segments.render(data.segments);
+        } else {
+            document.getElementById('seg-container').style.display = 'none';
+            document.getElementById('dmd-container').style.display = 'block';
+        }
+        Matrix.update(data);
+    },
+};
+
+/* ================= object names (switches) + custom labels ================= */
+
+const Names = {
+    sw: {},   /* num -> standard WPC name */
+    custom: JSON.parse(localStorage.getItem('pinmame-labels') || '{}'),
+
+    async load() {
+        try {
+            const data = await Api.get('/api/switches');
+            data.switches.forEach((s) => { if (s.name) this.sw['s' + s.num] = s.name; });
+        } catch (e) { /* offline; retry later */ }
+        Cabinet.build();
+    },
+
+    label(num) {
+        const c = this.custom['s' + num];
+        const std = this.sw['s' + num];
+        if (c && std) return `${c} (${std})`;
+        return c || std || '';
+    },
+
+    setCustom(num) {
+        const cur = this.custom['s' + num] || '';
+        const v = prompt(`Custom label for switch ${num}:`, cur);
+        if (v === null) return;
+        if (v) this.custom['s' + num] = v; else delete this.custom['s' + num];
+        localStorage.setItem('pinmame-labels', JSON.stringify(this.custom));
+        Matrix.relabel();
+    },
+};
+
+/* ================= cabinet / service buttons ================= */
+
+const Cabinet = {
+    /* build service buttons from switches that carry a standard name */
+    build() {
+        const wanted = ['Coin 1', 'Coin 2', 'Start', 'Enter', 'Up', 'Down', 'Escape', 'Coin Door', 'Tilt', 'Slam Tilt'];
+        const byName = {};
+        Object.keys(Names.sw).forEach((k) => { byName[Names.sw[k]] = parseInt(k.substring(1), 10); });
+        const box = document.getElementById('cabinet-buttons');
+        box.innerHTML = '';
+        wanted.forEach((name) => {
+            const num = byName[name];
+            if (num === undefined) return;
+            const b = document.createElement('button');
+            b.className = 'btn btn-cabinet';
+            b.style.width = 'auto';
+            if (name === 'Start') b.style.background = '#0e639c';
+            b.textContent = name;
+            b.title = 'switch ' + num;
+            b.onmousedown = () => Dbg.press(num);
+            b.onmouseup = () => Dbg.release(num);
+            box.appendChild(b);
+        });
+    },
+};
+
+/* ================= matrices ================= */
+
+const Matrix = {
+    init() {
+        const l = document.getElementById('matrix-lamps');
+        const s = document.getElementById('matrix-sw');
+        const sl = document.getElementById('matrix-sol');
+        const dd = document.getElementById('matrix-ded');
+        for (let i = 0; i < 64; i++) {
+            l.innerHTML += `<div id="lamp-${i}" class="matrix-dot" title="lamp ${Math.floor(i / 8) * 10 + i % 8 + 11}"></div>`;
+            s.innerHTML += `<div id="sw-${i}" class="matrix-dot sw-clickable" onclick="Matrix.swClick(event,${i})"></div>`;
+        }
+        for (let i = 0; i < 32; i++)
+            sl.innerHTML += `<div id="sol-${i}" class="matrix-dot" title="solenoid ${i + 1}"></div>`;
+        for (let i = 0; i < 8; i++)
+            dd.innerHTML += `<div id="ded-${i}" class="matrix-dot sw-clickable" onclick="Matrix.toggleSwitch(${i},true)"></div>`;
+    },
+
+    swNumber(idx) {
+        const col = Math.floor(idx / 8), row = idx % 8;
+        return col === 0 ? row + 1 : col * 10 + row + 1;
+    },
+
+    /* left click toggles the switch; Shift+click assigns a custom label */
+    swClick(ev, idx) {
+        if (ev.shiftKey) { Names.setCustom(this.swNumber(idx)); return; }
+        this.toggleSwitch(idx, false);
+    },
+
+    async toggleSwitch(idx, dedicated) {
+        const cur = dedicated ? State.dedicatedStates[idx] : State.switchStates[idx];
+        const swNum = dedicated ? idx + 1 : this.swNumber(idx);
+        await Api.get(`/api/input?sw=${swNum}&val=${cur ? 0 : 1}`);
+        Status.refresh();
+    },
+
+    swTitle(num) {
+        const label = Names.label(num);
+        return 'switch ' + num + (label ? ' — ' + label : '') + ' (Shift+click to label)';
+    },
+
+    relabel() {
+        for (let i = 0; i < 64; i++)
+            document.getElementById(`sw-${i}`).title = this.swTitle(this.swNumber(i));
+    },
+
+    update(data) {
+        for (let i = 0; i < 64; i++) {
+            const col = Math.floor(i / 8), bit = i % 8;
+            const swActive = parseInt(data.switches.substr(col * 2, 2), 16) & (1 << bit);
+            const lampActive = parseInt(data.lamps.substr(col * 2, 2), 16) & (1 << bit);
+            State.switchStates[i] = !!swActive;
+            document.getElementById(`lamp-${i}`).className = 'matrix-dot' + (lampActive ? ' active-lamp' : '');
+            const sw = document.getElementById(`sw-${i}`);
+            sw.className = 'matrix-dot sw-clickable' + (swActive ? ' active-sw' : '');
+            sw.title = this.swTitle(this.swNumber(i));
+        }
+        for (let i = 0; i < 32; i++)
+            document.getElementById(`sol-${i}`).className = 'matrix-dot' + ((data.solenoids & (1 << i)) ? ' active-sol' : '');
+        for (let i = 0; i < 8; i++) {
+            const active = data.dedicated & (1 << i);
+            State.dedicatedStates[i] = !!active;
+            document.getElementById(`ded-${i}`).className = 'matrix-dot sw-clickable' + (active ? ' active-sw' : '');
+        }
+    },
+};
+
+/* ================= DMD / segments ================= */
+
+const Dmd = {
+    async refresh() {
+        if (document.getElementById('dmd-container').style.display === 'none') return;
+        if (!document.getElementById('auto-refresh-dmd').checked) return;
+        const info = await Api.get('/api/dmd/info').catch(() => null);
+        if (!info || info.status === 'error') return;
+        State.dmd.w = info.width;
+        State.dmd.h = info.height;
+        document.getElementById('dmd-res').textContent = `${info.width}x${info.height}`;
+        const buf = await Api.getRaw('/api/dmd/raw').catch(() => null);
+        if (!buf) return;
+        const canvas = document.getElementById('dmd-canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = State.dmd.w;
+        canvas.height = State.dmd.h;
+        const img = ctx.createImageData(State.dmd.w, State.dmd.h);
+        const bytes = new Uint8Array(buf);
+        for (let i = 0; i < bytes.length; i++) {
+            const o = i * 4;
+            img.data[o] = 255; img.data[o + 1] = 150; img.data[o + 2] = 0;
+            img.data[o + 3] = bytes[i];
+        }
+        ctx.putImageData(img, 0, 0);
+    },
+};
+
+/* Authoritative Williams 16-segment pixel maps, decoded from PinMAME's
+ * core segment table (segSize1C[0], the 20x15 anti-aliased glyph grid).
+ * SEG_BITS[bit] holds SEG_ROWS row masks; column c of a row is lit when
+ * (mask >> c) & 1. Rendering the actual footprint guarantees the display
+ * matches PinMAME exactly, including all 16 segments, comma and period. */
+const SEG_COLS = 15, SEG_ROWS = 20;
+const SEG_BITS = [
+    [4094, 1980, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 1, 1, 3, 3, 3, 3, 3, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 6, 6, 6, 6, 6, 4, 4, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7920, 16376, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 8192, 8192, 24576, 24576, 24576, 24576, 24576, 16384, 16384, 0, 0],
+    [0, 4096, 4096, 12288, 12288, 12288, 12288, 12288, 8192, 8192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 7680, 8064, 7680, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 2],
+    [0, 2048, 2048, 1024, 1024, 512, 512, 256, 256, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 64, 64, 192, 192, 192, 192, 192, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 2, 4, 8, 8, 16, 32, 32, 64, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 60, 252, 60, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 64, 64, 32, 32, 16, 16, 8, 8, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 128, 384, 384, 384, 384, 384, 256, 256, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 256, 512, 512, 1024, 2048, 2048, 4096, 8192, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 0],
+];
+
+const Segments = {
+    PIX: 2,          /* pixel size */
+    GAP: 6,          /* gap between characters */
+    ROWGAP: 10,      /* gap between the two display rows */
+
+    /* Precompute the OR of all bit maps once so unlit segments can be shown
+     * faintly (like a real display's ghost segments). */
+    _allMask: null,
+    all() {
+        if (this._allMask) return this._allMask;
+        const m = new Array(SEG_ROWS).fill(0);
+        for (let b = 0; b < 16; b++)
+            for (let r = 0; r < SEG_ROWS; r++) m[r] |= SEG_BITS[b][r];
+        this._allMask = m;
+        return m;
+    },
+
+    drawGrid(ctx, ox, oy, mask, color) {
+        ctx.fillStyle = color;
+        for (let r = 0; r < SEG_ROWS; r++) {
+            const bits = mask[r];
+            if (!bits) continue;
+            /* PinMAME blits the glyph LSB-first from the right edge (see
+             * drawChar in core.c: *(--line) starting at col+cols), so the
+             * decoded bit c maps to screen column (SEG_COLS-1-c). */
+            for (let c = 0; c < SEG_COLS; c++)
+                if ((bits >> c) & 1)
+                    ctx.fillRect(ox + (SEG_COLS - 1 - c) * this.PIX, oy + r * this.PIX, this.PIX, this.PIX);
+        }
+    },
+
+    render(hex) {
+        const canvas = document.getElementById('seg-canvas');
+        const ctx = canvas.getContext('2d');
+        const cw = SEG_COLS * this.PIX + this.GAP;
+        const ch = SEG_ROWS * this.PIX;
+        canvas.width = 16 * cw + 8;
+        canvas.height = 2 * ch + this.ROWGAP + 8;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        const off = this.all();
+        for (let i = 0; i < 32; i++) {
+            const val = parseInt(hex.substr(i * 4, 4), 16);
+            if (isNaN(val)) continue;
+            const ox = (i % 16) * cw + 4;
+            const oy = Math.floor(i / 16) * (ch + this.ROWGAP) + 4;
+            /* dim ghost of every segment, then the lit ones on top */
+            this.drawGrid(ctx, ox, oy, off, '#3a0f0a');
+            const lit = new Array(SEG_ROWS).fill(0);
+            for (let b = 0; b < 16; b++)
+                if (val & (1 << b))
+                    for (let r = 0; r < SEG_ROWS; r++) lit[r] |= SEG_BITS[b][r];
+            this.drawGrid(ctx, ox, oy, lit, '#ff5030');
+        }
+    },
+};
+
+/* ================= CPU registers ================= */
+
+const Cpu = {
+    async refresh() {
+        const data = await Api.get('/api/debugger/state');
+        if (!data.cpus) return;
+        const container = document.getElementById('cpu-panels-container');
+        container.innerHTML = '';
+        data.cpus.forEach((cpu) => {
+            if (cpu.id === 0 && State.lastPC !== cpu.pc) {
+                State.lastPC = cpu.pc;
+                if (State.paused && document.getElementById('dasm-follow').checked) {
+                    Dasm.followPC();
+                    Stack.refresh();
+                }
+            }
+            const panel = document.createElement('div');
+            panel.className = 'panel';
+            panel.style.margin = '5px 10px';
+            const isM6809 = cpu.a !== undefined;
+            let html = `<h2>CPU ${cpu.id} (${isM6809 ? 'M6809' : 'ADSP'})</h2><div class="reg-grid">`;
+            /* show the currently paged ROM bank next to PC (WPC main CPU) */
+            if (isM6809 && cpu.id === 0 && State.wpcBank !== undefined && State.wpcBank !== -1) {
+                const inWindow = cpu.pc >= 0x4000 && cpu.pc < 0x8000;
+                html += `<div class="reg-item" style="border-left-color:#dcaa4f;" ` +
+                        `title="currently paged ROM bank (0x4000-0x7FFF window)${inWindow ? '' : ' — PC is not in the banked window'}">` +
+                        `<span class="reg-label">BANK</span>` +
+                        `<div><span class="reg-val" style="color:${inWindow ? '#dcaa4f' : '#858585'};">` +
+                        `${Fmt.hex(State.wpcBank, 2)}</span></div></div>`;
+            }
+            for (const [reg, val] of Object.entries(cpu)) {
+                if (reg === 'id' || reg === 'type') continue;
+                html += `<div class="reg-item"><span class="reg-label">${reg.toUpperCase()}</span>` +
+                        `<div><span class="reg-val" title="click to edit" ` +
+                        `onclick="Cpu.editReg(${cpu.id},'${reg}',${val})">${Fmt.hex(val, 2)}</span>` +
+                        `<span class="reg-dec">${val}</span></div></div>`;
+            }
+            html += '</div>';
+            if (cpu.cc !== undefined) {
+                const flags = ['C', 'V', 'Z', 'N', 'I', 'H', 'F', 'E'];
+                html += '<div class="flags-grid">' + flags
+                    .map((f, i) => `<div class="flag ${(cpu.cc & (1 << i)) ? 'active' : ''}">${f}</div>`)
+                    .reverse().join('') + '</div>';
+            }
+            panel.innerHTML = html;
+            container.appendChild(panel);
+        });
+    },
+
+    async editReg(cpuId, reg, current) {
+        const v = prompt(`Set ${reg.toUpperCase()} (hex):`, Fmt.hex(current, 2));
+        if (v === null) return;
+        const num = Fmt.parseHex(v);
+        if (isNaN(num)) { Toast.show('Invalid hex value'); return; }
+        const name = (reg === 'sp') ? 'SP' : reg.toUpperCase();
+        await Api.get(`/api/debugger/state/write?cpu=${cpuId}&reg=${name}&val=${num.toString(16)}`);
+        this.refresh();
+    },
+};
+
+/* ================= disassembler ================= */
+
+const Dasm = {
+    async refresh() {
+        const addr = Fmt.parseHex(document.getElementById('dasm-addr').value);
+        if (isNaN(addr)) { Toast.show('Disassembler: invalid address'); return; }
+        const cpu = document.getElementById('dasm-cpu').value || 0;
+        const bankStr = document.getElementById('dasm-bank').value.trim();
+        let url = `/api/debugger/dasm?addr=${addr.toString(16)}&lines=24&before=6&cpu=${cpu}`;
+        if (bankStr) {
+            const bank = Fmt.parseHex(bankStr);
+            if (isNaN(bank)) { Toast.show('Disassembler: invalid bank'); return; }
+            url += `&bank=${bank.toString(16)}`;
+        }
+        const data = await Api.get(url);
+        const table = document.getElementById('dasm-view');
+        table.innerHTML = '';
+        if (!data.lines) return;
+        /* pull coverage flags for this window if the overlay is enabled */
+        if (data.lines.length) {
+            const first = parseInt(data.lines[0].addr);
+            const last = parseInt(data.lines[data.lines.length - 1].addr);
+            await Coverage.loadWindow(first, Math.max(1, last - first + 4), data.bank === -1 ? undefined : data.bank);
+        }
+        data.lines.forEach((line) => {
+            const row = table.insertRow();
+            row.className = 'dasm-row';
+            const a = parseInt(line.addr);
+            if (Coverage.covered(a)) row.style.background = '#12351a';
+            if (a === State.lastPC && (data.bank === -1 || data.bank === State.wpcBank))
+                row.classList.add('current-pc');
+            const c1 = row.insertCell();
+            c1.className = 'addr-col';
+            c1.textContent = Fmt.hex(a, 4);
+            row.insertCell().textContent = line.text;
+            row.title = 'click: use as breakpoint address';
+            row.onclick = () => {
+                document.getElementById('bp-addr').value = Fmt.hex(a, 4);
+                document.getElementById('bp-bank').value = data.bank === -1 ? '' : Fmt.hex(data.bank, 2);
+            };
+        });
+    },
+
+    followPC() {
+        document.getElementById('dasm-addr').value = Fmt.hex(State.lastPC, 4);
+        document.getElementById('dasm-bank').value = '';
+        this.refresh();
+    },
+};
+
+/* ================= callstack ================= */
+
+const Stack = {
+    async refresh() {
+        const data = await Api.get('/api/debugger/callstack');
+        const view = document.getElementById('callstack-view');
+        view.innerHTML = '';
+        if (!data.stack) return;
+        [...data.stack].reverse().forEach((e) => {
+            const div = document.createElement('div');
+            div.className = 'stack-item';
+            div.textContent = `${Fmt.hex(e.caller, 4)} → ${Fmt.hex(e.receiver, 4)}  (ret ${Fmt.hex(e.pc, 4)}, bank ${Fmt.hex(e.bank, 2)})`;
+            div.title = `A=${Fmt.hex(e.a, 2)} B=${Fmt.hex(e.b, 2)} X=${Fmt.hex(e.x, 4)} Y=${Fmt.hex(e.y, 4)} U=${Fmt.hex(e.u, 4)} S=${Fmt.hex(e.s, 4)}`;
+            div.onclick = () => {
+                document.getElementById('dasm-addr').value = Fmt.hex(e.receiver, 4);
+                document.getElementById('dasm-bank').value = Fmt.hex(e.bank, 2);
+                Dasm.refresh();
+            };
+            view.appendChild(div);
+        });
+    },
+};
+
+/* ================= message log ================= */
+
+const Log = {
+    lastCount: -1,
+    async refresh() {
+        const data = await Api.get('/api/debugger/messages');
+        if (data.messages.length === this.lastCount) return;
+        this.lastCount = data.messages.length;
+        const log = document.getElementById('console-log');
+        log.innerHTML = '';
+        data.messages.forEach((m) => {
+            const div = document.createElement('div');
+            div.className = 'console-line';
+            div.textContent = '> ' + m;
+            log.appendChild(div);
+        });
+        log.scrollTop = log.scrollHeight;
+    },
+};
+
+/* ================= break-/watchpoints ================= */
+
+const Points = {
+    async refresh() {
+        const data = await Api.get('/api/debugger/points');
+        const list = document.getElementById('point-list');
+        list.innerHTML = '';
+        data.breakpoints.forEach((p) => {
+            if (p.temp) return; /* temporary run-to/step points are internal */
+            const meta = [];
+            if (p.cond) meta.push(p.cond);
+            if (p.ignore) meta.push('ign ' + p.ignore);
+            meta.push('hits ' + p.hits);
+            const label = (p.bank !== -1 ? `BP ${Fmt.hex(p.bank, 2)}:` : 'BP ') + Fmt.hex(p.addr, 4);
+            this.row(list, 'bp', p.idx, label, p.enabled, meta.join(' | '));
+        });
+        data.watchpoints.forEach((p) => {
+            const bankPrefix = (p.bank !== undefined && p.bank !== -1) ? `${Fmt.hex(p.bank, 2)}:` : '';
+            const label = `WP(${['', 'R', 'W', 'RW'][p.mode]}) ${bankPrefix}${Fmt.hex(p.addr, 4)}` + (p.len > 1 ? `+${p.len}` : '');
+            this.row(list, 'wp', p.idx, label, p.enabled, p.cond ? 'if ' + p.cond : '');
+        });
+    },
+
+    row(container, type, idx, label, enabled, meta) {
+        const div = document.createElement('div');
+        div.className = 'point-item';
+        div.innerHTML =
+            `<span class="${enabled ? '' : 'point-disabled'}">${label}` +
+            (meta ? `<span class="point-meta">${meta}</span>` : '') + '</span>' +
+            `<div><button class="btn" onclick="Points.action('toggle','${type}',${idx})">${enabled ? 'Off' : 'On'}</button>` +
+            `<button class="btn btn-danger" onclick="Points.action('delete','${type}',${idx})">X</button></div>`;
+        container.appendChild(div);
+    },
+
+    async action(cmd, type, idx) {
+        await Api.get(`/api/debugger/points?cmd=${cmd}&type=${type}&idx=${idx}`);
+        this.refresh();
+    },
+
+    async add(type) {
+        if (type === 'bp') {
+            const addr = Fmt.parseHex(document.getElementById('bp-addr').value);
+            if (isNaN(addr)) { Toast.show('Breakpoint: invalid address'); return; }
+            let url = `/api/debugger/breakpoints?cmd=add&addr=${addr.toString(16)}`;
+            const bankStr = document.getElementById('bp-bank').value.trim();
+            if (bankStr) {
+                const bank = Fmt.parseHex(bankStr);
+                if (isNaN(bank)) { Toast.show('Breakpoint: invalid bank'); return; }
+                url += `&bank=${bank.toString(16)}`;
+            }
+            const cond = document.getElementById('bp-cond').value.trim();
+            if (cond) url += '&cond=' + encodeURIComponent(cond);
+            const ign = document.getElementById('bp-ignore').value.trim();
+            if (ign) url += '&ignore=' + parseInt(ign, 10);
+            await Api.get(url);
+        } else {
+            const addr = Fmt.parseHex(document.getElementById('wp-addr').value);
+            if (isNaN(addr)) { Toast.show('Watchpoint: invalid address'); return; }
+            const len = parseInt(document.getElementById('wp-len').value, 10) || 1;
+            const mode = document.getElementById('wp-mode').value;
+            let url = `/api/debugger/watchpoints?cmd=add&addr=${addr.toString(16)}&len=${len}&mode=${mode}`;
+            const bankStr = document.getElementById('wp-bank').value.trim();
+            if (bankStr) {
+                const bank = Fmt.parseHex(bankStr);
+                if (isNaN(bank)) { Toast.show('Watchpoint: invalid bank'); return; }
+                url += `&bank=${bank.toString(16)}`;
+            }
+            const cond = document.getElementById('wp-cond').value;
+            if (cond) {
+                const v = Fmt.parseHex(document.getElementById('wp-val').value);
+                if (isNaN(v)) { Toast.show('Watchpoint: condition needs a hex value'); return; }
+                url += `&cond=${cond}&val=${v.toString(16)}`;
+            }
+            await Api.get(url);
+        }
+        this.refresh();
+        Log.refresh();
+    },
+};
+
+/* ================= memory hex editor ================= */
+
+const Mem = {
+    lastAddr: -1,
+    lastData: null,
+    searchPos: -1,
+
+    async refresh(keepDiff) {
+        const addr = Fmt.parseHex(document.getElementById('mem-addr').value);
+        if (isNaN(addr)) { Toast.show('Memory: invalid address'); return; }
+        const size = parseInt(document.getElementById('mem-size').value, 10) || 256;
+        const cpu = document.getElementById('mem-cpu').value || 0;
+        let url = `/api/debugger/memory?addr=${addr.toString(16)}&size=${size}&cpu=${cpu}`;
+        const bankStr = document.getElementById('mem-bank').value.trim();
+        if (bankStr) {
+            const bank = Fmt.parseHex(bankStr);
+            if (isNaN(bank)) { Toast.show('Memory: invalid bank'); return; }
+            url += `&bank=${bank.toString(16)}`;
+        }
+        const data = await Api.get(url);
+        if (!data.data) return;
+        const prev = (keepDiff && this.lastAddr === data.addr) ? this.lastData : null;
+        this.lastAddr = data.addr;
+        this.lastData = data.data;
+        this.render(data, prev, cpu);
+    },
+
+    render(data, prev, cpu) {
+        const table = document.getElementById('hex-view');
+        table.innerHTML = '';
+        let row = null, ascii = '';
+        data.data.forEach((byte, i) => {
+            if (i % 16 === 0) {
+                if (row) { const c = row.insertCell(); c.className = 'hex-ascii'; c.textContent = ascii; }
+                row = table.insertRow();
+                ascii = '';
+                const aCell = row.insertCell();
+                aCell.className = 'addr-col';
+                aCell.textContent = Fmt.hex(data.addr + i, 4);
+            }
+            const c = row.insertCell();
+            c.className = 'hex-byte';
+            if (prev && prev[i] !== undefined && prev[i] !== byte) c.classList.add('hex-changed');
+            c.textContent = Fmt.hex(byte, 2);
+            c.title = '0x' + Fmt.hex(data.addr + i, 4);
+            c.onclick = () => this.editByte(c, data.addr + i, byte, cpu);
+            ascii += (byte >= 32 && byte <= 126) ? String.fromCharCode(byte) : '.';
+        });
+        if (row) {
+            while (row.cells.length < 17) row.insertCell();
+            row.cells[16].className = 'hex-ascii';
+            row.cells[16].textContent = ascii;
+        }
+    },
+
+    /* inline single-byte editor: Enter commits, Escape cancels */
+    editByte(cell, addr, oldVal, cpu) {
+        if (cell.querySelector('input')) return;
+        const input = document.createElement('input');
+        input.className = 'hex-edit';
+        input.maxLength = 2;
+        input.value = Fmt.hex(oldVal, 2);
+        cell.textContent = '';
+        cell.appendChild(input);
+        input.focus();
+        input.select();
+        const done = (commit) => {
+            if (commit) {
+                const v = Fmt.parseHex(input.value);
+                if (isNaN(v) || v > 255) { Toast.show('Invalid byte value'); }
+                else {
+                    Api.get(`/api/debugger/memory/write?addr=${addr.toString(16)}&val=${v.toString(16)}&cpu=${cpu}`)
+                        .then(() => this.refresh(true));
+                    return;
+                }
+            }
+            cell.textContent = Fmt.hex(oldVal, 2);
+        };
+        input.onkeydown = (e) => {
+            if (e.key === 'Enter') done(true);
+            else if (e.key === 'Escape') done(false);
+            e.stopPropagation();
+        };
+        input.onblur = () => done(false);
+    },
+
+    page(dir) {
+        const addr = Fmt.parseHex(document.getElementById('mem-addr').value) || 0;
+        const size = parseInt(document.getElementById('mem-size').value, 10) || 256;
+        const next = Math.max(0, addr + dir * size);
+        document.getElementById('mem-addr').value = Fmt.hex(next, 4);
+        this.refresh();
+    },
+
+    nvramView() {
+        document.getElementById('mem-addr').value = '0000';
+        document.getElementById('mem-size').value = 512;
+        document.getElementById('mem-cpu').value = 0;
+        this.refresh();
+    },
+
+    async search(fromAddr) {
+        const pat = document.getElementById('search-pat').value.trim();
+        if (!pat) return;
+        const start = fromAddr !== undefined ? fromAddr : (Fmt.parseHex(document.getElementById('mem-addr').value) || 0);
+        const cpu = document.getElementById('mem-cpu').value || 0;
+        const data = await Api.get(
+            `/api/debugger/memory/find?addr=${start.toString(16)}&size=32768&pattern=${pat}&cpu=${cpu}`);
+        if (data.status === 'ok') {
+            this.searchPos = data.found;
+            const hexAddr = Fmt.hex(data.found, 4);
+            document.getElementById('mem-addr').value = hexAddr;
+            document.getElementById('dasm-addr').value = hexAddr;
+            this.refresh();
+            Dasm.refresh();
+            Toast.show('Pattern found at 0x' + hexAddr, true);
+        } else {
+            Toast.show('Pattern not found');
+        }
+    },
+
+    searchNext() {
+        if (this.searchPos >= 0) this.search(this.searchPos + 1);
+        else this.search();
+    },
+};
+
+/* ================= watches ================= */
+
+const Watches = {
+    items: JSON.parse(localStorage.getItem('pinmame-watches') || '[]'),
+
+    persist() { localStorage.setItem('pinmame-watches', JSON.stringify(this.items)); },
+
+    add() {
+        const addr = Fmt.parseHex(document.getElementById('watch-addr').value);
+        if (isNaN(addr)) { Toast.show('Watch: invalid address'); return; }
+        const len = Math.min(16, Math.max(1, parseInt(document.getElementById('watch-len').value, 10) || 1));
+        this.items.push({ addr, len });
+        this.persist();
+        this.refresh();
+    },
+
+    remove(i) {
+        this.items.splice(i, 1);
+        this.persist();
+        this.refresh();
+    },
+
+    async refresh() {
+        const list = document.getElementById('watch-list');
+        if (!this.items.length) { list.innerHTML = '<div class="hint">no watches</div>'; return; }
+        const parts = await Promise.all(this.items.map((w) =>
+            Api.get(`/api/debugger/memory?addr=${w.addr.toString(16)}&size=${w.len}`).catch(() => null)));
+        list.innerHTML = '';
+        this.items.forEach((w, i) => {
+            const div = document.createElement('div');
+            div.className = 'watch-item';
+            const bytes = parts[i] && parts[i].data ? parts[i].data.map((b) => Fmt.hex(b, 2)).join(' ') : '??';
+            div.innerHTML = `<span>0x${Fmt.hex(w.addr, 4)}+${w.len}</span><span style="color:#dcdcaa;">${bytes}</span>` +
+                `<button class="btn btn-danger" onclick="Watches.remove(${i})">X</button>`;
+            list.appendChild(div);
+        });
+    },
+};
+
+/* ================= memory trace ================= */
+
+const Trace = {
+    async add() {
+        const addr = Fmt.parseHex(document.getElementById('trace-addr').value);
+        if (isNaN(addr)) { Toast.show('Trace: invalid address'); return; }
+        let url = `/api/debugger/trace?cmd=add&addr=${addr.toString(16)}`;
+        const bankStr = document.getElementById('trace-bank').value.trim();
+        if (bankStr) {
+            const bank = Fmt.parseHex(bankStr);
+            if (isNaN(bank)) { Toast.show('Trace: invalid bank'); return; }
+            url += `&bank=${bank.toString(16)}`;
+        }
+        await Api.get(url);
+        this.refresh();
+    },
+
+    async clear() {
+        await Api.get('/api/debugger/trace?cmd=clear');
+        this.refresh();
+    },
+
+    async refresh() {
+        const data = await Api.get('/api/debugger/trace');
+        document.getElementById('trace-watched').textContent =
+            data.watched.length
+                ? 'traced: ' + data.watched.map((w) => (w.bank !== -1 ? Fmt.hex(w.bank, 2) + ':' : '') + Fmt.hex(w.addr, 4)).join(', ')
+                : 'no traced addresses';
+        const table = document.getElementById('trace-view');
+        table.innerHTML = '<tr><th>CPU</th><th>PC</th><th>Bank</th><th>Access</th><th>Addr</th><th>Len</th></tr>';
+        [...data.logs].reverse().slice(0, 200).forEach((e) => {
+            const row = table.insertRow();
+            row.insertCell().textContent = e.cpu;
+            const pcCell = row.insertCell();
+            pcCell.textContent = Fmt.hex(e.pc, 4);
+            pcCell.style.color = '#9cdcfe';
+            row.insertCell().textContent = e.bank === -1 ? '-' : Fmt.hex(e.bank, 2);
+            row.insertCell().textContent = e.write ? 'W' : 'R';
+            row.insertCell().textContent = Fmt.hex(e.adr, 4);
+            row.insertCell().textContent = e.len;
+        });
+    },
+};
+
+/* ================= code instrumentation ================= */
+
+const Instrument = {
+    async add() {
+        const addr = Fmt.parseHex(document.getElementById('instr-addr').value);
+        if (isNaN(addr)) { Toast.show('Instrument: invalid address'); return; }
+        let url = `/api/debugger/instrument?cmd=add&addr=${addr.toString(16)}`;
+        const bankStr = document.getElementById('instr-bank').value.trim();
+        if (bankStr) {
+            const bank = Fmt.parseHex(bankStr);
+            if (isNaN(bank)) { Toast.show('Instrument: invalid bank'); return; }
+            url += `&bank=${bank.toString(16)}`;
+        }
+        await Api.get(url);
+        this.refresh();
+    },
+    async clear() { await Api.get('/api/debugger/instrument?cmd=clear'); this.refresh(); },
+    async refresh() {
+        const data = await Api.get('/api/debugger/instrument').catch(() => null);
+        if (!data) return;
+        const table = document.getElementById('instr-view');
+        table.innerHTML = '<tr><th>Addr</th><th>Bank</th><th>Hits</th></tr>';
+        data.points.forEach((p) => {
+            const row = table.insertRow();
+            const a = row.insertCell();
+            a.textContent = Fmt.hex(p.addr, 4);
+            a.style.color = '#9cdcfe';
+            a.style.cursor = 'pointer';
+            a.onclick = () => { document.getElementById('dasm-addr').value = Fmt.hex(p.addr, 4); Dasm.refresh(); };
+            row.insertCell().textContent = p.bank === -1 ? 'any' : Fmt.hex(p.bank, 2);
+            row.insertCell().textContent = p.count;
+        });
+    },
+};
+
+/* ================= value scan ================= */
+
+const Scan = {
+    async newScan() {
+        const addr = Fmt.parseHex(document.getElementById('scan-addr').value);
+        if (isNaN(addr)) { Toast.show('Scan: invalid address'); return; }
+        const size = parseInt(document.getElementById('scan-size').value, 10) || 2048;
+        const cpu = document.getElementById('scan-cpu').value || 0;
+        const data = await Api.get(`/api/debugger/scan?cmd=new&addr=${addr.toString(16)}&size=${size}&cpu=${cpu}`);
+        this.render(data);
+    },
+    async filter(op) {
+        let url = `/api/debugger/scan?cmd=filter&op=${op}`;
+        if (op === 'eq') {
+            const v = Fmt.parseHex(document.getElementById('scan-val').value);
+            if (isNaN(v)) { Toast.show('Scan: invalid value'); return; }
+            url += `&val=${v.toString(16)}`;
+        }
+        const data = await Api.get(url);
+        this.render(data);
+    },
+    render(data) {
+        document.getElementById('scan-count').textContent = data.count + ' candidates';
+        const table = document.getElementById('scan-view');
+        table.innerHTML = '<tr><th>Addr</th><th>Value</th></tr>';
+        data.results.forEach((r) => {
+            const row = table.insertRow();
+            const a = row.insertCell();
+            a.textContent = Fmt.hex(r.addr, 4);
+            a.style.color = '#9cdcfe';
+            a.style.cursor = 'pointer';
+            a.onclick = () => { document.getElementById('mem-addr').value = Fmt.hex(r.addr, 4); Mem.refresh(); };
+            row.insertCell().textContent = Fmt.hex(r.val, 2) + ' (' + r.val + ')';
+        });
+    },
+};
+
+/* ================= object monitor & action log ================= */
+
+const Monitor = {
+    async add() {
+        const type = document.getElementById('mon-type').value;
+        const id = parseInt(document.getElementById('mon-id').value, 10);
+        if (isNaN(id)) { Toast.show('Monitor: invalid number'); return; }
+        const brk = document.getElementById('mon-break').checked ? '&break=1' : '';
+        await Api.get(`/api/monitor?cmd=add&type=${type}&id=${id}${brk}`);
+        this.refresh();
+    },
+    async clear() { await Api.get('/api/monitor?cmd=clear'); this.refresh(); },
+    async clearLog() { await Api.get('/api/monitor/log?cmd=clear'); this.refresh(); },
+    async refresh() {
+        const mon = await Api.get('/api/monitor').catch(() => null);
+        if (mon) {
+            document.getElementById('mon-list').textContent =
+                mon.monitors.length ? 'monitoring: ' + mon.monitors.map((m) => `${m.type}${m.id}`).join(', ') : 'nothing monitored';
+        }
+        const log = await Api.get('/api/monitor/log').catch(() => null);
+        if (!log) return;
+        const table = document.getElementById('action-view');
+        table.innerHTML = '<tr><th>Time</th><th>Object</th><th>&rarr;</th></tr>';
+        [...log.actions].reverse().slice(0, 200).forEach((a) => {
+            const row = table.insertRow();
+            row.insertCell().textContent = (a.t / 1000).toFixed(3) + 's';
+            const o = row.insertCell();
+            let label = `${a.type} ${a.id}`;
+            if (a.type === 'switch') { const l = Names.label(a.id); if (l) label += ' (' + l + ')'; }
+            o.textContent = label;
+            const v = row.insertCell();
+            v.textContent = a.val ? 'ON' : 'off';
+            v.style.color = a.val ? '#4ec94e' : '#888';
+        });
+    },
+};
+
+/* ================= save states ================= */
+
+const SaveState = {
+    async save() {
+        const slot = document.getElementById('ss-slot').value.trim();
+        if (!slot) { Toast.show('Save state: enter a slot name'); return; }
+        await Api.get(`/api/debugger/savestate?cmd=save&slot=${encodeURIComponent(slot)}`);
+        Toast.show(`Saved slot '${slot}'`, true);
+        this.refresh();
+    },
+    async load() {
+        const slot = document.getElementById('ss-slot').value.trim();
+        if (!slot) return;
+        await Api.get(`/api/debugger/savestate?cmd=load&slot=${encodeURIComponent(slot)}`);
+        Toast.show(`Loaded slot '${slot}'`, true);
+        refreshAfterHalt();
+    },
+    async del(slot) {
+        await Api.get(`/api/debugger/savestate?cmd=delete&slot=${encodeURIComponent(slot)}`);
+        this.refresh();
+    },
+    async diff() {
+        const slot = document.getElementById('ss-slot').value.trim();
+        if (!slot) { Toast.show('Save state: enter a slot name'); return; }
+        const d = await Api.get(`/api/debugger/savestate/diff?a=${encodeURIComponent(slot)}`);
+        const box = document.getElementById('ss-diff');
+        if (d.count < 0) { box.innerHTML = '<div class="hint">slot not found</div>'; return; }
+        box.innerHTML = `<div class="hint">${d.count} RAM bytes changed since '${slot}' (showing ${d.diffs.length}):</div>` +
+            '<table class="trace-table"><tr><th>Addr</th><th>saved</th><th>&rarr; live</th></tr>' +
+            d.diffs.map((x) =>
+                `<tr><td style="color:#9cdcfe;cursor:pointer" onclick="document.getElementById('mem-addr').value='${Fmt.hex(x.addr, 4)}';Mem.refresh()">${Fmt.hex(x.addr, 4)}</td>` +
+                `<td>${Fmt.hex(x.a, 2)}</td><td>${Fmt.hex(x.b, 2)}</td></tr>`).join('') + '</table>';
+    },
+    async refresh() {
+        const data = await Api.get('/api/debugger/savestate').catch(() => null);
+        if (!data) return;
+        const list = document.getElementById('ss-list');
+        if (!data.slots.length) { list.innerHTML = '<div class="hint">no saved states</div>'; return; }
+        list.innerHTML = '';
+        data.slots.forEach((s) => {
+            const div = document.createElement('div');
+            div.className = 'point-item';
+            div.innerHTML = `<span>${s.name} <span class="point-meta">PC ${Fmt.hex(s.pc, 4)}</span></span>` +
+                `<div><button class="btn" onclick="document.getElementById('ss-slot').value='${s.name}';SaveState.load()">Load</button>` +
+                `<button class="btn btn-danger" onclick="SaveState.del('${s.name}')">X</button></div>`;
+            list.appendChild(div);
+        });
+    },
+};
+
+/* ================= DMD recorder ================= */
+
+const DmdRec = {
+    frames: [],   /* {t, pixels: Uint8Array} */
+    w: 0, h: 0,
+    pos: 0,
+    playing: false,
+    timer: null,
+
+    async toggle() {
+        const info = await Api.get('/api/debugger/dmdrec').catch(() => null);
+        if (!info) return;
+        if (info.recording) await Api.get('/api/debugger/dmdrec?cmd=stop');
+        else await Api.get('/api/debugger/dmdrec?cmd=start');
+        this.refresh();
+    },
+    async clear() {
+        await Api.get('/api/debugger/dmdrec?cmd=clear');
+        this.frames = [];
+        this.pos = 0;
+        this.draw();
+        this.refresh();
+    },
+    async refresh() {
+        const info = await Api.get('/api/debugger/dmdrec').catch(() => null);
+        if (!info) return;
+        document.getElementById('dmdrec-toggle').textContent = info.recording ? '■ Stop' : '● Record';
+        document.getElementById('dmdrec-toggle').className = 'btn ' + (info.recording ? 'btn-danger' : 'btn-success');
+        document.getElementById('dmdrec-status').textContent =
+            `${info.recording ? 'recording' : 'idle'} — ${info.count} frames buffered (${info.width}x${info.height})`;
+    },
+    async loadFrames() {
+        const buf = await Api.getRaw('/api/debugger/dmdrec/data').catch(() => null);
+        if (!buf) { Toast.show('No frames recorded'); return; }
+        const dv = new DataView(buf);
+        const count = dv.getUint32(0, true);
+        this.w = dv.getUint32(4, true);
+        this.h = dv.getUint32(8, true);
+        const fsize = this.w * this.h;
+        this.frames = [];
+        let off = 12;
+        for (let i = 0; i < count; i++) {
+            const t = dv.getUint32(off, true); off += 4;
+            this.frames.push({ t, pixels: new Uint8Array(buf, off, fsize) });
+            off += fsize;
+        }
+        this.pos = 0;
+        const scrub = document.getElementById('dmdrec-scrub');
+        scrub.max = Math.max(0, count - 1);
+        scrub.value = 0;
+        scrub.oninput = () => { this.pos = parseInt(scrub.value, 10); this.draw(); };
+        Toast.show(`Loaded ${count} frames`, true);
+        this.draw();
+    },
+    draw() {
+        const canvas = document.getElementById('dmdrec-canvas');
+        const ctx = canvas.getContext('2d');
+        if (!this.frames.length) { canvas.width = 128; canvas.height = 32; ctx.clearRect(0, 0, 128, 32); return; }
+        canvas.width = this.w;
+        canvas.height = this.h;
+        const f = this.frames[this.pos];
+        const img = ctx.createImageData(this.w, this.h);
+        for (let i = 0; i < f.pixels.length; i++) {
+            const o = i * 4;
+            img.data[o] = 255; img.data[o + 1] = 150; img.data[o + 2] = 0;
+            img.data[o + 3] = f.pixels[i];
+        }
+        ctx.putImageData(img, 0, 0);
+        document.getElementById('dmdrec-frame').textContent =
+            `${this.pos + 1} / ${this.frames.length}  (+${((f.t - this.frames[0].t) / 1000).toFixed(2)}s)`;
+        document.getElementById('dmdrec-scrub').value = this.pos;
+    },
+    playToggle() {
+        if (this.playing) { clearInterval(this.timer); this.playing = false; document.getElementById('dmdrec-play').innerHTML = '▶ Play'; return; }
+        if (!this.frames.length) return;
+        this.playing = true;
+        document.getElementById('dmdrec-play').innerHTML = '❙❙ Pause';
+        this.timer = setInterval(() => {
+            this.pos = (this.pos + 1) % this.frames.length;
+            this.draw();
+        }, 50);
+    },
+};
+
+/* ================= execution trace ================= */
+
+const ExecTrace = {
+    async toggle() {
+        const d = await Api.get('/api/debugger/exectrace').catch(() => null);
+        if (!d) return;
+        await Api.get('/api/debugger/exectrace?cmd=' + (d.enabled ? 'stop' : 'start'));
+        this.refreshStatus();
+    },
+    async clear() { await Api.get('/api/debugger/exectrace?cmd=clear'); this.load(); },
+    async refreshStatus() {
+        const d = await Api.get('/api/debugger/exectrace').catch(() => null);
+        if (!d) return;
+        const btn = document.getElementById('et-toggle');
+        btn.textContent = d.enabled ? '■ Stop' : '● Record';
+        btn.className = 'btn ' + (d.enabled ? 'btn-danger' : 'btn-success');
+        document.getElementById('et-status').textContent = `${d.enabled ? 'recording' : 'idle'} — ${d.count} instr buffered`;
+    },
+    async load() {
+        const d = await Api.get('/api/debugger/exectrace');
+        this.refreshStatus();
+        const table = document.getElementById('et-view');
+        table.innerHTML = '<tr><th>#</th><th>Bank</th><th>PC</th><th>A</th><th>B</th><th>X</th></tr>';
+        /* newest last; show the most recent 300 */
+        const rows = d.trace.slice(-300);
+        rows.forEach((e, i) => {
+            const row = table.insertRow();
+            row.insertCell().textContent = d.trace.length - rows.length + i;
+            row.insertCell().textContent = e.bank === -1 ? '-' : Fmt.hex(e.bank, 2);
+            const pc = row.insertCell();
+            pc.textContent = Fmt.hex(e.pc, 4);
+            pc.style.color = '#9cdcfe';
+            pc.style.cursor = 'pointer';
+            pc.onclick = () => { document.getElementById('dasm-addr').value = Fmt.hex(e.pc, 4); Dasm.refresh(); };
+            row.insertCell().textContent = Fmt.hex(e.a, 2);
+            row.insertCell().textContent = Fmt.hex(e.b, 2);
+            row.insertCell().textContent = Fmt.hex(e.x, 4);
+        });
+        table.scrollTop = table.scrollHeight;
+    },
+};
+
+/* ================= code coverage ================= */
+
+const Coverage = {
+    executedMap: {},   /* addr(hex string) -> executed, for the current dasm window */
+
+    async toggle() {
+        const d = await Api.get('/api/debugger/coverage').catch(() => null);
+        if (!d) return;
+        await Api.get('/api/debugger/coverage?cmd=' + (d.enabled ? 'stop' : 'start'));
+        this.refresh();
+    },
+    async clear() { await Api.get('/api/debugger/coverage?cmd=clear'); this.refresh(); Dasm.refresh(); },
+    async refresh() {
+        const d = await Api.get('/api/debugger/coverage').catch(() => null);
+        if (!d) return;
+        const btn = document.getElementById('cov-toggle');
+        btn.textContent = d.enabled ? '■ Stop' : '● Record';
+        btn.className = 'btn ' + (d.enabled ? 'btn-danger' : 'btn-success');
+        document.getElementById('cov-status').textContent = `${d.enabled ? 'recording' : 'idle'} — ${d.executed} addresses executed`;
+    },
+    overlayOn() { return document.getElementById('cov-overlay').checked; },
+    /* fetch executed flags for a dasm window and index by address */
+    async loadWindow(addr, size, bank) {
+        this.executedMap = {};
+        if (!this.overlayOn()) return;
+        let url = `/api/debugger/coverage?addr=${addr.toString(16)}&size=${size}`;
+        if (bank !== undefined && bank !== null && !isNaN(bank)) url += `&bank=${bank.toString(16)}`;
+        const d = await Api.get(url).catch(() => null);
+        if (!d || !d.executed) return;
+        d.executed.forEach((v, i) => { if (v) this.executedMap[addr + i] = 1; });
+    },
+    covered(a) { return this.executedMap[a] === 1; },
+};
+
+/* ================= tracepoints ================= */
+
+const Tracepoints = {
+    async add() {
+        const addr = Fmt.parseHex(document.getElementById('tp-addr').value);
+        if (isNaN(addr)) { Toast.show('Tracepoint: invalid address'); return; }
+        let url = `/api/debugger/tracepoints?cmd=add&addr=${addr.toString(16)}`;
+        const bankStr = document.getElementById('tp-bank').value.trim();
+        if (bankStr) {
+            const bank = Fmt.parseHex(bankStr);
+            if (isNaN(bank)) { Toast.show('Tracepoint: invalid bank'); return; }
+            url += `&bank=${bank.toString(16)}`;
+        }
+        await Api.get(url);
+        this.refresh();
+    },
+    async clear() { await Api.get('/api/debugger/tracepoints?cmd=clear'); this.refresh(); },
+    async refresh() {
+        const d = await Api.get('/api/debugger/tracepoints').catch(() => null);
+        if (!d) return;
+        document.getElementById('tp-points').textContent = d.points.length
+            ? 'points: ' + d.points.map((p) => (p.bank !== -1 ? Fmt.hex(p.bank, 2) + ':' : '') + Fmt.hex(p.addr, 4) + ' (' + p.hits + ')').join(', ')
+            : 'no tracepoints';
+        const table = document.getElementById('tp-view');
+        table.innerHTML = '<tr><th>Bank</th><th>PC</th><th>A</th><th>B</th><th>X</th><th>Y</th><th>U</th><th>S</th><th>CC</th></tr>';
+        [...d.log].reverse().slice(0, 200).forEach((t) => {
+            const row = table.insertRow();
+            row.insertCell().textContent = t.bank === -1 ? '-' : Fmt.hex(t.bank, 2);
+            const pc = row.insertCell();
+            pc.textContent = Fmt.hex(t.pc, 4);
+            pc.style.color = '#9cdcfe';
+            row.insertCell().textContent = Fmt.hex(t.a, 2);
+            row.insertCell().textContent = Fmt.hex(t.b, 2);
+            row.insertCell().textContent = Fmt.hex(t.x, 4);
+            row.insertCell().textContent = Fmt.hex(t.y, 4);
+            row.insertCell().textContent = Fmt.hex(t.u, 4);
+            row.insertCell().textContent = Fmt.hex(t.s, 4);
+            row.insertCell().textContent = Fmt.hex(t.cc, 2);
+        });
+    },
+};
+
+/* ================= classic CLI ================= */
+
+const Cli = {
+    async run() {
+        const inp = document.getElementById('cli-cmd');
+        if (!inp.value) return;
+        await Api.get('/api/debugger/command?cmd=' + encodeURIComponent(inp.value));
+        inp.value = '';
+        refreshAfterHalt();
+        Dasm.refresh();
+    },
+};
+
+/* ================= keyboard shortcuts ================= */
+
+document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+    switch (e.key) {
+        case 'F8':
+            Dbg.control(State.paused ? 'resume' : 'pause');
+            break;
+        case 'F10':
+            Dbg.control('stepover');
+            break;
+        case 'F11':
+            Dbg.control(e.shiftKey ? 'stepout' : 'step');
+            break;
+        default:
+            return;
+    }
+    e.preventDefault();
+});
+
+document.getElementById('cli-cmd').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') Cli.run();
+});
+
+/* ================= boot ================= */
+
+Matrix.init();
+Names.load();
+Events.start();
+Poll.start();
+Status.refresh();
+Cpu.refresh();
+Mem.refresh();
+Dasm.refresh();
+Points.refresh();
+Watches.refresh();
+Trace.refresh();
+Instrument.refresh();
+Monitor.refresh();
+SaveState.refresh();
+DmdRec.refresh();
+ExecTrace.refreshStatus();
+Coverage.refresh();
+Tracepoints.refresh();
+
+/* fold the new panels into the adaptive polling cadence */
+Poll.loop(() => { Instrument.refresh(); Monitor.refresh(); DmdRec.refresh(); },
+    () => !State.online ? 8000 : (State.paused ? 4000 : 1500));
+Poll.loop(() => { ExecTrace.refreshStatus(); Coverage.refresh(); Tracepoints.refresh(); },
+    () => !State.online ? 8000 : (State.paused ? 3000 : 2000));
+</script>
+</body>
+</html>

--- a/src/unix/Makefile
+++ b/src/unix/Makefile
@@ -119,7 +119,7 @@ $(MY_TARGET): $(OBJS)
 	$(CC_COMPILE) $(RANLIB) $@
 
 $(OBJDIRS):
-	-mkdir $@
+	-mkdir -p $@
 
 $(OBJDIR)/%.o: %.c xmame.h
 	$(CC_COMMENT) @echo 'Compiling src/unix/$< ...'

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -96,6 +96,12 @@ struct rc_option pinmame_opts[] = {
 #ifdef PINMAME_HOST_UART
 	{ "serial_device", NULL, rc_string, &pmoptions.serial_device, NULL, 0, 0, NULL, "/dev/tty serial port mapped to WPC UART" },
 #endif
+#ifdef REMOTE_DEBUG
+	{ "Remote Debugging options", NULL, rc_seperator, NULL, NULL, 0, 0, NULL, NULL },
+	{ "headless", "hl", rc_bool, &pmoptions.headless, "0", 0, 0, NULL, "Headless mode (no display)" },
+	{ "httpport", "hp", rc_int, &pmoptions.http_port, "8080", 1024, 65535, NULL, "HTTP server port" },
+	{ "startpaused", "sp", rc_bool, &pmoptions.start_paused, "0", 0, 0, NULL, "Start emulator in paused state" },
+#endif
 	{ NULL,	NULL, rc_end, NULL, NULL, 0, 0,	NULL, NULL }
 };
 #endif /* PINMAME */

--- a/src/unix/main.c
+++ b/src/unix/main.c
@@ -73,6 +73,21 @@ int main(int argc, char **argv)
 #endif
 
 
+#ifdef REMOTE_DEBUG
+	/* Remote debugger: parse configuration file and environment first so
+	   that pmoptions.headless is known before any display setup happens.
+	   Without REMOTE_DEBUG the original startup order is preserved. */
+	if ((res = config_init(argc, argv)) != 1234)
+		return res;
+
+	if (pmoptions.headless) {
+		options.skip_disclaimer = 1;
+		options.skip_gameinfo = 1;
+		res2 = OSD_OK;
+	}
+	else
+#endif
+	{
 	/* some display methods need to do some stuff with root rights */
 	res2 = sysdep_init();
 
@@ -84,20 +99,35 @@ int main(int argc, char **argv)
 		sysdep_close();
 		return OSD_NOT_OK;
 	}
+	}
 
 	/* Set the title, now auto build from defines from the makefile */
+#ifdef REMOTE_DEBUG
+	if (pmoptions.headless)
+		snprintf(title, sizeof(title), "%s (HEADLESS) version %s", NAME, build_version);
+	else
+#endif
 	snprintf(title, sizeof(title), "%s (%s) version %s", NAME, DISPLAY_METHOD, build_version);
 
 	/* parse configuration file and environment */
+#ifdef REMOTE_DEBUG
+	/* (already parsed above) */
+	if (res2 == OSD_NOT_OK)
+		goto leave;
+#else
 	if ((res = config_init(argc, argv)) != 1234 || res2 == OSD_NOT_OK)
 		goto leave;
+#endif
 
 	/* Check the colordepth we're requesting */
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless)
+#endif
 	if (!options.color_depth && !sysdep_display_16bpp_capable())
 		options.color_depth = 8;
 
-	/* 
-	 * Initialize whatever is needed before the display is actually 
+	/*
+	 * Initialize whatever is needed before the display is actually
 	 * opened, e.g., artwork setup.
 	 */
 	osd_video_initpre();

--- a/src/unix/unix.mak
+++ b/src/unix/unix.mak
@@ -322,6 +322,16 @@ ifdef EFENCE
 MY_LIBS += -lefence
 endif
 
+ifdef REMOTE_DEBUG
+CORE_OBJDIRS += $(OBJ)/remote_debug
+
+src/remote_debug/ui_html.h: src/remote_debug/ui.html
+	$(CC_COMMENT) @echo 'Compiling HTML $< ... $@'
+	xxd -i src/remote_debug/ui.html > src/remote_debug/ui_html.h
+
+$(OBJ)/remote_debug/api_handler.o: src/remote_debug/ui_html.h
+endif
+
 OBJS += $(COREOBJS) $(DRVLIBS) $(OBJ)/unix.$(DISPLAY_METHOD)/osdepend.a
 
 MY_OBJDIRS = $(CORE_OBJDIRS) $(sort $(OBJDIRS))
@@ -338,7 +348,7 @@ tools: $(ZLIB) $(OBJDIRS) $(TOOLS)
 objdirs: $(MY_OBJDIRS)
 
 $(MY_OBJDIRS):
-	-mkdir $@
+	-mkdir -p $@
 
 xlistdev: src/unix/contrib/tools/xlistdev.c
 	$(CC_COMMENT) @echo 'Compiling $< ...'
@@ -496,7 +506,7 @@ copycab:
 	for j in $$i/*; do $(INSTALL_DATA) $$j $(XMAMEROOT)/$$i; done; done
 
 clean: 
-	rm -fr $(OBJ) $(NAME).* xlistdev src/unix/contrib/cutzlib-1.1.4/libz.a src/unix/contrib/cutzlib-1.1.4/*.o $(TOOLS)
+	rm -fr $(OBJ) $(NAME).* xlistdev src/unix/contrib/cutzlib-1.1.4/libz.a src/unix/contrib/cutzlib-1.1.4/*.o $(TOOLS) src/remote_debug/ui_html.h
 #	cd makedep; make clean
 
 clean68k:

--- a/src/unix/video.c
+++ b/src/unix/video.c
@@ -361,6 +361,16 @@ int osd_create_display(const struct osd_create_params *params,
 {
 	int r, g, b;
 
+#ifdef REMOTE_DEBUG
+	if (pmoptions.headless) {
+		memset(&display_palette_info, 0, sizeof(struct sysdep_palette_info));
+		display_palette_info.depth = 32;
+		display_palette_info.red_mask   = 0x00FF0000;
+		display_palette_info.green_mask = 0x0000FF00;
+		display_palette_info.blue_mask  = 0x000000FF;
+	}
+#endif
+
 	bitmap_depth = (params->depth == 15) ? 16 : params->depth;
 	using_15bpp_rgb_direct = (params->depth == 15);
 
@@ -419,8 +429,14 @@ int osd_create_display(const struct osd_create_params *params,
 	use_aspect_ratio	= normal_use_aspect_ratio;
 	video_fps		= params->fps;
 
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless) {
+#endif
 	if (sysdep_create_display(bitmap_depth) != OSD_OK)
 		return -1;
+#ifdef REMOTE_DEBUG
+	}
+#endif
 
 #if 0 /* DEBUG */
 	fprintf(stderr_file, "viswidth = %d, visheight = %d, visstartx= %d,"
@@ -430,8 +446,14 @@ int osd_create_display(const struct osd_create_params *params,
 
 	/* a lot of display_targets need to have the display initialised before
 	   initialising any input devices */
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless) {
+#endif
 	if (osd_input_initpost() != OSD_OK)
 		return -1;
+#ifdef REMOTE_DEBUG
+	}
+#endif
 
 	if (bitmap_depth == 16)
 		fprintf(stderr_file,"Using 16bpp video mode\n");
@@ -440,11 +462,17 @@ int osd_create_display(const struct osd_create_params *params,
 		return 1;
 
 	/* alloc the total number of colors that can be used by the palette */
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless) {
+#endif
 	if (sysdep_display_alloc_palette(65536))
 	{
 		osd_free_colors();
 		return 1;
 	}
+#ifdef REMOTE_DEBUG
+	}
+#endif
 
 	/* initialize the palette to a fixed 5-5-5 mapping */
 	if (using_15bpp_rgb_direct)
@@ -517,6 +545,10 @@ static void osd_change_display_settings(struct rectangle *new_visual,
 		struct sysdep_palette_struct *new_palette, int new_widthscale,
 		int new_heightscale, int new_use_aspect_ratio)
 {
+#ifdef REMOTE_DEBUG
+	/* fprintf(stderr, "osd_change_display_settings: headless=%d\n", pmoptions.headless); */
+	if (pmoptions.headless) return;
+#endif
 	int new_visual_width, new_visual_height;
 
 	/* always update the visual info */
@@ -743,9 +775,17 @@ void change_debugger_focus(int new_debugger_focus)
 	}
 }
 
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#endif
+
 /* Update the display. */
 void osd_update_video_and_audio(struct mame_display *display)
 {
+#ifdef REMOTE_DEBUG
+	remote_debug_frame_update(display);
+	if (pmoptions.headless) return;
+#endif
 	int skip_this_frame;
 	cycles_t curr;
 
@@ -947,8 +987,14 @@ void osd_update_video_and_audio(struct mame_display *display)
 
 	/* if the LEDs have changed, update them */
 	if (display->changed_flags & LED_STATE_CHANGED)
+#ifdef REMOTE_DEBUG
+		if (!pmoptions.headless)
+#endif
 		sysdep_set_leds(display->led_state);
 
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless)
+#endif
 	osd_poll_joysticks();
 }
 
@@ -958,6 +1004,9 @@ void adjust_bitmap_and_update_display(struct mame_bitmap *srcbitmap,
 {
 	orient_rect(&bounds);
 
+#ifdef REMOTE_DEBUG
+	if (!pmoptions.headless)
+#endif
 	sysdep_update_display(srcbitmap);
 }
 #endif

--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -14,6 +14,9 @@
 #include <math.h>
 #include "ui_text.h"
 #include "state.h"
+#ifdef REMOTE_DEBUG
+#include "remote_debug/remote_debug.h"
+#endif
 
 #if defined(PINMAME) && defined(PROC_SUPPORT)
 #include "p-roc/p-roc.h"
@@ -2295,6 +2298,9 @@ int showcopyright(struct mame_bitmap *bitmap)
 
 	do
 	{
+#ifdef REMOTE_DEBUG
+		if (remote_debug_should_quit()) return 1;
+#endif
 		erase_screen(bitmap);
 		ui_drawbox(bitmap,0,0,uirotwidth,uirotheight);
 		ui_displaymessagewindow(bitmap,buf);
@@ -2608,6 +2614,9 @@ int showgamewarnings(struct mame_bitmap *bitmap)
 		done = 0;
 		do
 		{
+#ifdef REMOTE_DEBUG
+			if (remote_debug_should_quit()) return 1;
+#endif
 			erase_screen(bitmap);
 			ui_drawbox(bitmap,0,0,uirotwidth,uirotheight);
 			ui_displaymessagewindow(bitmap,buf);
@@ -2638,6 +2647,9 @@ int showgameinfo(struct mame_bitmap *bitmap)
 
 	while (displaygameinfo(bitmap,0) == 1)
 	{
+#ifdef REMOTE_DEBUG
+		if (remote_debug_should_quit()) return 1;
+#endif
 		update_video_and_audio();
 	}
 
@@ -3739,6 +3751,10 @@ void ui_display_fps(struct mame_bitmap *bitmap)
 
 int handle_user_interface(struct mame_bitmap *bitmap)
 {
+#ifdef REMOTE_DEBUG
+	if (remote_debug_should_quit())
+		return 1;
+#endif
 	/* if the user pressed F12, save the screen to a file */
 	if (input_ui_pressed(IPT_UI_SNAPSHOT))
 		save_screen_snapshot(bitmap);

--- a/src/wpc/core.c
+++ b/src/wpc/core.c
@@ -3948,6 +3948,21 @@ void core_sound_throttle_adj(int sIn, int *sOut, int buffersize, double samplera
    }
 }
 
+#ifdef REMOTE_DEBUG
+void core_get_dmd_data(int layout_idx, float **pixels, int *width, int *height) {
+  if (layout_idx >= 0 && layout_idx < 16 && locals.dmdStates[layout_idx]) {
+    unsigned int lumFrameId;
+    *pixels = core_dmd_update_pwm(locals.dmdStates[layout_idx]->layout, &lumFrameId);
+    *width = locals.dmdStates[layout_idx]->width;
+    *height = locals.dmdStates[layout_idx]->height;
+  } else {
+    *pixels = NULL;
+    *width = 0;
+    *height = 0;
+  }
+}
+#endif
+
 /*----------------------------------------------
 /  Add a timer when building the machine driver
 /-----------------------------------------------*/

--- a/src/wpc/wpc.c
+++ b/src/wpc/wpc.c
@@ -356,6 +356,12 @@ void wpc_set_fastflip_addr(int addr)
   }
 #endif
 
+#ifdef REMOTE_DEBUG
+int wpc_get_bank(void) {
+  return wpc_data ? wpc_data[WPC_ROMBANK] : -1;
+}
+#endif
+
 /*-----------------
 /  Machine drivers
 /------------------*/


### PR DESCRIPTION
## Summary

This adds a self-contained **HTTP remote debugger** for PinMAME under
`src/remote_debug/`: a small pthread-based HTTP/1.1 server exposing a REST +
Server-Sent-Events API plus a single-file web dashboard. It targets
**headless operation and reverse engineering** — driving and inspecting a
running machine over HTTP, with no X11 display.

It is **opt-in and off by default**: nothing changes unless you build with
`REMOTE_DEBUG=1`. A normal build is byte-for-byte unaffected (verified: the
default binary contains zero `remote_debug` symbols).

## Why

Debugging/RE of WPC (and other M6809) games is much easier with programmatic
access: scriptable breakpoints, memory search, live lamp/switch/solenoid
state, DMD/segment capture, coverage, tracing, etc. Doing this over a clean
HTTP API (and a browser UI) works headless, is language-agnostic, and is
convenient for CI and automation.

## Design: minimally invasive

The feature lives almost entirely in its own `src/remote_debug/` folder.
Every change to existing sources is wrapped in `#ifdef REMOTE_DEBUG` (or
expands to nothing via empty macros), so with the feature off the code is
identical to upstream. The integration surface is ~340 lines across 20 files:

- `cpuexec.c` — pause/step/quit polling + a lock around `cpu_timeslice`
- `mamedbg.h` — route `CALL_MAME_DEBUG` through the per-instruction hook
- `memory.c` — a memory-access hook in the READ/WRITE macros (empty macro
  when off) for watchpoints/trace
- `cpu/m6809` — `DEBUG_PUSH_CALL/POP_CALL` macros for callstack tracking
  (no-ops when off)
- `mame.c` / `usrintrf.c` — init/exit + quit checks
- `wpc/core.c`, `wpc/wpc.c` — `core_get_dmd_data()` and `wpc_get_bank()`
- `driver.h` — three `tPMoptions` fields (headless, http_port, start_paused)
- `unix/{main,config,video}.c` — headless mode (run without an X11 display)

Build: `makefile.unix` gains a commented-out `REMOTE_DEBUG = 1` switch;
`pinmame.mak`/`unix.mak` compile the three objects and generate `ui_html.h`
from `ui.html` via `xxd`, only under `REMOTE_DEBUG`. The debugger objects
build cleanly with `-Wall -Wextra -pedantic`.

## What it provides

Run control (pause/resume/step in/over/out, run-to); bank-aware and
conditional breakpoints; ranged watchpoints with an optional value
condition; memory read/write/fill/find and a cheat-engine style value scan;
bank-aware disassembly and callstack; register access; switch/lamp/solenoid
inspection and injection (incl. timed pulses); object monitoring with an
action log and optional break-on-change; code instrumentation, execution
trace, code coverage and tracepoints; in-memory save-state checkpoints and
diff; DMD/segment/screenshot capture and a DMD recorder; NVRAM dump/clear.
Events are pushed over SSE; the web UI falls back to polling.

Full API reference and usage examples: `src/remote_debug/README.md`
(also served live at `/api/doc`).

## How to build & try

```sh
make -f makefile.unix REMOTE_DEBUG=1 DEBUG=1
./xpinmamed.x11 -headless -startpaused -httpport 8926 -nosound <rom>
# then open http://localhost:8926/ui
```

`DEBUG=1` is needed because the disassembly endpoint uses the built-in MAME
disassembler.

## Testing

`src/remote_debug/` includes verification scripts run against a real game
(`taf_l7`): `test_suite.sh` (full API suite, exercises every endpoint),
`test_breakpoint.sh`, and RE examples `re_demo.sh` and `find_nvram_coins.sh`.

## Scope / limitations

- **Unix-only** for now: the server uses pthreads/POSIX and is wired into the
  Unix (`src/unix`) build. Other platforms are unaffected (the feature is
  guarded off).
- Developed and verified on **Williams WPC**; most of it is platform-generic
  (it hooks the shared per-instruction/memory/core-state paths), with a few
  WPC-specific bits (bank features, NVRAM dump, save states) that degrade
  gracefully elsewhere. The callstack uses the M6809 core. See the
  "Platform Support" section in `src/remote_debug/README.md`.

## Notes for reviewers

- Off by default; no change to existing build defaults.
- New files carry the `// license:BSD-3-Clause` header.
- Happy to split, adjust, or gate things further based on your preferences.


<img width="1623" height="1682" alt="grafik" src="https://github.com/user-attachments/assets/8a0fd893-58d3-4804-a055-fb0e6d13f9c5" />
