### PR TITLE
LibPinMAME: add PMPI_READ_MEMORY plugin message

### DIFF
--- a/src/libpinmame/PinMAMEPlugin.h
+++ b/src/libpinmame/PinMAMEPlugin.h
@@ -34,6 +34,17 @@ typedef struct PinMAMEMachineStateMsg
    uint64_t hardwareGen;
 } PinMAMEMachineStateMsg;
 
+#define PMPI_READ_MEMORY                     "ReadMemory"
+
+typedef struct PinMAMEReadMemoryMsg
+{
+   int version;         // Always 1 (to allow upgrading this message in later revisions)
+   uint32_t address;    // Request: start address in the main CPU address space
+   uint32_t size;       // Request: number of bytes to read
+   uint8_t* data;       // Request: caller-owned buffer, at least 'size' bytes
+   uint32_t read;       // Response: bytes actually read, 0 if unavailable
+} PinMAMEReadMemoryMsg;
+
 
 // State groups
 // 

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -268,6 +268,7 @@ static struct
    unsigned int onConsoleDataId;
 
    unsigned int onGetMachineStateId;
+   unsigned int onReadMemoryId;
 
    struct MemMapState
    {
@@ -1829,6 +1830,18 @@ static void OnGetMachineState(const unsigned int eventId, void* userData, void* 
    msg->hardwareGen = core_gameData->gen;
 }
 
+static void OnReadMemory(const unsigned int eventId, void* userData, void* msgData)
+{
+   if (_isRunning != 1)
+      return;
+
+   auto msg = static_cast<PinMAMEReadMemoryMsg*>(msgData);
+   if (msg->version != 1 || msg->data == nullptr || msg->size == 0)
+      return;
+
+   msg->read = PinmameReadMainCPUMemory(msg->address, msg->data, (int)msg->size);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Device states
 
@@ -2654,6 +2667,8 @@ static void SetupMsgApi()
    msgLocals.onConsoleDataId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_EVT_ON_CONSOLE_DATA);
    msgLocals.onGetMachineStateId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_GET_MACHINE_STATE);
    msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
+   msgLocals.onReadMemoryId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_READ_MEMORY);
+   msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onReadMemoryId, OnReadMemory, nullptr);
 
    msgLocals.controllerProvider = std::make_unique<PinballPlugin::Controller::CtrlItemProvider<ControllerDef>>(msgLocals.msgApi, msgLocals.endpointId, CTLPI_CONTROLLERS_GET_MSG, CTLPI_CONTROLLERS_ON_CHG_MSG);
 
@@ -2673,9 +2688,11 @@ static void ReleaseMsgApi()
    msgLocals.registered = false;
 
    msgLocals.msgApi->UnsubscribeMsg(msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
+   msgLocals.msgApi->UnsubscribeMsg(msgLocals.onReadMemoryId, OnReadMemory, nullptr);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onDmdCmdId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onConsoleDataId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onGetMachineStateId);
+   msgLocals.msgApi->ReleaseMsgID(msgLocals.onReadMemoryId);
 
    msgLocals.controllerProvider = nullptr;
 


### PR DESCRIPTION
## What

Exposes the main CPU address space to plugins via a new controller message:

```
    #define PMPI_READ_MEMORY "ReadMemory"
    typedef struct PinMAMEReadMemoryMsg { int version; uint32_t address;
        uint32_t size; uint8_t* data; uint32_t read; } PinMAMEReadMemoryMsg;
```

Handled in `OnReadMemory`, backed by `PinmameReadMainCPUMemory` ([#623](https://github.com/vpinball/pinmame/pull/623)).

## Why

`PMPI_GROUP_GAMESTATE` already covers reading decoded game state, and for consumers that want scores, ball, player and so on, that is the interface to use. This is not a route around it.

What it does not cover is modifying memory at locations that have no named state. A modify is a read-modify-write, and the read half has to reach the same addresses as the write half. Those addresses are, by definition, the ones the state interface _does not name_. Concrete example, setting credits on a Gottlieb System 80B means updating three NVRAM copies, a RAM mirror and display memory, none of which are addressable as states. Additionally, config/adjustments are structurally different than game states and will require this capability to properly access.

`PinmameReadMainCPUMemory` ([#623](https://github.com/vpinball/pinmame/pull/623)) already provides this in the C API. This is the same capability reachable from a plugin. This is the exposure of access PinMAME already performs internally, not new capability. The write counterpart follows as a separate change.

## Implementation

Follows `PMPI_GET_MACHINE_STATE` throughout: id in `msgLocals`, handler beside `OnGetMachineState`, subscribe in `SetupMsgApi`, unsubscribe and `ReleaseMsgID` in `ReleaseMsgApi`. Caller owns the buffer, as `GetDisplaySrcMsg` does.

Guarded with `_isRunning != 1`, matching the neighbouring handlers rather than the looser `!_isRunning` used in the read functions, as memory tables aren't built at the first state transition.

## Testing

Built on macOS/arm64. Verified in VPX 10.8.1 Beta (rev 5436): the PinMAME plugin loads against the modified libpinmame, runs `ij_l7` normally, and unloads cleanly through `ReleaseMsgApi`.

The handler is registered but not exercised end-to-end. This needs a consumer plugin, which is the next piece of work.

[Edit 9/1/26] Re-verified after rebasing onto master following #625 and #626. That range includes the advertised-parts lifecycle restructure, which reorganises the advertise blocks and moves unadvertise to the start of stop. The same area `SetupMsgApi`/`ReleaseMsgApi` live in. Same result: plugin loads, `ij_l7` runs, and teardown is clean, with the new audio streaming and controller-provider paths active alongside it.

## Disclosure

Per CONTRIBUTING.md: I use Claude/Anthropic to check my work and provide interactive guidance as I write, mostly to keep me from causing collateral damage. It helps me navigate the codebase and tells me when I'm being stupid, and when I'm testing, helps me find my bugs. I wrote and built the change, ran the verification above, and can explain the implementation!