### PR TITLE
Accept CRLF line endings in alias files

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -317,7 +317,7 @@ static const char* CheckGameAlias(const char* const romName)
 
 			if (!strcasecmp(token, romName))
 			{
-				strcpy(_aliasFromFile,  strtok(nullptr, " ,\n#;'"));
+				strcpy(_aliasFromFile,  strtok(nullptr, " ,\r\n#;'"));
 				fclose(file);
 				return _aliasFromFile;
 			}

--- a/src/win32com/Alias.cpp
+++ b/src/win32com/Alias.cpp
@@ -58,7 +58,7 @@ const char* checkGameAlias(const char* aRomName) {
 				
 				if (_stricmp(token, aRomName) == 0)
 				{
-					strcpy_s(alias_from_file, sizeof(alias_from_file), strtok(NULL, " ,\n#;'"));
+					strcpy_s(alias_from_file, sizeof(alias_from_file), strtok(NULL, " ,\r\n#;'"));
 					fclose(f);
 					return alias_from_file;
 				}


### PR DESCRIPTION
Both alias readers (`CheckGameAlias` in libpinmame for `alias.txt`, `checkGameAlias` in VPinMAME for `VPMAlias.txt`) terminate the real rom name with `strtok` on `" ,\n#;'"`, which does not include `\r`.

On Windows `fopen` in text mode strips the `\r` before `fgets` sees it, so CRLF files work. On Linux and macOS the same file leaves a trailing `\r` on the resolved name, so the driver lookup fails and the alias is silently ignored.

Adding `\r` to the delimiter set fixes this in both readers with no behavior change for LF files.