### PR TITLE
remote_debug: filter by CPU, expose the mechanics flag, fix column 0 names

### DIFF
--- a/src/remote_debug/api_handler.c
+++ b/src/remote_debug/api_handler.c
@@ -539,22 +539,24 @@ static void handle_api_debugger_trace(const http_request_t *req, http_response_t
 
 static void handle_api_debugger_breakpoints(const http_request_t *req, http_response_t *resp)
 {
-	char cmd_buf[32], addr_buf[32], bank_buf[32], cond_buf[32], ignore_buf[32];
+	char cmd_buf[32], addr_buf[32], bank_buf[32], cond_buf[32], ignore_buf[32], cpu_buf[32];
 	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
 	if (strcmp(cmd_buf, "add") == 0) {
-		int bank;
+		int bank, cpu;
 		UINT32 ignore;
 		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
 		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
 		get_query_param(req->query, "cond", cond_buf, (int)sizeof(cond_buf));
 		get_query_param(req->query, "ignore", ignore_buf, (int)sizeof(ignore_buf));
+		get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
 		if (!addr_buf[0]) {
 			respond_error(resp, 400, "missing parameter: addr");
 			return;
 		}
 		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
+		cpu = cpu_buf[0] ? parse_int(cpu_buf) : -1;
 		ignore = ignore_buf[0] ? (UINT32)parse_int(ignore_buf) : 0;
-		if (remote_debug_breakpoint_add_ex(parse_hex(addr_buf), bank, cond_buf, ignore) != 0) {
+		if (remote_debug_breakpoint_add_ex(parse_hex(addr_buf), bank, cpu, cond_buf, ignore) != 0) {
 			respond_error(resp, 400, "bad condition or breakpoint table full");
 			return;
 		}
@@ -1036,6 +1038,25 @@ static void handle_api_input(const http_request_t *req, http_response_t *resp)
 		respond_error(resp, 503, "core not initialized");
 }
 
+/* Read or set g_fHandleMechanics, the flag a front end uses to take ownership
+ * of driver-modelled mechanics (VPinMAME exposes it as
+ * Controller.HandleMechanics; libpinmame defaults it to 0). The standalone
+ * build pins it at 0xff and offers no way to change it, which left the
+ * front-end-owned code paths untestable from the harnesses - e.g. the
+ * rfranco trough handover, which hands switch 27 to the front end when the
+ * flag is 0. GET without val reports the current value.                     */
+static void handle_api_mechanics(const http_request_t *req, http_response_t *resp)
+{
+	extern int g_fHandleMechanics;
+	char val_buf[32];
+	char out[64];
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	if (val_buf[0])
+		g_fHandleMechanics = parse_int(val_buf);
+	snprintf(out, sizeof(out), "{\"handleMechanics\": %d}", g_fHandleMechanics);
+	respond_json(resp, 200, out);
+}
+
 static void handle_api_switches(const http_request_t *req, http_response_t *resp)
 {
 	char *body = NULL;
@@ -1120,20 +1141,22 @@ static void handle_api_monitor_log(const http_request_t *req, http_response_t *r
 
 static void handle_api_debugger_instrument(const http_request_t *req, http_response_t *resp)
 {
-	char cmd_buf[32], addr_buf[32], bank_buf[32];
+	char cmd_buf[32], addr_buf[32], bank_buf[32], cpu_buf[32];
 	char *body = NULL;
 	int len = 0;
 	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
 	if (strcmp(cmd_buf, "add") == 0) {
-		int bank;
+		int bank, cpu;
 		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
 		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
 		if (!addr_buf[0]) {
 			respond_error(resp, 400, "missing parameter: addr");
 			return;
 		}
 		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
-		if (remote_debug_instrument_add(parse_hex(addr_buf), bank) != 0) {
+		cpu = cpu_buf[0] ? parse_int(cpu_buf) : -1;
+		if (remote_debug_instrument_add(parse_hex(addr_buf), bank, cpu) != 0) {
 			respond_error(resp, 400, "instrumentation table full");
 			return;
 		}
@@ -1323,20 +1346,22 @@ static void handle_api_debugger_coverage(const http_request_t *req, http_respons
 
 static void handle_api_debugger_tracepoints(const http_request_t *req, http_response_t *resp)
 {
-	char cmd_buf[32], addr_buf[32], bank_buf[32];
+	char cmd_buf[32], addr_buf[32], bank_buf[32], cpu_buf[32];
 	char *body = NULL;
 	int len = 0;
 	get_query_param(req->query, "cmd", cmd_buf, (int)sizeof(cmd_buf));
 	if (strcmp(cmd_buf, "add") == 0) {
-		int bank;
+		int bank, cpu;
 		get_query_param(req->query, "addr", addr_buf, (int)sizeof(addr_buf));
 		get_query_param(req->query, "bank", bank_buf, (int)sizeof(bank_buf));
+		get_query_param(req->query, "cpu", cpu_buf, (int)sizeof(cpu_buf));
 		if (!addr_buf[0]) {
 			respond_error(resp, 400, "missing parameter: addr");
 			return;
 		}
 		bank = bank_buf[0] ? (int)parse_hex(bank_buf) : -1;
-		if (remote_debug_tracepoint_add(parse_hex(addr_buf), bank) != 0) {
+		cpu = cpu_buf[0] ? parse_int(cpu_buf) : -1;
+		if (remote_debug_tracepoint_add(parse_hex(addr_buf), bank, cpu) != 0) {
 			respond_error(resp, 400, "tracepoint table full");
 			return;
 		}
@@ -1417,7 +1442,7 @@ static const api_route_t api_routes[] = {
 	{"/api/debugger/command", handle_api_debugger_command,
 	 "?cmd=... - classic command (BP/BC/WP/WC/G/S/F/QUIT/HELP)"},
 	{"/api/debugger/breakpoints", handle_api_debugger_breakpoints,
-	 "?cmd=add&addr=HEX[&bank=HEX][&cond=REG==HEX][&ignore=N] | ?cmd=clear"},
+	 "?cmd=add&addr=HEX[&bank=HEX][&cpu=N][&cond=REG==HEX][&ignore=N] | ?cmd=clear"},
 	{"/api/debugger/watchpoints", handle_api_debugger_watchpoints,
 	 "?cmd=add&addr=HEX[&len=N][&mode=1|2|3][&bank=HEX][&cond=eq|ne|lt|gt|le|ge&val=HEX] | ?cmd=clear"},
 	{"/api/debugger/points", handle_api_debugger_points,
@@ -1436,13 +1461,13 @@ static const api_route_t api_routes[] = {
 	{"/api/debugger/nvram/dump", handle_api_debugger_nvram_dump,
 	 "raw 8KB WPC CMOS RAM dump"},
 	{"/api/debugger/instrument", handle_api_debugger_instrument,
-	 "PC hit counting; ?cmd=add&addr=HEX[&bank=HEX] | ?cmd=clear | list"},
+	 "PC hit counting; ?cmd=add&addr=HEX[&bank=HEX][&cpu=N] | ?cmd=clear | list"},
 	{"/api/debugger/exectrace", handle_api_debugger_exectrace,
 	 "instruction trace ring; ?cmd=start|stop|clear | list (last N executed)"},
 	{"/api/debugger/coverage", handle_api_debugger_coverage,
 	 "code coverage; ?cmd=start|stop|clear | summary | ?addr=HEX[&size=N][&bank=HEX] region"},
 	{"/api/debugger/tracepoints", handle_api_debugger_tracepoints,
-	 "log-and-continue points; ?cmd=add&addr=HEX[&bank=HEX] | ?cmd=clear | list+log"},
+	 "log-and-continue points; ?cmd=add&addr=HEX[&bank=HEX][&cpu=N] | ?cmd=clear | list+log"},
 	{"/api/debugger/scan", handle_api_debugger_scan,
 	 "value scan; ?cmd=new&addr=HEX[&size=N][&cpu=N] | ?cmd=filter&op=eq|ne|changed|unchanged|inc|dec[&val=HEX]"},
 	{"/api/switches", handle_api_switches,
@@ -1461,6 +1486,8 @@ static const api_route_t api_routes[] = {
 	 "DMD frame recorder; ?cmd=start|stop|clear | status"},
 	{"/api/debugger/dmdrec/data", handle_api_debugger_dmdrec_data,
 	 "packed binary of recorded DMD frames (u32 count,w,h; per frame u32 t + w*h bytes)"},
+	{"/api/mechanics", handle_api_mechanics,
+	 "?val=N - set g_fHandleMechanics (0 = front end owns the mechanics); no val = read"},
 	{"/api/input", handle_api_input,
 	 "?sw=N&val=0|1[&pulse=MS] - set a switch, optionally as a timed pulse"},
 	{"/ui", handle_ui, "the web UI"},

--- a/src/remote_debug/remote_debug.c
+++ b/src/remote_debug/remote_debug.c
@@ -61,6 +61,7 @@ enum {
 typedef struct {
 	UINT32 adr;
 	int bank;             /* -1: any bank */
+	int cpu;              /* -1: any CPU */
 	int enabled;
 	int temp;             /* one-shot (run-to/step-over/step-out) */
 	int cond_op;          /* COND_NONE for unconditional */
@@ -170,6 +171,7 @@ static volatile sig_atomic_t coverage_enabled = 0;
 typedef struct {
 	UINT32 addr;
 	int bank;
+	int cpu;              /* -1: any CPU */
 	UINT32 hits;
 } tracepoint_t;
 
@@ -207,6 +209,7 @@ static int action_count = 0;
 typedef struct {
 	UINT32 addr;
 	int bank;       /* -1: any bank */
+	int cpu;        /* -1: any CPU */
 	UINT32 count;
 } instrument_t;
 
@@ -630,7 +633,7 @@ static int cond_matches(const breakpoint_t *bp)
 }
 
 /* Internal add; temp breakpoints are silent. */
-static int breakpoint_add_internal(UINT32 adr, int bank, int temp,
+static int breakpoint_add_internal(UINT32 adr, int bank, int cpu, int temp,
                                    const char *cond, UINT32 ignore)
 {
 	int result = -1;
@@ -640,6 +643,7 @@ static int breakpoint_add_internal(UINT32 adr, int bank, int temp,
 		memset(bp, 0, sizeof(*bp));
 		bp->adr = adr;
 		bp->bank = bank;
+		bp->cpu = cpu;
 		bp->enabled = 1;
 		bp->temp = temp;
 		bp->ignore_count = ignore;
@@ -664,19 +668,19 @@ static int breakpoint_add_internal(UINT32 adr, int bank, int temp,
 	return result;
 }
 
-int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, const char *cond, UINT32 ignore)
+int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, int cpu, const char *cond, UINT32 ignore)
 {
-	return breakpoint_add_internal(adr, bank, 0, cond, ignore);
+	return breakpoint_add_internal(adr, bank, cpu, 0, cond, ignore);
 }
 
 void remote_debug_breakpoint_add(UINT32 adr)
 {
-	breakpoint_add_internal(adr, -1, 0, NULL, 0);
+	breakpoint_add_internal(adr, -1, -1, 0, NULL, 0);
 }
 
 void remote_debug_breakpoint_add_banked(UINT32 adr, int bank)
 {
-	breakpoint_add_internal(adr, bank, 0, NULL, 0);
+	breakpoint_add_internal(adr, bank, -1, 0, NULL, 0);
 }
 
 void remote_debug_breakpoint_clear(void)
@@ -722,13 +726,17 @@ static UINT32 coverage_index(UINT32 pc, int bank)
 void remote_debug_breakpoint_hook(void)
 {
 	UINT32 pc;
-	int current_bank, i;
+	int current_bank, current_cpu, i;
 
 	if (breakpoint_count == 0 && instrument_count == 0 && tracepoint_count == 0
 			&& !exec_trace_enabled && !coverage_enabled)
 		return;
 	pc = activecpu_get_reg(REG_PC);
 	current_bank = wpc_get_bank();
+	/* Which processor is running matters on multi-CPU boards: the two address
+	   spaces overlap, so an unfiltered point on a low address counts hits from
+	   whichever core happens to be there. */
+	current_cpu = cpu_getactivecpu();
 
 	/* execution trace: record this instruction in the ring buffer */
 	if (exec_trace_enabled) {
@@ -758,7 +766,8 @@ void remote_debug_breakpoint_hook(void)
 	/* tracepoints: log a register snapshot and continue (no halt) */
 	for (i = 0; i < tracepoint_count; i++) {
 		if (tracepoints[i].addr == pc
-				&& (tracepoints[i].bank == -1 || tracepoints[i].bank == current_bank)) {
+				&& (tracepoints[i].bank == -1 || tracepoints[i].bank == current_bank)
+				&& (tracepoints[i].cpu == -1 || tracepoints[i].cpu == current_cpu)) {
 			tp_log_t *t = &tp_log[tp_head];
 			tracepoints[i].hits++;
 			t->pc = pc;
@@ -780,7 +789,8 @@ void remote_debug_breakpoint_hook(void)
 	/* code instrumentation: count passes over marked addresses */
 	for (i = 0; i < instrument_count; i++) {
 		if (instruments[i].addr == pc
-				&& (instruments[i].bank == -1 || instruments[i].bank == current_bank))
+				&& (instruments[i].bank == -1 || instruments[i].bank == current_bank)
+				&& (instruments[i].cpu == -1 || instruments[i].cpu == current_cpu))
 			instruments[i].count++;
 	}
 
@@ -789,6 +799,8 @@ void remote_debug_breakpoint_hook(void)
 		if (!bp->enabled || pc != bp->adr)
 			continue;
 		if (bp->bank != -1 && current_bank != bp->bank)
+			continue;
+		if (bp->cpu != -1 && current_cpu != bp->cpu)
 			continue;
 		if (!cond_matches(bp))
 			continue;
@@ -1186,7 +1198,7 @@ void remote_debug_step_over(void)
 		if (need_ctx)
 			cpuintrf_pop_context();
 		if (size > 0) {
-			breakpoint_add_internal(pc + (UINT32)size, -1, 1, NULL, 0);
+			breakpoint_add_internal(pc + (UINT32)size, -1, cpu_getactivecpu(), 1, NULL, 0);
 			is_paused = 0;
 			remote_debug_add_message("Stepping over...");
 		}
@@ -1203,7 +1215,7 @@ void remote_debug_step_out(void)
 	if (callstack_ptr > 0) {
 		const callstack_entry_t *e = &callstack[callstack_ptr - 1];
 		char b[MSG_LEN];
-		breakpoint_add_internal(e->pc, e->bank, 1, NULL, 0);
+		breakpoint_add_internal(e->pc, e->bank, -1, 1, NULL, 0);
 		is_paused = 0;
 		snprintf(b, sizeof(b), "Stepping out to %04X...", e->pc);
 		remote_debug_add_message(b);
@@ -1219,7 +1231,7 @@ void remote_debug_run_to(UINT32 addr, int bank)
 {
 	char b[MSG_LEN];
 	remote_debug_lock();
-	breakpoint_add_internal(addr, bank, 1, NULL, 0);
+	breakpoint_add_internal(addr, bank, -1, 1, NULL, 0);
 	is_paused = 0;
 	remote_debug_unlock();
 	if (bank != -1)
@@ -1493,8 +1505,15 @@ static const char *switch_name(int num)
 		"L.R Flipper EOS", "L.R Flipper", "L.L Flipper EOS", "L.L Flipper",
 		"U.R Flipper EOS", "U.R Flipper", "U.L Flipper EOS", "U.L Flipper"
 	};
+	/* Column 0 is the coin door on WPC, and these names belong to that family
+	   alone. Other generations use the column for whatever the driver says it
+	   is - rfranco keeps its two operator door switches there - so labelling
+	   one of those "Coin 1" states something that is not true. Fall through to
+	   the empty name instead, which is what the rest of such a driver's
+	   switches already report. */
 	if (num >= 1 && num <= 8)
-		return coindoor[num - 1];
+		return (core_gameData && (core_gameData->gen & GEN_ALLWPC))
+		       ? coindoor[num - 1] : "";
 	if (num >= CORE_FLIPPERSWCOL * 10 + 1 && num <= CORE_FLIPPERSWCOL * 10 + 8)
 		return flippers[num - (CORE_FLIPPERSWCOL * 10 + 1)];
 	if (core_gameData) {
@@ -1773,13 +1792,14 @@ void remote_debug_get_action_log(char **buffer, int *len)
 /* Code instrumentation (PC hit counting)                             */
 /* ================================================================== */
 
-int remote_debug_instrument_add(UINT32 addr, int bank)
+int remote_debug_instrument_add(UINT32 addr, int bank, int cpu)
 {
 	int result = -1;
 	remote_debug_lock();
 	if (instrument_count < INSTRUMENT_MAX) {
 		instruments[instrument_count].addr = addr;
 		instruments[instrument_count].bank = bank;
+		instruments[instrument_count].cpu = cpu;
 		instruments[instrument_count].count = 0;
 		instrument_count++;
 		result = 0;
@@ -1803,9 +1823,9 @@ void remote_debug_get_instrumentation(char **buffer, int *len)
 	remote_debug_lock();
 	sb_appendf(&sb, "{\"points\": [");
 	for (i = 0; i < instrument_count; i++)
-		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"count\": %u}",
+		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"cpu\": %d, \"count\": %u}",
 		           (i > 0) ? "," : "", instruments[i].addr,
-		           instruments[i].bank, instruments[i].count);
+		           instruments[i].bank, instruments[i].cpu, instruments[i].count);
 	sb_appendf(&sb, "]}");
 	remote_debug_unlock();
 	*buffer = sb.buf;
@@ -2249,13 +2269,14 @@ void remote_debug_get_coverage_region(char **buffer, int *len, UINT32 addr, int 
 /* Tracepoints (log-and-continue)                                     */
 /* ================================================================== */
 
-int remote_debug_tracepoint_add(UINT32 addr, int bank)
+int remote_debug_tracepoint_add(UINT32 addr, int bank, int cpu)
 {
 	int result = -1;
 	remote_debug_lock();
 	if (tracepoint_count < MAX_POINTS) {
 		tracepoints[tracepoint_count].addr = addr;
 		tracepoints[tracepoint_count].bank = bank;
+		tracepoints[tracepoint_count].cpu = cpu;
 		tracepoints[tracepoint_count].hits = 0;
 		tracepoint_count++;
 		result = 0;
@@ -2281,9 +2302,9 @@ void remote_debug_get_tracepoints(char **buffer, int *len)
 	remote_debug_lock();
 	sb_appendf(&sb, "{\"points\": [");
 	for (i = 0; i < tracepoint_count; i++)
-		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"hits\": %u}",
+		sb_appendf(&sb, "%s{\"addr\": %u, \"bank\": %d, \"cpu\": %d, \"hits\": %u}",
 		           (i > 0) ? "," : "", tracepoints[i].addr,
-		           tracepoints[i].bank, tracepoints[i].hits);
+		           tracepoints[i].bank, tracepoints[i].cpu, tracepoints[i].hits);
 	sb_appendf(&sb, "], \"log\": [");
 	for (i = 0; i < tp_count; i++) {
 		int idx = (tp_head - tp_count + i + TP_LOG_SIZE) % TP_LOG_SIZE;

--- a/src/remote_debug/remote_debug.h
+++ b/src/remote_debug/remote_debug.h
@@ -88,7 +88,7 @@ void remote_debug_memref(UINT32 adr, int length, int write);
  * "REG<=VAL", "REG>=VAL" with an M6809 register name and a hex value
  * (NULL or "" for unconditional). ignore skips that many hits before
  * halting. Returns 0 on success, -1 on a bad condition or full table. */
-int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, const char *cond, UINT32 ignore);
+int remote_debug_breakpoint_add_ex(UINT32 adr, int bank, int cpu, const char *cond, UINT32 ignore);
 
 void remote_debug_breakpoint_add(UINT32 adr);
 void remote_debug_breakpoint_add_banked(UINT32 adr, int bank);
@@ -198,8 +198,8 @@ void remote_debug_monitor_sample(void);
 /* ------------------------------------------------------------------ */
 
 /* Count how often execution passes a code address. bank -1 matches any
- * bank. Returns 0 on success, -1 on a full table. */
-int remote_debug_instrument_add(UINT32 addr, int bank);
+ * bank, cpu -1 any CPU. Returns 0 on success, -1 on a full table. */
+int remote_debug_instrument_add(UINT32 addr, int bank, int cpu);
 void remote_debug_instrument_clear(void);
 
 /* JSON list of instrumented addresses with hit counts. *buffer malloc()ed. */
@@ -234,8 +234,8 @@ void remote_debug_get_coverage_region(char **buffer, int *len, UINT32 addr, int 
 /* Tracepoints (log a register snapshot and continue, no halt)        */
 /* ------------------------------------------------------------------ */
 
-/* Add a tracepoint at addr (bank -1 = any). Returns 0, -1 if full. */
-int remote_debug_tracepoint_add(UINT32 addr, int bank);
+/* Add a tracepoint at addr (bank/cpu -1 = any). Returns 0, -1 if full. */
+int remote_debug_tracepoint_add(UINT32 addr, int bank, int cpu);
 void remote_debug_tracepoint_clear(void);
 
 /* JSON of tracepoints and their collected register-snapshot log. malloc()ed. */


### PR DESCRIPTION
``markdown
Three independent improvements to the remote debug API. No emulation behaviour
changes.

- **Per-CPU filtering for breakpoints, instrumentation points and tracepoints.**
  The per-instruction hook read `activecpu_get_reg(REG_PC)` with no idea which
  processor was running, so on a multi-CPU board any point below the smaller
  CPU's ROM size counted hits from both. On the board this was found on, that
  made every measurement of the main CPU's low addresses meaningless — `0x0286`
  is an error path in the game ROM and a `MOV` inside a live voice routine in
  the sound ROM. All three point types now carry an optional `cpu` field,
  exposed as `&cpu=N` on the endpoints and reported back in the JSON. Omitted,
  it keeps the old any-CPU behaviour.
- **`/api/mechanics`** reads and sets `g_fHandleMechanics`. The standalone build
  pins the flag at `0xff` with no route to change it, which leaves the
  front-end-owned ball path untestable in any driver that has one.
- **`switch_name()` no longer mislabels column 0.** It gave switches 1–8 the WPC
  coin-door names ("Coin 1".."Escape") whatever the game. Column 0 is the coin
  door on WPC and whatever its driver makes it elsewhere, so the table is now
  gated on `GEN_ALLWPC` and otherwise falls through to the empty name that the
  rest of such a driver's switches already report.
  
  Created as part of PR 614 and PR 615 (Add Super Star) to help with debugging, should be possible to independently merge.