### PR TITLE
i8085: fix RIM/SIM, the EI delay, TRAP re-arming and callback loss

### DIFF
--- a/src/cpu/i8085/i8085.c
+++ b/src/cpu/i8085/i8085.c
@@ -211,6 +211,8 @@ typedef struct {
 	INT8	filler; /* align on dword boundary */
 	int 	(*irq_callback)(int);
 	void	(*sod_callback)(int state);
+	int 	(*sid_callback)(void);
+	UINT8	after_ei;	/* EI takes effect one instruction late - see below */
 }	i8085_Regs;
 
 int i8085_ICount = 0;
@@ -219,6 +221,41 @@ static i8085_Regs I;
 static UINT8 ZS[256];
 static UINT8 ZSP[256];
 static UINT8 RIM_IEN = 0; //AT: IEN status latch used by the RIM instruction
+
+/* Build the value RIM returns. The 8085 RIM byte is:
+ *   bit 0-2  RST5.5/6.5/7.5 interrupt masks
+ *   bit 3    IE (interrupt enable)
+ *   bit 4-6  RST5.5/6.5/7.5 pending flags
+ *   bit 7    SID (serial input data pin)
+ * I.IM only holds the masks and IE in the right places; the pending flags live
+ * in I.IREQ and SID has to be sampled from the driver at the moment RIM runs.
+ * The old code returned I.IM raw, which put IM_TRAP where the RST5.5 pending
+ * flag belongs and IM_SOD where RST7.5 pending belongs, and never reported SID
+ * unless a driver had pushed it in with i8085_set_SID().
+ */
+#define RIM_I55 0x10
+#define RIM_I65 0x20
+#define RIM_I75 0x40
+
+static UINT8 i8085_get_RIM(void)
+{
+	UINT8 result = I.IM & (IM_M55 | IM_M65 | IM_M75 | IM_IE);
+
+	if( I.IREQ & IM_M55 ) result |= RIM_I55;
+	if( I.IREQ & IM_M65 ) result |= RIM_I65;
+	if( I.IREQ & IM_M75 ) result |= RIM_I75;
+
+	/* Prefer a live read through the pull callback; fall back to whatever a
+	   driver last pushed in via i8085_set_SID(). */
+	if( I.sid_callback )
+	{
+		if( (*I.sid_callback)() ) result |= IM_SID;
+	}
+	else if( I.IM & IM_SID )
+		result |= IM_SID;
+
+	return result;
+}
 static UINT8 ROP(void)
 {
 	return cpu_readop(I.PC.w.l++);
@@ -378,9 +415,9 @@ INLINE void execute_one(int opcode)
 			break;
 
 		case 0x20:
-			if( I.cputype ) { //!! misses fixes from newer MAME
+			if( I.cputype ) {
 						/* RIM	*/
-				I.AF.b.h = I.IM;
+				I.AF.b.h = i8085_get_RIM();
 				I.AF.b.h |= RIM_IEN; RIM_IEN = 0; //AT: read and clear IEN status latch
 /*				survival_prot ^= 0x01; */
 			} else {
@@ -456,7 +493,7 @@ INLINE void execute_one(int opcode)
 			if( I.cputype ) { I.AF.b.l |= VF; }
 			break;
 
-		case 0x30: //!! misses new port from MAME
+		case 0x30:
 			if( I.cputype ) {
 						/* SIM	*/
 				if (I.AF.b.h & 0x40) //SOE - only when bit 0x40 is set!
@@ -472,6 +509,22 @@ INLINE void execute_one(int opcode)
 				// overwrite RST5.5-7.5 interrupt masks only when bit 0x08 of the accumulator is set
 				if (I.AF.b.h & 0x08)
 					I.IM = (I.IM & ~(IM_M55+IM_M65+IM_M75)) | (I.AF.b.h & (IM_M55+IM_M65+IM_M75));
+
+				/* bit 4 (R7.5) resets the RST7.5 flip-flop. RST7.5 is edge
+				   triggered and latches in I.IREQ, so unlike RST5.5/6.5 it is
+				   never cleared by the line going low - only by SIM or by the
+				   interrupt being taken. Without this the latch sticks and the
+				   handler re-enters forever. */
+				if (I.AF.b.h & 0x10)
+				{
+					I.IREQ &= ~IM_M75;
+					/* also drop it if it was scheduled but not yet taken */
+					if (I.ISRV == IM_M75)
+					{
+						I.ISRV = 0;
+						I.IRQ2 = 0;
+					}
+				}
 			} else {
 						/* NOP undocumented */
 			}
@@ -1175,9 +1228,16 @@ INLINE void execute_one(int opcode)
 		case 0xfa: // JM nnnn
 			M_JMP( I.AF.b.l & SF );
 			break;
-		case 0xfb: // EI //!! not ported from new MAME
+		case 0xfb: // EI
 			/* set interrupt enable */
 			I.IM |= IM_IE;
+			/* The 8085 does not recognise an interrupt until the instruction
+			   after EI has completed. Real code leans on this: an interrupt
+			   service routine that ends
+			       EI / POP PSW / RET
+			   relies on the POP running before anything else can be taken, or
+			   the frame is left half unwound. */
+			I.after_ei = 1;
 			/* remove serviced IRQ flag */
 			I.IREQ &= ~I.ISRV;
 			/* reset serviced IRQ */
@@ -1318,6 +1378,7 @@ static void Interrupt(void)
 					execute_one(I.IRQ1 & 0xff);
 			}
 	}
+
 }
 
 int i8085_execute(int cycles)
@@ -1328,7 +1389,13 @@ int i8085_execute(int cycles)
 	{
 		CALL_MAME_DEBUG;
 		/* interrupts enabled or TRAP pending ? */
-		if ( (I.IM & IM_IE) || (I.IREQ & IM_TRAP) )
+		if ( I.after_ei )
+		{
+			/* swallow exactly one instruction's worth of interrupt latency
+			   after EI (see case 0xfb) */
+			I.after_ei--;
+		}
+		else if ( (I.IM & IM_IE) || (I.IREQ & IM_TRAP) )
 		{
 			/* copy scheduled to executed interrupt request */
 			I.IRQ1 = I.IRQ2;
@@ -1403,12 +1470,20 @@ void i8085_init(void)
 void i8085_reset(void *param)
 {
 	int cputype_bak = I.cputype; //AT: backup cputype(0=8080, 1=8085)
+	/* Callbacks are wiring set up once by the driver, not CPU state - they
+	   must survive a reset. The memset below would otherwise drop them. */
+	int  (*irq_cb_bak)(int)     = I.irq_callback;
+	void (*sod_cb_bak)(int)     = I.sod_callback;
+	int  (*sid_cb_bak)(void)    = I.sid_callback;
 
 	init_tables();
 	memset(&I, 0, sizeof(i8085_Regs)); //AT: this also resets I.cputype so 8085 features were never ever used!
 	change_pc16(I.PC.d);
 
 	I.cputype = cputype_bak; //AT: restore cputype
+	I.irq_callback = irq_cb_bak;
+	I.sod_callback = sod_cb_bak;
+	I.sid_callback = sid_cb_bak;
 }
 
 /****************************************************************************
@@ -1531,6 +1606,17 @@ void i8085_set_SID(int state)
 /****************************************************************************/
 /* Set a callback to be called at SOD output change 						*/
 /****************************************************************************/
+/****************************************************************************/
+/* Set a callback used to sample the SID input when RIM executes			*/
+/* Preferred over i8085_set_SID(): the 8085 latches SID at the moment RIM	*/
+/* runs, so hardware that shifts serial data in (e.g. a switch matrix on a	*/
+/* 74165 chain) has to be read at that instant rather than pushed in advance.*/
+/****************************************************************************/
+void i8085_set_SID_callback(int (*callback)(void))
+{
+	I.sid_callback = callback;
+}
+
 void i8085_set_SOD_callback(void (*callback)(int state))
 {
 	I.sod_callback = callback;
@@ -1544,8 +1630,18 @@ void i8085_set_TRAP(int state)
 	LOG(("i8085: TRAP %d\n", state));
 	if (state)
 	{
+		/* Gate on the pending flag, not on I.ISRV. I.ISRV is an "in service"
+		   lock that only EI clears, and a TRAP handler is under no obligation
+		   to EI on the way out - running with interrupts disabled and simply
+		   RETing is perfectly legal, and this hardware does exactly that at
+		   boot. Keying off I.ISRV therefore wedged TRAP permanently after the
+		   first one. Interrupt() clears the pending flag as it takes the
+		   interrupt, so testing it here re-arms TRAP for the next edge while
+		   still ignoring a second edge that arrives before the first is taken.
+		   I.ISRV is deliberately left alone so it keeps blocking the maskable
+		   RST5.5/6.5/7.5 for the duration of the handler. */
+		if( I.IREQ & IM_TRAP ) return;	/* edge already pending, not yet taken */
 		I.IREQ |= IM_TRAP;
-		if( I.ISRV & IM_TRAP ) return;	/* already servicing TRAP ? */
 		I.ISRV = IM_TRAP;				/* service TRAP */
 		I.IRQ2 = ADDR_TRAP;
 	}

--- a/src/cpu/i8085/i8085.h
+++ b/src/cpu/i8085/i8085.h
@@ -16,6 +16,7 @@ enum {
 extern int i8085_ICount;
 
 extern void i8085_set_SID(int state);
+extern void i8085_set_SID_callback(int (*callback)(void));
 extern void i8085_set_SOD_callback(void (*callback)(int state));
 extern void i8085_init(void);
 extern void i8085_reset(void *param);


### PR DESCRIPTION
Please note @volkenborn looked at this code already, he is aware that I am going to do separate PR's to get a currently not working game (Recreativos Franco - Super Star) working. 

```markdown
Five defects in the 8085A core, all found while bringing up a driver that drives
its display and reads its switches through the serial pins. None of the fixes is
specific to that machine.

- **RIM returned `I.IM` raw.** That register holds the masks and IE in the
  positions the RIM byte expects, but `IM_TRAP` (0x10) sat where the RST5.5
  pending flag belongs and `IM_SOD` (0x40) where RST7.5 pending belongs, and SID
  was only ever reported if a driver had pushed a value in beforehand. The byte
  is now composed properly.
- **SIM ignored bit 4 (R7.5).** RST7.5 is edge triggered and latches, so unlike
  RST5.5/6.5 it is never cleared by the line going low — only by SIM or by the
  interrupt being taken. Without handling bit 4 the latch sticks and the handler
  re-enters forever.
- **`i8085_reset()` wiped the callbacks.** It memsets the whole register struct,
  which dropped the irq, sod and sid callbacks a driver installs at init. Those
  are wiring, not CPU state.
- **EI took effect immediately.** On real hardware an interrupt is not
  recognised until the instruction after EI has completed, and service routines
  rely on it: an ISR ending `EI / POP PSW / RET` needs the POP to run first or
  the frame is left half unwound.
- **TRAP could only ever fire once.** `i8085_set_TRAP()` gated on `I.ISRV`, an
  "in service" lock that only EI clears — but a TRAP handler is free to run with
  interrupts disabled and simply RET. The lock then stayed set forever, blocking
  not just further TRAPs but RST5.5/6.5/7.5 as well. It now gates on the pending
  flag, which `Interrupt()` clears as it takes the interrupt, so a new edge
  re-arms while a second edge arriving before the first is taken is still
  ignored.

Adds `i8085_set_SID_callback()` so hardware that clocks serial data in is
sampled at the moment RIM executes rather than ahead of time.
`i8085_set_SID()` still works for drivers that prefer to push.

### Risk to existing drivers

This core is not unused, and these changes are not free of consequence for the
two drivers already on it:

- `src/wpc/regama.c` (Regama Trebol, added 2020) instantiates an `8085A` and
  drives **both** serial pins — `i8085_set_SID()` for the battery-good line and
  `i8085_set_SOD_callback()`.
- `src/wpc/micropin.c` has an `8085A` machine.

The RIM composition change, the EI delay, the TRAP re-arm and the callback
preservation all apply to them. I have no ROMs for either and could not test
them; a smoke test from someone who has would be worth having before this is
merged.