### PR TITLE
LibPinMAME: add PinmameReadMainCPUMemory for ranged CPU reads

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1717,6 +1717,31 @@ PINMAMEAPI int PinmameReadMainCPUByte(const uint32_t address, uint8_t* const p_v
 }
 
 /******************************************************
+ * PinmameReadMainCPUMemory
+ ******************************************************/
+
+PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p_buffer, const int size)
+{
+	if (!_isRunning || p_buffer == nullptr || size <= 0)
+	{
+		return 0;
+	}
+
+	for (int i = 0; i < size; i++)
+	{
+		uint8_t* p_memory = static_cast<uint8_t*>(memory_get_read_ptr(0, address + i));
+		if (p_memory == nullptr)
+		{
+			return i;
+		}
+
+		p_buffer[i] = *p_memory;
+	}
+
+	return size;
+}
+
+/******************************************************
  * PinmameGetRawMemoryRegion
  ******************************************************/
 

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -486,6 +486,7 @@ PINMAMEAPI int PinmameGetMaxNVRAM();
 PINMAMEAPI int PinmameGetNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameReadMainCPUByte(uint32_t address, uint8_t* const p_value);
+PINMAMEAPI int PinmameReadMainCPUMemory(uint32_t address, uint8_t* const p_buffer, int size);
 PINMAMEAPI const uint8_t* PinmameGetRawMemoryRegion(const int region);
 PINMAMEAPI size_t PinmameGetRawMemoryRegionLength(const int region);
 PINMAMEAPI void PinmameSetUserData(void* const p_userData);


### PR DESCRIPTION
## What

Adds a ranged counterpart to the existing `PinmameReadMainCPUByte`:

    PINMAMEAPI int PinmameReadMainCPUMemory(uint32_t address, uint8_t* const p_buffer, int size);

Reads `size` bytes starting at `address` from the main CPU address space.
Returns the number of bytes read.

## Why

I'm working on an integration that reads game state from the CPU address space using pinmame-nvram-maps. Those maps address contiguous ranges. A player score is typically 4-8 bytes of BCD, and the existing byte-at-a-time function means one call per byte. That's fine when you're running in-process, but the integration runs out-of-process, so each byte becomes a round trip, which can get ugly pretty fast.

## Implementation notes

**Loops per byte rather than one memcpy.** `memory_get_read_ptr` returns a pointer valid at the given address, but the address space is banked, so a range can cross a boundary where host memory isn't contiguous. Asking per byte is always correct; a memcpy from the first pointer would silently read the wrong data across a bank edge.

**Returns a count, not a boolean.** On hitting an unmapped address it returns how many bytes were read before stopping, so a caller can tell a partial read from a total failure. `read != size` signals the range wasn't fully mapped. Guards mirror the byte version, plus `size <= 0`.

## Testing

Built on macOS/arm64 (Release, -O3) via `cmake/libpinmame`.

Verified against `t2_l8` running under `pinmame_test`: reading 5 bytes at 0x1730 (player 1 score per the tomlogic map) returns `read=5`, and the bytes match `PinmameReadMainCPUByte` called individually at each of the five addresses. Test harness changes were local and are not included here.

## Unrelated observation

While testing I hit a segfault calling this from `OnStateUpdated` at state=2. The cause is pre-existing and applies equally to `PinmameReadMainCPUByte`: `_isRunning` is set to the state value at the first transition, but `memory_get_read_ptr` dereferences `memport->read.table` (memory.c:789) without a null check, and that table isn't built that early. Not addressed here since it's a separate concern, but flagging it.

## Disclosure

Per CONTRIBUTING.md: I use Claude/Anthropic to check my work and provide interactive guidance as I write, mostly to keep me from causing collateral damage. It helps me navigate the codebase and tells me when I'm being stupid, and when I'm testing, helps me find my bugs. I wrote and built the change, ran the verification above, and can explain the implementation!