### PR TITLE
libpinmame: memory map parser fixes (invert, ch encoding, nibble handling, enum values, parse safety)

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2726,7 +2726,7 @@ PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t
                continue;
             if (regionDef["nibble"].get<std::string>() == "low")
                nibble = 1;
-            else if (regionDef["nibble"].get<std::string>() == "hight")
+            else if (regionDef["nibble"].get<std::string>() == "high")
                nibble = 2;
             else
                continue;

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2764,8 +2764,20 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
    std::string gameString(game, game + gameSize);
    json memMapDef = json::parse(gameString);
 
+   // The 'ch' encoding decodes through the map's char_map when it declares one: per the format
+   // spec, "if the map has char_map metadata, all bytes (including 0x00) are indexes into that
+   // string". It lives in _metadata, which traverse_and_collect walks as a group rather than
+   // inheriting as a field, so it is read here and captured.
+   std::string charMap;
+   if (memMapDef.is_object() && memMapDef.contains("_metadata") && memMapDef["_metadata"].is_object())
+   {
+      const json& metadata = memMapDef["_metadata"];
+      if (metadata.contains("char_map") && metadata["char_map"].is_string())
+         charMap = metadata["char_map"].get<std::string>();
+   }
+
    std::function<void(const json&, const std::string&, std::map<std::string, json>)> traverse_and_collect;
-   traverse_and_collect = [&traverse_and_collect, &parseAddress, &jsonFlagIsSet, &jsonFlagIsClear, &memRegions, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
+   traverse_and_collect = [&traverse_and_collect, &parseAddress, &jsonFlagIsSet, &jsonFlagIsClear, &memRegions, &charMap, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
       if (!node.is_object())
          return;
 
@@ -2991,22 +3003,52 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
          }
          else if (encoding == "ch")
          {
+            // The cheat sheet in the map format spec marks mask as applying to ch, and the encoding
+            // notes describe char_map and null for it. None of the three were implemented, so a map
+            // that relies on them decoded to raw bytes: initials came back lowercase where a mask of
+            // 0x5F was meant to upcase them, and came back as arbitrary bytes on the maps that index
+            // a char_map rather than ASCII.
+            unsigned int byteMask = 0xFF;
+            if (fields.contains("mask"))
+               parseAddress(fields["mask"], byteMask);
+            std::string nullMode;
+            if (fields.contains("null") && fields["null"].is_string())
+               nullMode = fields["null"].get<std::string>();
+
             type = CTLPI_STATE_FORMAT_STRING;
-            getter = [offsets](unsigned int index, void* pResult)
+            getter = [offsets, byteMask, nullMode, charMap](unsigned int index, void* pResult)
                {
                   const unsigned int baseOffset = offsets[0];
                   const uint8_t* ptr = static_cast<const uint8_t*>(memory_find_base(0, baseOffset));
                   if (ptr == nullptr)
                      return;
 
-                  assert(offsets.size() < 255);
+                  assert(offsets.size() < sizeof(msgLocals.memMapStringBuffer));
                   char* pStr = msgLocals.memMapStringBuffer;
                   for (auto offset : offsets)
                   {
-                     *pStr = *(ptr + (offset - baseOffset));
+                     const uint8_t byte = (*(ptr + (offset - baseOffset))) & byteMask;
+
+                     if (byte == 0)
+                     {
+                        if (nullMode == "terminate")
+                           break;
+                        if (nullMode == "ignore")
+                           continue;
+                     }
+
+                     if (!charMap.empty())
+                        *pStr = byte < charMap.length() ? charMap[byte] : '?';
+                     else
+                        *pStr = (byte >= 32 && byte <= 126) ? (char)byte : '?';
                      pStr++;
                   }
                   *pStr = 0;
+
+                  // These fields are fixed width and commonly space padded.
+                  while (pStr > msgLocals.memMapStringBuffer && *(pStr - 1) == ' ')
+                     *--pStr = 0;
+
                   *static_cast<const char**>(pResult) = msgLocals.memMapStringBuffer;
                };
          }

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2709,6 +2709,26 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
          return false;
       };
 
+   // Pinball Memory Maps write their boolean flags as JSON booleans -- "invert": true -- not as
+   // quoted strings. Reading them with is_string() therefore never matches and the flag is silently
+   // ignored. Both spellings are accepted here so the flag applies either way.
+   const auto jsonFlagIsSet = [](const json& node) -> bool
+      {
+         if (node.is_boolean())
+            return node.get<bool>();
+         if (node.is_string())
+            return node.get_ref<const std::string&>() == "true";
+         return false;
+      };
+   const auto jsonFlagIsClear = [](const json& node) -> bool
+      {
+         if (node.is_boolean())
+            return !node.get<bool>();
+         if (node.is_string())
+            return node.get_ref<const std::string&>() == "false";
+         return false;
+      };
+
    struct MemRegion { unsigned int start; unsigned int end; int nibble; };
    std::vector<MemRegion> memRegions;
    bool isLittleEndianPlatform = false;
@@ -2745,7 +2765,7 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
    json memMapDef = json::parse(gameString);
 
    std::function<void(const json&, const std::string&, std::map<std::string, json>)> traverse_and_collect;
-   traverse_and_collect = [&traverse_and_collect, &parseAddress, &memRegions, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
+   traverse_and_collect = [&traverse_and_collect, &parseAddress, &jsonFlagIsSet, &jsonFlagIsClear, &memRegions, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
       if (!node.is_object())
          return;
 
@@ -2856,7 +2876,7 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
                   break;
                }
             }
-            if (fields.contains("packed") && fields["packed"].is_string() && fields["packed"].get<std::string>() == "false")
+            if (fields.contains("packed") && jsonFlagIsClear(fields["packed"]))
                nibble = 1;
             else if (fields.contains("nibble") && fields["nibble"].is_string())
             {
@@ -2868,7 +2888,7 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
                else if (nibbleLiteral == "high")
                   nibble = 2;
             }
-            const bool isReversed = fields.contains("invert") && fields["invert"].is_string() && fields["invert"].get<std::string>() == "true";
+            const bool isReversed = fields.contains("invert") && jsonFlagIsSet(fields["invert"]);
             bool isLittleEndian = isLittleEndianPlatform;
             if (fields.contains("endian") && fields["endian"].is_string())
             {

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2906,7 +2906,7 @@ PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t
                            else if (nibble == 1)
                               v = (v * 10) + (dig1 > 9 ? 0 : dig1);
                            else if (nibble == 2)
-                              v = (v * 10) + (dig2 > 9 ? 0 : dig1);
+                              v = (v * 10) + (dig2 > 9 ? 0 : dig2);
                         }
                      }
                      else
@@ -2921,7 +2921,7 @@ PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t
                            else if (nibble == 1)
                               v = (v * 10) + (dig1 > 9 ? 0 : dig1);
                            else if (nibble == 2)
-                              v = (v * 10) + (dig2 > 9 ? 0 : dig1);
+                              v = (v * 10) + (dig2 > 9 ? 0 : dig2);
                         }
                      }
                   }

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2776,8 +2776,19 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
          charMap = metadata["char_map"].get<std::string>();
    }
 
+
+   // Shared value lists. Since _fileformat 0.5 an entry's "values" may be a string naming a list in
+   // _metadata.values rather than carrying the array inline, which the pricing tables for DIP
+   // switches use heavily. Resolved here so the enum decode below can take either form.
+   json sharedValueLists = json::object();
+   if (memMapDef.is_object() && memMapDef.contains("_metadata") && memMapDef["_metadata"].is_object())
+   {
+      const json& metadata = memMapDef["_metadata"];
+      if (metadata.contains("values") && metadata["values"].is_object())
+         sharedValueLists = metadata["values"];
+   }
    std::function<void(const json&, const std::string&, std::map<std::string, json>)> traverse_and_collect;
-   traverse_and_collect = [&traverse_and_collect, &parseAddress, &jsonFlagIsSet, &jsonFlagIsClear, &memRegions, &charMap, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
+   traverse_and_collect = [&traverse_and_collect, &parseAddress, &jsonFlagIsSet, &jsonFlagIsClear, &memRegions, &charMap, &sharedValueLists, isLittleEndianPlatform](const json& node, const std::string& group, const std::map<std::string, json>& inherited_fields) {
       if (!node.is_object())
          return;
 
@@ -2924,8 +2935,49 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
             }
             const double valueScale = fields.contains("scale") && fields["scale"].is_number() ? fields["scale"].get<double>() : 1.0;
             const double valueOffset = fields.contains("offset") && fields["offset"].is_number() ? fields["offset"].get<double>() : 0.0;
-            type = CTLPI_STATE_FORMAT_INT64;
-            getter = [offsets, nibble, byteMask, isBCD, isBool, isReversed, isLittleEndian, valueScale, valueOffset](unsigned int index, void* pResult)
+            // An enum's decoded number is an index into "values", not the value itself. The parser
+            // never read that array, so every enum state reported its raw index -- which is wrong
+            // for any consumer, and actively harmful where the map uses the mapping to mark states
+            // invalid. alpok_l6's game_over is the case that surfaced it: bit 1 is tilt, so the
+            // 0xFF the status byte passes through at ball transitions masks to 0b11, an index the
+            // map maps to false. Returning 3 instead made every ball change look like a game end.
+            //
+            // "values" may be the array itself or, since _fileformat 0.5, a string naming a list in
+            // _metadata.values.
+            std::vector<json> enumValues;
+            if (encoding == "enum" && fields.contains("values"))
+            {
+               const json& declared = fields["values"];
+               const json* resolved = nullptr;
+               if (declared.is_array())
+                  resolved = &declared;
+               else if (declared.is_string())
+               {
+                  const std::string& key = declared.get_ref<const std::string&>();
+                  if (sharedValueLists.contains(key) && sharedValueLists[key].is_array())
+                     resolved = &sharedValueLists[key];
+               }
+               if (resolved != nullptr)
+                  enumValues.assign(resolved->begin(), resolved->end());
+            }
+
+            // The mapped values decide what the state reports. Booleans and numbers stay numeric;
+            // a list holding any string is reported as a string, since that is what the label is.
+            // A list of anything else is left alone rather than guessed at, and decodes as before.
+            bool enumIsString = false;
+            bool enumUsable = !enumValues.empty();
+            for (const json& value : enumValues)
+            {
+               if (value.is_string())
+                  enumIsString = true;
+               else if (!value.is_boolean() && !value.is_number())
+                  enumUsable = false;
+            }
+            if (!enumUsable)
+               enumValues.clear();
+
+            type = enumIsString ? CTLPI_STATE_FORMAT_STRING : CTLPI_STATE_FORMAT_INT64;
+            getter = [offsets, nibble, byteMask, isBCD, isBool, isReversed, isLittleEndian, valueScale, valueOffset, enumValues, enumIsString](unsigned int index, void* pResult)
                {
                   int64_t v = 0;
 
@@ -3008,6 +3060,30 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
                         v = v == 0 ? 1 : 0;
                      else
                         v = v == 0 ? 0 : 1;
+                  }
+
+                  // Map the decoded number through the enum's value list. An index the list does
+                  // not cover cannot be a value, so it reports the format's default rather than the
+                  // index itself, which is what the getters already do when a state is unavailable.
+                  if (!enumValues.empty())
+                  {
+                     if (v < 0 || (size_t)v >= enumValues.size())
+                     {
+                        if (enumIsString)
+                           *static_cast<const char**>(pResult) = "";
+                        else
+                           *static_cast<int64_t*>(pResult) = 0;
+                        return;
+                     }
+                     const json& mapped = enumValues[(size_t)v];
+                     if (enumIsString)
+                     {
+                        const std::string text = mapped.is_string() ? mapped.get<std::string>() : mapped.dump();
+                        snprintf(msgLocals.memMapStringBuffer, sizeof(msgLocals.memMapStringBuffer), "%s", text.c_str());
+                        *static_cast<const char**>(pResult) = msgLocals.memMapStringBuffer;
+                        return;
+                     }
+                     v = mapped.is_boolean() ? (mapped.get<bool>() ? 1 : 0) : mapped.get<int64_t>();
                   }
 
                   *static_cast<int64_t*>(pResult) = v;

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -825,7 +825,7 @@ extern "C" void OnSolenoid(const int solenoid, const int state)
 
 extern "C" void libpinmame_log_info(const char* format, ...)
 {
-	if (!_p_Config->cb_OnLogMessage)
+	if (!_p_Config || !_p_Config->cb_OnLogMessage)
 		return;
 
 	va_list args;
@@ -840,7 +840,7 @@ extern "C" void libpinmame_log_info(const char* format, ...)
 
 extern "C" void libpinmame_log_error(const char* format, ...)
 {
-	if (!_p_Config->cb_OnLogMessage)
+	if (!_p_Config || !_p_Config->cb_OnLogMessage)
 		return;
 
 	va_list args;
@@ -2680,7 +2680,7 @@ PINMAMEAPI void PinmameSetMsgAPI(MsgPluginAPI* msgApi, unsigned int endpointId)
       SetupMsgApi();
 }
 
-PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t* game, size_t gameSize)
+static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game, size_t gameSize)
 {
    const auto parseAddress = [](const json& node, unsigned int& value) -> bool
       {
@@ -3025,4 +3025,23 @@ PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t
          return s < 0;
       return false;
       });
+}
+
+/******************************************************
+ * PinmameSetMemMap
+ ******************************************************/
+
+PINMAMEAPI void PinmameSetMemMap(uint8_t* platform, size_t platformSize, uint8_t* game, size_t gameSize)
+{
+	// Map files are read from disk at a path the host chooses, so a truncated or hand-edited
+	// file is reachable input rather than a build bug. nlohmann::json signals that by throwing,
+	// which would cross this C boundary and terminate the host, so failure is contained here
+	// and reported the same way an empty map is: no states.
+	try {
+		SetMemMapImpl(platform, platformSize, game, gameSize);
+	}
+	catch (const std::exception& e) {
+		msgLocals.memMapStates.clear();
+		libpinmame_log_error("PinmameSetMemMap(): failed to parse memory map: %s", e.what());
+	}
 }

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2880,11 +2880,23 @@ static void SetMemMapImpl(uint8_t* platform, size_t platformSize, uint8_t* game,
             if (fields.contains("mask"))
                parseAddress(fields["mask"], byteMask);
             int nibble = 0;
+            // A field that names its own mask has been authored against the byte as it stands, so a
+            // nibble declared by the platform's memory_layout must not silently reinterpret it. Both
+            // are byte-level rules and applying them together destroys the field: centaur reads its
+            // game-over lamp as mask 0x04 at 0x20C, which the bally-35-8K layout covers with a
+            // high-nibble NVRAM region, and 0x04 selects a bit the high nibble does not contain --
+            // masking then shifting yields 0 for every byte the machine can hold.
+            //
+            // A nibble on the field itself still wins below: that is the author saying so directly,
+            // and the same map does exactly that for current_ball and player_count, which share a
+            // byte at 0x0B.
+            const bool fieldNamesItsOwnMask = fields.contains("mask");
             for (const auto& region : memRegions)
             {
                if (region.start <= offsets[0] && offsets[0] <= region.end)
                {
-                  nibble = region.nibble;
+                  if (!fieldNamesItsOwnMask)
+                     nibble = region.nibble;
                   break;
                }
             }


### PR DESCRIPTION
Seven fixes to the `PinmameSetMemMap` parser, in one PR. Found by decoding the full
[pinmame-nvram-maps](https://github.com/tomlogic/pinmame-nvram-maps) corpus (384 maps) and running
the results against real machines on two RK3588 cabinets, cross-checked the whole time against a
second, independent decoder reading the same maps and the same live memory.

Rebased onto current `master`; each commit stands alone and explains its own reasoning.

Every one is a real defect with a measured consequence — none is a style change.

---

## The fixes

### 1. `invert` was read as a string — `36d6af72`

The map format writes it as a JSON boolean. The parser tested `is_string()`, which matched
**0 of 234 uses across 183 maps**; the quoted spelling appears nowhere in the corpus. The flag was
dead code.

It only applies to `bool` encodings, and those are overwhelmingly `game_over` — so read without the
inversion, `game_over` is true exactly while a game is running. `btmn_106` is typical: `game_over`
is the byte at `0x86`, which is also `current_player`, with the map's own note *"game is over if
current player/ball is 0"*.

Measured: a table recorded a single ball where it had previously recorded a full per-ball breakdown,
because the consumer believed every game was already over.

### 2. `ch` ignored `mask`, `char_map` and `null` — `fe66dfd1`

The format spec's cheat sheet marks `mask` as applying to `ch`; its encoding notes define
`char_map` ("all bytes, including 0x00, are indexes into that string") and `null` for it. None were
implemented — the getter was a raw byte copy.

5 maps mask their initials, in every case to upcase them, so those came back lowercase. 8 declare a
`char_map`, and there the damage is total: `whirl_l3` — the example the spec itself cites — maps
byte 11 to `'A'` and byte 1 to `'0'`, so those bytes are not printable ASCII and every initial
decoded to `'?'`.

Verified on hardware after the fix: `HHR`, `JCY`, `JRK`, `CPG`, `PFZ`.

### 3. `"hight"` typo dropped high-nibble platform regions — `685b9387`

The high-nibble branch of the `memory_layout` parser tests for `"hight"`. No map spells it that way,
and the entry-level nibble parser a hundred lines below already matches `"high"`, so the two
disagree. A region matching neither hits `continue` and decodes as a full byte rather than a nibble.

Affects `bally-17-{3K,4K,8K}`, `bally-35-{6K,8K}` and `stern-m100` — 44 maps in the corpus.

### 4. High-nibble BCD read the low nibble — `e4afa9d0`

```c
v = (v * 10) + (dig2 > 9 ? 0 : dig1);
```

The `nibble == 2` branch guards on `dig2` then accumulates `dig1`, in both endian loops. Same
platforms as #3, and their scores are BCD, so until both are fixed every score on those machines
decodes from the wrong half of each byte.

### 5. A platform-region nibble reinterpreted a masked field — `ee4a4372`

`mask` is applied before `nibble`, the reverse of the order the code's own comment documents, so the
two together destroy a field naming bits outside the selected nibble.

`centaur` reads its game-over lamp as `mask: "0x04"` at `0x20C`, which `bally-35-8K` covers with a
high-nibble NVRAM region: `(byte & 0x04) >> 4` is **0 for every possible byte**, and `"invert": true`
then makes it 1. A nibble declared on the *field* still wins — that is the author speaking directly,
and the same map does exactly that for `current_ball` and `player_count`, which share the byte at
`0x0B`.

Worth flagging honestly: fixing #3 is what exposed this. Before it the region never registered,
`nibble` stayed 0, and the mask survived — so `centaur` worked by accident. Which of `mask` and
`nibble` should apply first is left open; no map in the corpus needs both.

### 6. A malformed map file terminated the host — `966a176e`

Two `json::parse` calls with no handler, across a C entry point. Map files are read from a
host-chosen path, so a truncated or hand-edited file is reachable input rather than a build bug. The
body moves to a static `SetMemMapImpl` and the public entry point wraps it; the signature is
unchanged and a failed parse is reported the same way an empty map is — no states published.

That also exposed a second issue fixed in the same commit: `libpinmame_log_info` /
`libpinmame_log_error` dereference `_p_Config` unconditionally. Every existing caller runs during or
after a game, so it never fired — the new parse-failure path is the first that can log before
`PinmameSetConfig`, and it segfaulted on the way to reporting the error.

---

### 7. `enum` states reported their index instead of their value — `a88b61d4`

An enum's decoded number is an index into `values`, not the value itself. The parser never read that
array, so every enum state reported its raw index. For a label that is merely useless; where a map
uses the mapping to mark a state invalid it is actively wrong.

tomlogic proposed encoding Williams System 6's `game_over` as an enum over the bottom two bits, so
the `0xFF` its status byte passes through at every ball transition masks to `0b11` — an index the
map maps to `false`, since bit 1 is `tilt` and cannot be set during game over. We put that map on a
cabinet and logged what the decoder produced, before and after this commit:

```
before:  0x0078 = 0xFF (11111111) encoding=enum raw_decode=3
after:   0x0078 = 0xFF (11111111) encoding=enum raw_decode=0
         0x0078 = 0x01 (00000001) encoding=enum raw_decode=1   (both)
```

Identical map both times, so the map change alone could not fix it — any truthiness test reads `3`
as game over, and one three-ball game was being recorded as three separate games because of it.

`values` may be the array itself or, since `_fileformat` 0.5, a string naming a list in
`_metadata.values`; both resolve, the latter being 112 uses across the corpus. A list holding any
string makes the state a string, since the label *is* the value; booleans and numbers stay numeric.
A list of anything else is left alone and decodes as before rather than being guessed at. An index
the list does not cover reports the format's default.

Scoped to `enum`. `values` means something different for `bits` — values for bit 0, 1, 2 rather than
an index — and that is a separate change.

## An eighth fix I could not port, and why

On `plugin_state` the memory-map getters returned `int`, so a getter could say "this state cannot be
read right now". On `master` they return `void`, and `GetMemMapState` falls back to
`GetDefaultValue`, which writes **zero** for every numeric format.

That removes the only way to distinguish *unreadable* from *a real zero* — and for BCD that
distinction matters. A nibble outside `0..9` is not a digit, so a field of `0xFF` bytes currently
decodes to a confident zero. `centaur` keeps its scores in display memory that reads `0xFF` while
blanked, and a poll landing there reported 0 and flattened a live game total: its last ball scored 0
and its final came out 0, while the per-ball breakdown had already recorded 4,500 and 102,500.

The fix is small — reject a field holding no valid digit at all, leaving anything with even one real
digit decoding exactly as before — but it cannot be expressed against a `void` getter. I have left
it out rather than ship something that silently does nothing.

If you would take a getter that can signal failure, I have it implemented and will open it
separately -- it is a small change: the getter returns bool, and GetMemMapState answers a false with
GetDefaultValue, which is the same answer it already gives when no game is running, so callers going
through the plugin API see no difference.

It seems worth having independently of this. `ptr == nullptr` already returns without writing
`pResult`, which leaves the caller reading whatever was in the buffer, and that is the same gap seen
from the other side.

---

## Verification

- All **384** maps parse; every `_metadata.platform` reference resolves; no map yields zero states.
- Truncated game maps, truncated platform files and empty input all yield 0 states instead of
  terminating.
- On device (RK3588, two cabinets), decoded against a second independent decoder reading the same
  maps and the same live memory — `taf` (WPC), `godzilla` (Whitestar), `nbafastbreak` (WPC),
  `btmn_106` (Data East), `centaur` (Bally AS-2518-35), `wwind` (System 11), `flash_l1` and
  `alpok_l6` (System 6): **zero disagreements**, with per-ball score deltas summing exactly to each
  final score.

`centaur` is the useful case, because it had never decoded correctly: it now reads
38,540 + 11,510 + 8,500 = 58,550, matching its own breakdown.

Builds clean on GCC 12 with an fmtlib `<format>` shim; the `std::format` call is untouched.

## Not included

The fork this came from adds a small direct C API over `msgLocals.memMapStates` for hosts that link
libpinmame in-process and have no `MsgPluginAPI`. That is specific to embedding and is deliberately
left out.
