### PR TITLE
i86: restore 20-bit opcode base updates (CHANGE_PC)

### DIFF
--- a/src/cpu/i86/i86.c
+++ b/src/cpu/i86/i86.c
@@ -163,7 +163,7 @@ void i86_reset(void *param)
 	I.pc = 0xffff0 & AMASK;
 	ExpandFlags(I.flags);
 
-	change_pc16(I.pc);
+	change_pc20(I.pc);
 }
 
 void i86_exit(void)
@@ -189,7 +189,7 @@ void i86_set_context(void *src)
 		I.base[DS] = SegBase(DS);
 		I.base[ES] = SegBase(ES);
 		I.base[SS] = SegBase(SS);
-		change_pc16(I.pc);
+		change_pc20(I.pc);
 	}
 }
 
@@ -586,7 +586,7 @@ static void v30_interrupt(unsigned int_num, BOOLEAN md_flag)
 	I.sregs[CS] = (WORD) dest_seg;
 	I.base[CS] = SegBase(CS);
 	I.pc = (I.base[CS] + dest_off) & AMASK;
-	change_pc16(I.pc);
+	change_pc20(I.pc);
 /*	logerror("=%06x\n",activecpu_get_pc()); */
 }
 

--- a/src/cpu/i86/i86.h
+++ b/src/cpu/i86/i86.h
@@ -95,7 +95,7 @@ typedef enum { AH,AL,CH,CL,DH,DL,BH,BL,SPH,SPL,BPH,BPL,SIH,SIL,DIH,DIL } BREGS;
 #define FETCHOP					(cpu_readop(I.pc++))
 #define PEEKOP(addr)			(cpu_readop(addr))
 #define FETCHWORD(var) 			{ var = cpu_readop_arg(I.pc); var += (cpu_readop_arg(I.pc + 1) << 8); I.pc += 2; }
-#define CHANGE_PC(addr)			change_pc16(addr)
+#define CHANGE_PC(addr)			change_pc20(addr)
 #define PUSH(val)				{ I.regs.w[SP] -= 2; WriteWord(((I.base[SS] + I.regs.w[SP]) & AMASK), val); }
 #define POP(var)				{ var = ReadWord(((I.base[SS] + I.regs.w[SP]) & AMASK)); I.regs.w[SP] += 2; }
 


### PR DESCRIPTION
### What

`CHANGE_PC` in the i86 core expands to `change_pc16`, but this is a 20-bit part. This
restores `change_pc20`, which is what the core was originally imported with.

Four call sites, two files.

### Why `change_pc20` is the correct macro

The 8086, 8088, 80186 and 80188 all drive a **20-bit physical address bus** (1 MB of
address space), because a segment:offset pair resolves to `(segment << 4) + offset`.
See Intel's *iAPX 86/88, 186/188 User's Manual* and the *80C186/80C188* datasheet
("1 MByte direct addressing", 20 address lines A0–A19).

The core already agrees with that everywhere except `CHANGE_PC`:

* `AMASK` is `0xfffff` — `src/cpu/i86/i86.c`
* every memory accessor is `cpu_readmem20` / `cpu_writemem20` — `src/cpu/i86/i86.h`
* `src/cpuintrf.c` declares `I86`, `I88`, `I186` and `I188` each with 20 address bits

### Why it looks accidental rather than deliberate

* `ddf58b28` (2002) — core imported from MAME using `change_pc20`
* `567dcea4` (2016-03-19) — replaced with the generic `change_pc`
* `d2bd81b2` (2016-03-19) — that merge resolved to `change_pc16`

So the 20-bit form was the original behaviour and was lost during a merge, not changed
on purpose. Happy to be corrected if there was a reason I have not found.

### What actually goes wrong

`change_pc_generic` derives its level-1 lookup index from the address-bit count it is
handed:

```c
#define change_pc_generic(pc,abits,minbits,setop)                                    \
    if (readmem_lookup[LEVEL1_INDEX((pc) & mem_amask,abits,minbits)] != opcode_entry) \
        setop(pc);
```

With `LEVEL1_INDEX(a,b,m) = (a) >> (LEVEL2_BITS((b)-(m)) + (m))` and `m = 0`:

| macro | `LEVEL2_BITS` | effective index |
|---|---|---|
| `change_pc16` | 4 | `readmem_lookup[pc >> 4]` |
| `change_pc20` | 8 | `readmem_lookup[pc >> 8]` |

For a 20-bit space the level-1 table holds `1 << LEVEL1_BITS(20)` = **4096** entries.
`pc >> 4` therefore leaves that table for any PC at or above `0x10000` — indexing into
the subtable region, or past the end of the allocation entirely. At `pc = 0xFFFF0` the
index is `0xFFFF` (65535).

That out-of-bounds byte is then compared against `opcode_entry` to decide whether the
opcode base needs refreshing, so the decision is made on unrelated memory: the base can
be left stale and the wrong memory executed. `change_pc16` additionally passes
`cpu_setopbase16` rather than `cpu_setopbase20`.

Note the indices differ at *every* address, not only above 64 KB — `pc >> 4` and
`pc >> 8` never agree — but below `0x10000` the wrong index at least stays inside the
table.

### Impact

Machines whose code sits high in the 1 MB space are the ones that notice.

The Sleic 80188 boards run their game code at `0xD0000`–`0xFFFFF` (memory map documented
here: https://github.com/gerwout/sleic-iomoon/blob/main/docs/hardware_architecture.md).
With the Sleic driver work that actually exercises those machines — which I will submit
as its own follow-up PR covering Bike Race and Sleic Pin-Ball — **Sleic Pin-Ball faults
during boot under `change_pc16`, and boots and runs its attract mode under
`change_pc20`.** I reverted just this macro, rebuilt only the i86 objects and re-ran
both games headless for 600 frames to confirm that is the sole variable:

| game | `change_pc20` | `change_pc16` |
|---|---|---|
| Sleic Pin-Ball | 2689 DMD frames, 2076 non-blank | **SIGSEGV**, 8 frames, all blank |
| Bike Race | 2690 DMD frames, 2605 non-blank | identical |

This core is instantiated by four drivers: `sleic.c` (I188), `gts80.c` (I86),
`mephisto.c` (I88) and `bingo.c` (I186).

### Testing

* Builds clean on Linux/SDL (`makefile.unixsdl`), no new warnings.
* A known-working non-i86 game (`jupk_513`) still runs normally at 60 FPS, as a general
  sanity check on the build.
* The Sleic before/after comparison above.

**Not tested by me:** `gts80`, `mephisto` and `bingo` — I do not have those ROM sets, so
I could not check them. They are the other three users of this core and I would
appreciate someone with those sets confirming there is no regression. Their code is
likely to live low in the address space, where the wrong index at least stays inside the
level-1 table, but I would rather that were verified than assumed.
