### PR TITLE
Sleic: Bike Race and Sleic Pin-Ball playable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and listen to/record the pinball game sounds with the pure PinMAME package itsel
 - *Sonic* - Odin DeLuxe (1985), Pole Position (1987), Star Wars (1987)
 - *Allied Leisure* - All games from Super Picker (1977) to Star Shooter (1979)
 - *Fascination, Int.* - Roy Clark - The Entertainer (1977), Eros One, and Circa 1933 (both 1979)
-- *Sleic*
+- *Sleic* - Bike Race (1992, standard and 2-ball versions), Sleic Pin-Ball (1993)
 - *Playmatic* - Last Lap (1978), Antar (1979), Evil Fight (1980), Mad Race (1982), Meg-Aaton (1983), KZ-26 (1984) (*)
 - *NSM*
 - *Grand Products* - 300/Bullseye (1986)

--- a/src/cpu/i86/i86.c
+++ b/src/cpu/i86/i86.c
@@ -163,7 +163,7 @@ void i86_reset(void *param)
 	I.pc = 0xffff0 & AMASK;
 	ExpandFlags(I.flags);
 
-	change_pc16(I.pc);
+	change_pc20(I.pc);
 }
 
 void i86_exit(void)
@@ -189,7 +189,7 @@ void i86_set_context(void *src)
 		I.base[DS] = SegBase(DS);
 		I.base[ES] = SegBase(ES);
 		I.base[SS] = SegBase(SS);
-		change_pc16(I.pc);
+		change_pc20(I.pc);
 	}
 }
 
@@ -586,7 +586,7 @@ static void v30_interrupt(unsigned int_num, BOOLEAN md_flag)
 	I.sregs[CS] = (WORD) dest_seg;
 	I.base[CS] = SegBase(CS);
 	I.pc = (I.base[CS] + dest_off) & AMASK;
-	change_pc16(I.pc);
+	change_pc20(I.pc);
 /*	logerror("=%06x\n",activecpu_get_pc()); */
 }
 

--- a/src/cpu/i86/i86.h
+++ b/src/cpu/i86/i86.h
@@ -95,7 +95,7 @@ typedef enum { AH,AL,CH,CL,DH,DL,BH,BL,SPH,SPL,BPH,BPL,SIH,SIL,DIH,DIL } BREGS;
 #define FETCHOP					(cpu_readop(I.pc++))
 #define PEEKOP(addr)			(cpu_readop(addr))
 #define FETCHWORD(var) 			{ var = cpu_readop_arg(I.pc); var += (cpu_readop_arg(I.pc + 1) << 8); I.pc += 2; }
-#define CHANGE_PC(addr)			change_pc16(addr)
+#define CHANGE_PC(addr)			change_pc20(addr)
 #define PUSH(val)				{ I.regs.w[SP] -= 2; WriteWord(((I.base[SS] + I.regs.w[SP]) & AMASK), val); }
 #define POP(var)				{ var = ReadWord(((I.base[SS] + I.regs.w[SP]) & AMASK)); I.regs.w[SP] += 2; }
 

--- a/src/wpc/driver.c
+++ b/src/wpc/driver.c
@@ -1388,6 +1388,7 @@ DRIVER  (harl,l13)      //           10/99 Harley-Davidson (Sega, 1.03 Spanish)
 // ----------------
 DRIVERNV(bikerace)      // 1992 - Bike Race
 DRIVERNV(bikerac2)      // 1992 - Bike Race (2-ball play)
+DRIVERNV(bikerac3)      // 1992 - Bike Race (V4.1)
 DRIVERNV(sleicpin)      // 1993 - Sleic Pin-Ball
 DRIVERNV(iomoon)        // 1994 - Io Moon
                         // 1996 - Dona Elvira 2

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -88,23 +88,114 @@ static INTERRUPT_GEN(sleic3_irq_gen) {
   else if (sleic3_int0_acc >= 1.0) { sleic3_int0_acc -= 1.0; cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x0C); }
 }
 
+/* How the panel's two raster fields are weighted, which differs per machine because the
+ * two games ship different I8039 display ROMs:
+ *
+ *   Sleic Pin-Ball (sp01-1_1.rom): both fields hold the row lit for essentially the same
+ *     time -- P1.7 is raised for MOV R6,#30 / DJNZ (98 cycles) in field 1 against
+ *     MOV R6,#2E / DJNZ (94 cycles) in field 2, a ratio of 1.04:1.  Two equal fields give
+ *     THREE levels, not four: off, one plane (either one, ~50%), both planes (100%).  The
+ *     artwork agrees -- in the source images the field-1 plane is a strict subset of the
+ *     field-2 plane (e.g. at F000:9943: 0 pixels in field 1 only, 769 in field 2 only,
+ *     872 in both), so the pair encodes "lit" plus "lit brightly", not a 2-bit number.
+ *     Both single-plane states do occur in the frame buffer during play (measured over a
+ *     scripted game: 7.9% of pixels field-1-only, 7.4% field-2-only), and the real panel
+ *     shows them at the SAME brightness -- rendering them two levels apart is what made
+ *     the shading look wrong against the machine.
+ *
+ *   Bike Race (bkdsp01.bin): field 1 carries an extra MOV R6,#20 / DJNZ dwell (66 cycles)
+ *     that field 2 does not have at all, so the fields are strongly asymmetric and the
+ *     pair really is a weighted 2-bit value.  Keep the 4-level mapping there.
+ *
+ * Set in MACHINE_INIT; SLEIC1 (Sleic Pin-Ball) overrides it. */
+static int sleic_dmd_equal_fields;
+
+/* Decode the 2-bitplane frame buffer at 0x60410 into a 128x32 brightness grid.
+ * See the plane/weighting notes in SLEIC_irq_i8039 below. */
+static void sleic3_build_dmd_frame(UINT8 *dst) {
+  int ii, jj, kk;
+  const UINT8 *buf = memory_region(SLEIC_MEMREG_CPU) + 0x60410;
+  for (ii = 0; ii < 32; ii++) {
+    UINT8 *line = dst + ii * 128;
+    const UINT8 *src = buf + ii * 32;
+    for (jj = 0; jj < 16; jj++) {
+      UINT8 f1 = src[jj];            /* plane lit by raster field 1 (rows 0x00-0x1F) */
+      UINT8 f2 = src[jj + 0x800];    /* plane lit by raster field 2 (rows 0x20-0x3F) */
+      for (kk = 7; kk >= 0; kk--) {
+        int a = (f1 >> kk) & 1, b = (f2 >> kk) & 1;
+        *line++ = sleic_dmd_equal_fields ? (a | b ? (a & b ? 3 : 2) : 0)  /* 3 levels  */
+                                         : ((a << 1) | b);                /* 4 levels  */
+      }
+    }
+  }
+}
+
+/* Bike Race V4.1 rebuilds the panel from scratch every frame: it strobes PCS4 bit 3 to
+ * announce a finished frame, then takes the DMD lock (PCS0 bit 0) to blank-clear all
+ * 0x2FFF bytes, drops it, and redraws.  Sampling the buffer freely -- as the I8039 tick
+ * below does -- therefore catches cleared and half-drawn states, which is exactly the
+ * garbage that set showed.  So latch a copy at the strobe and keep displaying it: the
+ * I8039 tick still submits at the panel rate (which the DMD PWM integrator wants), it
+ * just submits complete frames.
+ *
+ * The latch has to lapse rather than stay on for good.  The 1992 sets redraw the panel
+ * incrementally and are perfectly stable to sample, and they strobe bit 3 exactly once,
+ * during init -- latching on that one strobe and holding it freezes them on an empty
+ * frame.  So a strobe only claims the next second of ticks: if the strobes keep coming
+ * the latch stays in charge (V4.1 strobes every ~90 ms), and if they stop we fall back
+ * to sampling the buffer directly, which is safe precisely because a redraw is always
+ * followed by a strobe. */
+#define SLEIC3_DMD_LATCH_TICKS 244       /* ~1 s at the 244 Hz I8039 tick */
+static UINT8 sleic3_dmd_latch[128 * 32];
+static int   sleic3_dmd_latch_ttl;
+
 static INTERRUPT_GEN(SLEIC_irq_i8039) {
   cpu_set_irq_line(SLEIC_DISPLAY_CPU, 0, PULSE_LINE);
 
   /* The I8039 is a pure timing generator (drives only the panel scan), so we read
-   * the 80188's DMD frame buffer directly. The buffer at 0x60410 has a 32-byte row
-   * stride: 16 bytes (= 128 px, MSB first, 1 = lit) of pixel data, then 16 unused. */
-  int ii, jj, kk;
-  UINT8 *buf = memory_region(SLEIC_MEMREG_CPU) + 0x60410;
-  for (ii = 0; ii < 32; ii++) {
-    UINT8 *line = &locals.rawDMD[ii * 128];
-    UINT8 *src  = buf + ii * 32;
-    for (jj = 0; jj < 16; jj++) {
-      UINT8 b = src[jj];
-      for (kk = 7; kk >= 0; kk--)
-        *line++ = (b >> kk) & 1 ? 3 : 0;
-    }
+   * the 80188's DMD frame buffer directly.  The panel is a 2-bitplane PWM display
+   * with 4 brightness levels; both planes live in the frame buffer at 0x60410:
+   *
+   *   plane 0 : 0x60410 + row*0x20, 16 bytes (= 128 px, MSB first, 1 = lit)
+   *   plane 1 : same, +0x800
+   *
+   * (the 16 bytes following each row's plane 0 are unused padding).  The layout is
+   * written by the 80188 frame blitter at F000:08AF in bkcpu04:
+   *     mov di,0410h / mov cx,20h / mov bx,0800h
+   *     mov al,ds:[bp+si] / mov es:[bx+di],al   ; plane 1 -> +0x800
+   *     lodsb / stosb                           ; plane 0 -> +0x000
+   *     add di,20h                              ; row stride 32
+   *
+   * That there are two differently weighted fields (and not just two copies of one
+   * image) comes from the I8039 raster loop in bkdsp01 -- the whole program is 116
+   * bytes: it scans the row counter twice per refresh, 0x00-0x1F then 0x20-0x3F, and
+   * the first field carries an extra dwell (MOV R6,#20 / DJNZ R6,$ at 0x0032) that
+   * the second does not, so row-counter bit 5 picks the plane and the two fields are
+   * lit for different lengths of time.  Bit 5 is the long-dwell field when clear, which
+   * makes the +0x000 plane the bright one -- the MSB.
+   *
+   * That cannot be read off the raster loop alone, because the 80188 sees the panel RAM
+   * through a scrambled decode (the buffer base 0x410 holds A10 and A4 high, rows step
+   * A5-A9, the plane is A11), so bit 5 cannot be traced to A11 without the board's PAL.
+   * What settles it is how Sleic Pin-Ball actually uses the two planes in play: of 822
+   * distinct in-game frames captured over a scripted game, 613 are drawn entirely into
+   * the +0x000 plane and none of the rest use +0x800 on its own.  The whole ordinary
+   * display -- score, JUGADOR/BOLA, the text screens -- is that one plane, and on the
+   * real machine it reads as a normally bright display with only the highlights (both
+   * planes) hotter.  Making +0x000 the LSB would run the entire game at one third
+   * brightness and leave the two brighter levels almost unused, which is not what the
+   * hardware does.  This also agrees with the blitter, where +0x000 is the primary
+   * lodsb/stosb stream, and with Io Moon's decode above, where the base plane is the
+   * MSB.  (A statistic over the attract animation appears to favour the opposite
+   * assignment by counting single-level pixel steps; it does not, because it assumes
+   * fades are done by toggling the LSB when this firmware fades by toggling the main
+   * plane, which is a two-level step.) */
+  if (sleic3_dmd_latch_ttl > 0) {        /* firmware is announcing completed frames */
+    sleic3_dmd_latch_ttl--;
+    memcpy(locals.rawDMD, sleic3_dmd_latch, sizeof locals.rawDMD);
   }
+  else
+    sleic3_build_dmd_frame(locals.rawDMD);
   sleic_dmd_dump(locals.rawDMD);
   core_dmd_submit_frame(core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout, locals.rawDMD, 1);
 }
@@ -246,6 +337,17 @@ static WRITE_HANDLER(pic_w) {
   logerror("PIC W(%03x->%2x) = %02x\n", offset, offset>>7, data);
 }
 
+/* Io Moon submits its DMD from the display pointer at 4000:1150 when the firmware
+ * strobes PCS4 bit 3.  Bike Race and Sleic Pin-Ball instead have an I8039 that rasters
+ * the panel out of the 0x60410 frame buffer, and their 4000:1150 is ordinary work RAM,
+ * so the pointer-based submit must not run for them -- it would push whatever that RAM
+ * happens to hold as a frame.  Set in MACHINE_INIT(SLEIC) from the presence of the
+ * display CPU.  (Bike Race V4.1 made this visible: it clears and redraws the panel
+ * every frame and strobes PCS4 bit 3 each time -- 114 strobes in a 600-frame run,
+ * against a single one from the 1992 sets -- so the bogus frames swamped the real
+ * ones and the DMD showed garbage.) */
+static int sleic_dmd_from_ptr;
+
 /* Snapshot the 2-bitplane DMD frame buffer and submit the 128x32 brightness
  * grid to PinMAME's DMD core. Each plane is 512 bytes (32 rows x 16 bytes,
  * MSB = leftmost pixel); plane 0 weighted x2, plane 1 x1 -> 4 grey levels.
@@ -357,7 +459,14 @@ static WRITE_HANDLER(sleic_periph_w) {
       cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE);
       break;
     case 0x200:                          /* PCS4: DMD mode; bit 3 = frame swap */
-      if (data & 0x08) sleic_submit_dmd_frame();  /* buffer-swap ack is emitted by the PIC phase machine */
+      if (data & 0x08) {
+        if (sleic_dmd_from_ptr)
+          sleic_submit_dmd_frame();      /* Io Moon: buffer-swap ack is emitted by the PIC phase machine */
+        else {                           /* I8039 machines: latch the finished 0x60410 frame */
+          sleic3_build_dmd_frame(sleic3_dmd_latch);
+          sleic3_dmd_latch_ttl = SLEIC3_DMD_LATCH_TICKS;
+        }
+      }
       break;
     default:
       logerror("SLEIC periph A000:%03X = %02x\n", offset, data);
@@ -826,6 +935,12 @@ MEMORY_END
 
 static MACHINE_INIT(SLEIC) {
   memset(&locals, 0, sizeof locals);
+  /* Only Io Moon lacks the I8039 display CPU, and only Io Moon uses the 4000:1150
+   * display-pointer submit on the PCS4 bit-3 strobe. */
+  sleic_dmd_from_ptr = (Machine->drv->cpu[SLEIC_DISPLAY_CPU].cpu_type == CPU_DUMMY);
+  sleic_dmd_equal_fields = 0;        /* Bike Race weighting; SLEIC1 overrides below */
+  memset(sleic3_dmd_latch, 0, sizeof sleic3_dmd_latch);
+  sleic3_dmd_latch_ttl = 0;
   memset(&sleic_io, 0, sizeof sleic_io);
   sleic_oki_latch = sleic_oki_prev_strobe = 0;
   sleic_oki_pending = 0;
@@ -846,6 +961,13 @@ static MACHINE_INIT(SLEIC) {
    *     Z80 ROMs; the key bindings already exist in sleic3_pf_keys below.)
    * The driver does not fabricate the ball complement -- the frontend (Visual Pinball)
    * supplies trough state; the keys above are only for standalone testing. */
+}
+
+/* Sleic Pin-Ball's display ROM lights both raster fields for the same time, so its panel
+ * has three levels rather than four -- see sleic_dmd_equal_fields above. */
+static MACHINE_INIT(SLEIC1) {
+  machine_init_SLEIC();
+  sleic_dmd_equal_fields = 1;
 }
 
 /* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch
@@ -969,6 +1091,7 @@ MACHINE_DRIVER_END
 
 MACHINE_DRIVER_START(SLEIC1)
   MDRV_IMPORT_FROM(SLEIC)
+  MDRV_CORE_INIT_RESET_STOP(SLEIC1,NULL,NULL)
 
   // Sleic Pin-Ball cabinet/direct switches (C31-C36) -> swMatrix[9]; playfield
   // matrix via sleic1_pf_keys -> swMatrix[1..8].

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -6,14 +6,12 @@
 
    Hardware:
    ---------
-		CPU:     I80C188 @ ??? for game & sound,
-		         I80C39 @ ??? for DMD display,
-		         Z80 @ ??? for I/O
-		    INT: IRQ @ ???
-		DISPLAY: DMD
-		SOUND:   YM3812 @ ???,
-		         DAC,
-		         OKI6376 @ 2 or 4 MHz for speech / FX
+		CPU:     I80C188 for game & sound (drives YM3812 + OKI MSM6376 directly),
+		         DMD coprocessor: I80C39 (Bike Race / Sleic Pin-Ball),
+		         Z80 for I/O (switches/lamps/solenoids; forwards sound cmds over J1)
+		DISPLAY: DMD 128x32
+		SOUND:   YM3812 (OPL2 FM music) + OKI MSM6376 (ADPCM speech/FX),
+		         both driven by the 80188.
  ************************************************************************************************/
 
 #include "driver.h"
@@ -22,6 +20,7 @@
 #include "sound/adpcm.h"
 #include "sound/3812intf.h"
 #include "sleic.h"
+#include <stdlib.h>
 
 /*----------------
 /  Local variables
@@ -35,6 +34,26 @@ static struct {
   UINT8  rawDMD[128 * 32];
 } locals;
 
+/* DEBUG: env-gated DMD frame capture for headless verification.
+ * Set SLEIC_DMD_DUMP=/path/prefix to append one PGM (P5, 128x32) per submitted
+ * frame as /path/prefix.<seq>.pgm. No env var set = no-op. */
+static void sleic_dmd_dump(const UINT8 *frame) {
+  const char *pfx = getenv("SLEIC_DMD_DUMP");
+  static int seq = 0;
+  char fn[512];
+  FILE *fp;
+  int i;
+  if (!pfx) return;
+  snprintf(fn, sizeof fn, "%s.%05d.pgm", pfx, seq++);
+  if (!(fp = fopen(fn, "wb"))) return;
+  fprintf(fp, "P5\n128 32\n255\n");
+  for (i = 0; i < 128 * 32; i++) {
+    unsigned v = frame[i];                 /* brightness 0..3 */
+    fputc((int)(v > 3 ? v : v * 85), fp);  /* 0..3 -> 0,85,170,255 */
+  }
+  fclose(fp);
+}
+
 // switches start at 50 for column 1, and each column adds 10.
 static int SLEIC_sw2m(int no) { return (no/10 - 4)*8 + no%10; }
 static int SLEIC_m2sw(int col, int row) { return 40 + col*10 + row; }
@@ -43,26 +62,50 @@ static INTERRUPT_GEN(SLEIC_irq_i80188) {
   cpu_set_irq_line(SLEIC_MAIN_CPU, 0, PULSE_LINE);
 }
 
+/* Sleic Pin-Ball (SLEIC1) 80C188 interrupt: the firmware enables ONLY the internal
+ * Timer0 interrupt (reset PCB init at F000:FEAC: T0CON=0xE003 enable+int, T0CMPA/B=
+ * 0x4000, TCUCON=0x0003 unmasked; INT0-3/DMA0-1 all masked).  Timer0 clocks at
+ * CPU/4 = 2 MHz, so it fires ~122 Hz, vector type 0x08 -> ISR F000:DF7F, which
+ * decrements the firmware's delay counters ([0x4DF] etc.).  The PinMAME i188 core
+ * does not emulate the internal timer, so we must inject the Timer0 vector here.
+ * The base SLEIC_irq_i80188 pulses IRQ0 WITHOUT a vector, so the ISR never runs and
+ * the post-boot delay loops (e.g. E000:0050 'mov [0x4DF],0x12C; spin until 0') hang
+ * forever -> blank DMD.  Deliver vector 0x08 like the working Bike Race path. */
+static INTERRUPT_GEN(sleic1_irq_gen) {
+  cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x08);
+}
+
+/* Bike Race (SLEIC3): Timer0 (type 0x08) = 99.18 Hz (T0CON/T0CMP); INT0
+ * (type 0x0C) = 72.5 Hz frame strobe (the 145 Hz DMD wire rate / 2 bitplanes);
+ * NMI (type 0x02) is the J1-byte-arrival interrupt, strobe-driven from
+ * sleic3_z80_write (not periodic). No IVT memcpy here: bkcpu04 copies its own
+ * IVT (CS:00C4) to physical 0 before STI, so physical 0 must not be clobbered. */
+static double sleic3_int0_acc, sleic3_t0_acc;
+static INTERRUPT_GEN(sleic3_irq_gen) {
+  sleic3_t0_acc   += 99.18 / 244.0;
+  sleic3_int0_acc += 72.5 / 244.0;
+  if (sleic3_t0_acc >= 1.0)        { sleic3_t0_acc   -= 1.0; cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x08); }
+  else if (sleic3_int0_acc >= 1.0) { sleic3_int0_acc -= 1.0; cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x0C); }
+}
+
 static INTERRUPT_GEN(SLEIC_irq_i8039) {
   cpu_set_irq_line(SLEIC_DISPLAY_CPU, 0, PULSE_LINE);
 
-  // The IRQ is the VSYNC, as we are not emulating the rasterizer, we process the video frames here
+  /* The I8039 is a pure timing generator (drives only the panel scan), so we read
+   * the 80188's DMD frame buffer directly. The buffer at 0x60410 has a 32-byte row
+   * stride: 16 bytes (= 128 px, MSB first, 1 = lit) of pixel data, then 16 unused. */
   int ii, jj, kk;
-  UINT16 *RAM;
-  RAM = (void *)(memory_region(SLEIC_MEMREG_CPU) + 0x60410);
+  UINT8 *buf = memory_region(SLEIC_MEMREG_CPU) + 0x60410;
   for (ii = 0; ii < 32; ii++) {
     UINT8 *line = &locals.rawDMD[ii * 128];
+    UINT8 *src  = buf + ii * 32;
     for (jj = 0; jj < 16; jj++) {
-      for (kk = 7; kk >= 0; kk--) {
-        *line++ = (RAM[0]>>kk) & 1 ? 3 : 0;
-      }
-      for (kk = 15; kk > 7; kk--) {
-        *line++ = (RAM[0]>>kk) & 1 ? 3 : 0;
-      }
-      RAM++;
+      UINT8 b = src[jj];
+      for (kk = 7; kk >= 0; kk--)
+        *line++ = (b >> kk) & 1 ? 3 : 0;
     }
-    *line = 0;
   }
+  sleic_dmd_dump(locals.rawDMD);
   core_dmd_submit_frame(core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout, locals.rawDMD, 1);
 }
 
@@ -94,6 +137,87 @@ static void showData(int data) {
 }
 #endif /* MAME_DEBUG */
 
+/* DEBUG: env-gated headless test harness.  Nothing below has any effect unless the
+ * matching environment variable is set -- in normal use the frontend (Visual Pinball)
+ * supplies ball and switch state, and standalone play uses the key maps further down.
+ *
+ *   SLEIC_INJECT_CAB=<hex>  hold cabinet bits in swMatrix[9]
+ *   SLEIC_INJECT_COL=<n> + SLEIC_INJECT_BIT=<hex>   hold one matrix position
+ *   SLEIC_TROUGH[=<hex>]    close this game's ball-trough optos once the machine is up;
+ *                           the optional value overrides the per-game default mask
+ *   SLEIC_BALLSAT=<frame>   when that happens (default 400).  A full trough from frame 0
+ *                           is not "balls in the machine", it is optos that failed during
+ *                           power-up, which the firmware reports as a fault.
+ *   SLEIC_PLAY="f:what,..." scripted cabinet presses at frame f; what is one of
+ *                           coin, start, test, lflip, rflip, tilt
+ *   SLEIC_HOLD=<frames>     how long each scripted press is held (default 10)
+ */
+static void sleic_debug_switches(int troughCol, UINT8 troughDefault) {
+  static int frame = 0;
+  const char *e, *col, *bit;
+  frame++;
+
+  if ((e = getenv("SLEIC_INJECT_CAB")))
+    coreGlobals.swMatrix[9] |= (UINT8)strtol(e, NULL, 0);
+  col = getenv("SLEIC_INJECT_COL"); bit = getenv("SLEIC_INJECT_BIT");
+  if (col && bit)
+    coreGlobals.swMatrix[strtol(col, NULL, 0) & 0xf] |= (UINT8)strtol(bit, NULL, 0);
+
+  if ((e = getenv("SLEIC_TROUGH"))) {
+    const char *at  = getenv("SLEIC_BALLSAT");
+    const char *off = getenv("SLEIC_TROUGHOFF");
+    const UINT8 mask = (e[0] && e[0] != '1') ? (UINT8)strtol(e, NULL, 0) : troughDefault;
+    const int from = at ? (int)strtol(at, NULL, 10) : 400;
+    /* The optos are only closed between BALLSAT and TROUGHOFF: a ball that never leaves
+     * the trough is a ball that never reaches play, so holding them shut for the whole
+     * run keeps the game out of ball-in-play (and therefore silent). */
+    const int to = off ? (int)strtol(off, NULL, 10) : 0;
+    if (frame >= from && (!to || frame < to))
+      coreGlobals.swMatrix[troughCol] |= mask;
+  }
+
+  /* SLEIC_SWEEP=<col-lo>-<col-hi> pulses each matrix position in turn from SLEIC_SWEEPAT
+   * (default 1500), SLEIC_SWEEPHOLD frames each (default 6): playfield activity that a
+   * cabinet button alone cannot produce, so the game actually scores. */
+  if ((e = getenv("SLEIC_SWEEP"))) {
+    const char *at = getenv("SLEIC_SWEEPAT"), *hd = getenv("SLEIC_SWEEPHOLD");
+    const int from = at ? (int)strtol(at, NULL, 10) : 1500;
+    const int hold = hd ? (int)strtol(hd, NULL, 10) : 6;
+    int lo = 1, hi = 8; char *q;
+    lo = (int)strtol(e, &q, 10); if (*q == '-') hi = (int)strtol(q + 1, NULL, 10); else hi = lo;
+    if (frame >= from) {
+      const int slot = (frame - from) / hold;          /* which position we are on   */
+      const int ncol = (hi - lo + 1);
+      const int idx  = slot % (ncol * 8);
+      coreGlobals.swMatrix[lo + idx / 8] |= (UINT8)(1u << (idx % 8));
+    }
+  }
+
+  if ((e = getenv("SLEIC_PLAY"))) {
+    const char *h = getenv("SLEIC_HOLD");
+    const int hold = h ? (int)strtol(h, NULL, 10) : 10;
+    const char *p = e;
+    while (*p) {
+      char *end;
+      long at = strtol(p, &end, 10);
+      p = end;
+      if (*p == ':') p++;
+      if (frame >= at && frame < at + hold) {
+        UINT8 b = 0;
+        if      (!strncmp(p, "coin",  4)) b = 0x20;
+        else if (!strncmp(p, "start", 5)) b = 0x10;
+        else if (!strncmp(p, "test",  4)) b = 0x02;
+        else if (!strncmp(p, "lflip", 5)) b = 0x08;
+        else if (!strncmp(p, "rflip", 5)) b = 0x04;
+        else if (!strncmp(p, "tilt",  4)) b = 0x01;
+        coreGlobals.swMatrix[9] |= b;
+      }
+      while (*p && *p != ',') p++;
+      if (*p == ',') p++;
+    }
+  }
+}
+
 static SWITCH_UPDATE(SLEIC) {
 #ifdef MAME_DEBUG
   static UINT8 data = 0;
@@ -118,7 +242,144 @@ static SWITCH_UPDATE(SLEIC) {
 }
 
 static WRITE_HANDLER(pic_w) {
+  if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data); /* DEBUG */
   logerror("PIC W(%03x->%2x) = %02x\n", offset, offset>>7, data);
+}
+
+/* Snapshot the 2-bitplane DMD frame buffer and submit the 128x32 brightness
+ * grid to PinMAME's DMD core. Each plane is 512 bytes (32 rows x 16 bytes,
+ * MSB = leftmost pixel); plane 0 weighted x2, plane 1 x1 -> 4 grey levels.
+ * cpu_readmem20 routes through the 80188 memory map (per docs/dmd_graphics.md). */
+static void sleic_submit_dmd_frame(void) {
+  int row, byte_idx, bit;
+  UINT8 *dst = locals.rawDMD;
+  unsigned p1ptr, s1ptr, base;
+  const core_tLCDLayout *layout = core_gameData->lcdLayout->importedLayout
+                                    ? core_gameData->lcdLayout->importedLayout
+                                    : core_gameData->lcdLayout;
+  /* The 80188 draws the DMD into the buffer addressed by the display pointer at
+   * 4000:1150 (offset p1, segment s1); the PIC rasters from there. seg 7000h is
+   * only a clear/staging area (always zero). Plane 0 = base, plane 1 = base+0x200. */
+  p1ptr = cpu_readmem20(0x41150) | (cpu_readmem20(0x41151) << 8);
+  s1ptr = cpu_readmem20(0x41152) | (cpu_readmem20(0x41153) << 8);
+  base  = (s1ptr << 4) + p1ptr;
+  for (row = 0; row < 32; row++) {
+    int row_offset = row * 16;
+    for (byte_idx = 0; byte_idx < 16; byte_idx++) {
+      UINT8 b0 = cpu_readmem20(base + row_offset + byte_idx);
+      UINT8 b1 = cpu_readmem20(base + 0x200 + row_offset + byte_idx);
+      for (bit = 7; bit >= 0; bit--) {
+        UINT8 p0 = (b0 >> bit) & 1;
+        UINT8 p1 = (b1 >> bit) & 1;
+        *dst++ = (p0 << 1) | p1;          /* plane 0 = MSB, plane 1 = LSB */
+      }
+    }
+  }
+  sleic_dmd_dump(locals.rawDMD);
+  core_dmd_submit_frame(layout, locals.rawDMD, 1);
+}
+
+/* PACS peripheral chip-select block at segment A000h (base 0xA0000,
+ * 7 selects PCS0-PCS6 on 0x80 boundaries):
+ *   0xA0000 PCS0  DMD control reg 1  AND the OKI /OKCS strobe (bit 5)
+ *   0xA0080 PCS1  DMD control reg 2
+ *   0xA0200 PCS4  DMD mode; bit 3 rising edge = swap-buffer / frame strobe
+ *   0xA0280 PCS5  YM3812 register/index port (A0=0)
+ *   0xA0281 PCS5  YM3812 data port          (A0=1)
+ *   0xA0300 PCS6  DMD enable (init 0x80)  AND the OKI control latch
+ *                 (phrase number in bits 0-6, channel select in bit 7)
+ *
+ * YM3812 (IC60) = in-game FM music; OKI MSM6376 (IC51) = speech/FX. OKI trigger
+ * model (exact latch bits await the IC7 PAL dump): a non-zero phrase written to
+ * 0xA0300 ARMS a phrase, the next /OKCS rising edge (0xA0000 bit 5) STARTS it. */
+static UINT8 sleic_oki_latch;        /* last byte written to PCS6 (0xA0300)          */
+static UINT8 sleic_oki_prev_strobe;  /* last byte written to PCS0 (0xA0000) for edge */
+static int   sleic_oki_pending;      /* a real phrase number is armed at 0xA0300     */
+
+/* J1 inbound byte latch (IC43 at 80188 PCS2 = 0xA0100): the last byte the Z80 strobed
+ * across the J1 port. The Z80's port-0x81 bit-2 strobe latches the byte AND raises the
+ * 80188 NMI; the NMI handler dmd_vblank_isr (D000:016D = IVT type 0x02) reads 0xA0100,
+ * pushes the byte into the display command queue at 4000:1220 and sets the frame-pending
+ * flag [4000:1147] that vsync_check (D000:5D1B) waits on. */
+static UINT8 sleic_j1_inbound;       /* PCS2 0xA0100 latch: last byte strobed by the Z80 */
+static UINT8 sleic_j1_fresh;         /* a new Z80 byte is waiting to be read by the 80188 */
+static UINT8 sleic_j1_prev_ctrl;     /* port 0x81 shadow for bit-2 strobe edge         */
+static UINT8 sleic_188_cmd;          /* Bike Race: the byte the 80188 wrote to PCS1 0xA0080, latched
+                                       * for the Z80 to read via IN port 0x00 in its NMI handler. */
+
+static void sleic_oki_trigger(void) {
+  UINT8 sample = sleic_oki_latch & 0x7f;                 /* phrase number      */
+  UINT8 voice  = (sleic_oki_latch & 0x80) ? 0x1 : 0x2;   /* ch A=v0 / ch B=v1  */
+  sleic_oki_pending = 0;
+  if (!sample) return;
+  if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[oki] phrase %02x\n", sample); /* DEBUG */
+  OKIM6376_data_0_w(0, 0x80 | sample);   /* latch phrase number          */
+  OKIM6376_data_0_w(0, voice << 4);      /* trigger playback on the voice */
+}
+
+static WRITE_HANDLER(sleic_periph_w) {
+  if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data); /* DEBUG */
+  switch (offset) {
+    case 0x280:                          /* PCS5: YM3812 port */
+      /* Bike Race wires the YM3812 to the single address 0xA0280 and toggles A0 in hardware
+       * per write, so it streams (register,value) pairs all to 0xA0280. */
+      {
+        static int ym_a0 = 0;
+        if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[ym] %s %02x\n", ym_a0?"data":"reg ", data); /* DEBUG */
+        if (ym_a0) YM3812_write_port_0_w(0, data); else YM3812_control_port_0_w(0, data);
+        ym_a0 ^= 1;
+      }
+      return;
+    case 0x300:                          /* PCS6: DMD enable + OKI ctrl latch */
+      sleic_oki_latch = data;
+      if (data & 0x7f) sleic_oki_pending = 1;  /* real phrase (not 0x80 DMD-enable) */
+      break;
+    case 0x000:                          /* PCS0: OKI /OKCS strobe (bit 4) */
+      {
+        /* /OKCS strobe: Bike Race pulses PCS0 bit 4 (0x10). (Exact decode awaits
+         * the IC7 PAL20L10 dump.) */
+        const UINT8 okcs = 0x10;
+        if (sleic_oki_pending && (data & okcs) && !(sleic_oki_prev_strobe & okcs))
+          sleic_oki_trigger();
+      }
+      sleic_oki_prev_strobe = data;
+      break;
+    case 0x080:                          /* PCS1: command byte the 80188 sends to the I/O side */
+      /* Boot-init 3-gate handshake over the J1 queue:
+       *   gate A: wait for 0x5F ("I/O ready", sent once by the Z80 at boot);
+       *   gate B: send cmd 0xD4, wait for a byte >0xF0 (else trap "IMPOSIBLE SEGUIR");
+       *   gate C: send cmd 0xD5, wait (no timeout) for ball-status 0x5B/5C/5D. */
+      /* Bike Race: deliver the command to the real Z80 firmware (bkio07) and assert its NMI.
+       * The Z80's NMI handler (0x0066) reads it via IN 0x00; cmd 0xD4 -> reply IN(0x04)|0xF0
+       * (gate B), cmd 0xD5 -> reply ball-status 0x5B/5C/5D (gate C), via the Z80's normal
+       * send path (port 0x80 + strobe -> 0xA0100). */
+      sleic_188_cmd = data;
+      cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE);
+      break;
+    case 0x200:                          /* PCS4: DMD mode; bit 3 = frame swap */
+      if (data & 0x08) sleic_submit_dmd_frame();  /* buffer-swap ack is emitted by the PIC phase machine */
+      break;
+    default:
+      logerror("SLEIC periph A000:%03X = %02x\n", offset, data);
+      break;
+  }
+}
+
+static READ_HANDLER(sleic_periph_r) {
+  if (offset == 0x100) {                 /* PCS2: Z80->J1 inbound byte latch (IC43 74LS244) */
+    /* Consume-on-read: return the fresh Z80 byte if one was strobed over J1, else the
+     * idle value 0x37 (Bike Race's NMI treats 0x37 as "no event"). */
+    { UINT8 v;
+      if (sleic_j1_fresh) { sleic_j1_fresh = 0; v = sleic_j1_inbound; }   /* a freshly strobed Z80 byte */
+      else v = 0x37;                                                          /* idle: "no event" */
+      return v;
+    }
+  }
+  if (offset == 0x180)                   /* PCS1: DMD controller status -- bit 0 = ready for a command */
+    return 0x01;
+  if (offset == 0x280)                   /* PCS5: YM3812 status */
+    return YM3812_status_port_0_r(0);
+  return 0;                              /* PCS3 /OKBUSY etc. -- report not-busy */
 }
 
 /* handler called by the 3812 when the internal timers cause an IRQ */
@@ -154,6 +415,7 @@ static READ_HANDLER(read_0) {
   return 0;
 }
 
+
 static MEMORY_READ_START(SLEIC_80188_readmem)
   {0x00000,0x01fff, MRA_RAM},
   {0x10100,0x10900, read_0 /* MRA_RAM */},
@@ -166,6 +428,142 @@ static MEMORY_WRITE_START(SLEIC_80188_writemem)
   {0x10100,0x10900, MWA_RAM, &generic_nvram, &generic_nvram_size},
   {0xa0000,0xa07ff, pic_w},
   {0x60410,0x6340f, MWA_RAM},
+MEMORY_END
+
+/* Sleic Pin-Ball (SLEIC1) NVRAM. The base SLEIC map above maps NVRAM reads to
+ * read_0 (returns 0) and writes to a separate generic_nvram buffer, so the
+ * firmware's boot-time self-repair can never be read back -> the boot's signature
+ * re-validation always fails -> "Memoria EEPROM en mal estado / Imposible Seguir".
+ * (Boot: validate F000:80F5, on fail call factory-init F000:818D, re-validate,
+ *  still-fail -> error F000:49E8 + halt.  See research/sleicpin_disasm/eeprom_findings.md.)
+ * Fix: one coherent buffer for both reads and writes, persisted by NVRAM_HANDLER.
+ * The 80188 accesses NVRAM in segment 0x1000; the factory-init clears offset
+ * 0x000-0xFFF and writes signature/config blocks, so map the full 28C64A-class
+ * 8 KB window 0x10000-0x11FFF.  No embedded factory image is needed: on a fresh
+ * boot the firmware seeds valid defaults itself, then core_nvram persists them. */
+#define SLEIC1_NVRAM_BASE 0x10000
+#define SLEIC1_NVRAM_SIZE 0x2000
+static UINT8 sleic1_nvram[SLEIC1_NVRAM_SIZE];
+static READ_HANDLER(sleic1_nvram_r)  { return sleic1_nvram[offset]; }
+static WRITE_HANDLER(sleic1_nvram_w) { sleic1_nvram[offset] = data; }
+static NVRAM_HANDLER(SLEIC1) {
+  core_nvram(file, read_or_write, sleic1_nvram, sizeof sleic1_nvram, 0x00);
+}
+
+/* Sleic Pin-Ball (SLEIC1) YM3812 A0 latch (PCS0 0xA0000 bit 1): 0 = register/index
+ * port, 1 = data port.  sleicpin streams (register,value) pairs all to ONE address
+ * 0xA0280 and selects register-vs-data via PCS0 bit 1 (set by the FM write primitive
+ * at sp03 file 0x1E5E just before each 0xA0280 write) -- NOT 0x280/0x281 (IO Moon) and
+ * NOT simple per-write alternation (Bike Race). */
+static UINT8 sleic1_ym_a0;
+
+/* Sleic Pin-Ball (SLEIC1) 80188 peripheral write.  Two roles confirmed against sp03:
+ *
+ *  PCS1 (0xA0080) = reverse path: the command byte the 80188 sends to the Z80 I/O
+ *    side.  It latches to Z80 port 0x00 and raises the Z80 NMI (handler 0x0066), whose
+ *    buffered commands set the Z80's menu-mode flag [0xC051] (which gates the flipper
+ *    nav codes in the service menu) AND the lamp/solenoid data.  Without this the Z80
+ *    never learns it is in menu mode (flippers fire coils instead of scrolling) and
+ *    gets no lamp data (dark matrix).
+ *
+ *  SOUND (sp03 0x1AEF/0x1E05): the 80188 drives BOTH chips.
+ *    PCS5 (0xA0280)  = YM3812 register/data (A0 from PCS0 bit 1; see sleic1_ym_a0).
+ *    PCS6 (0xA0300)  = OKI MSM6376 phrase latch (the phrase number, sp03 0x1B36/0x1B47).
+ *    PCS0 (0xA0000)  = shared control shadow [0x4da]: bit1 = YM3812 A0, bit4 (0x10) =
+ *                      OKI /OKCS strobe (rising edge fires the latched phrase, sp03
+ *                      0x1B6B), bit3 (0x08) = OKI channel.
+ *
+ * PCS4 (0xA0200) is the DMD frame strobe (shadow [0x4de]) -- left alone, since the
+ * I8039 renders sleicpin's DMD from 0x60410 (calling sleic_submit_dmd_frame would
+ * corrupt it). */
+static WRITE_HANDLER(sleic1_periph_w) {
+  switch (offset) {
+    case 0x080:                          /* PCS1: 80188 -> Z80 command (reverse path) */
+      sleic_188_cmd = data;
+      cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE);
+      return;
+    case 0x280:                          /* PCS5: YM3812 (FM music) register or data */
+      if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[ym] %s %02x\n", sleic1_ym_a0?"data":"reg ", data);
+      if (sleic1_ym_a0) YM3812_write_port_0_w(0, data);
+      else              YM3812_control_port_0_w(0, data);
+      return;
+    case 0x300:                          /* PCS6: OKI MSM6376 phrase latch */
+      sleic_oki_latch = data;
+      if (data & 0x7f) sleic_oki_pending = 1;
+      return;
+    case 0x000:                          /* PCS0: shared control (bit1 YM A0, bit4 /OKCS) */
+      sleic1_ym_a0 = (data >> 1) & 1;
+      if (sleic_oki_pending && (data & 0x10) && !(sleic_oki_prev_strobe & 0x10)) {
+        sleic_oki_trigger();
+      }
+      sleic_oki_prev_strobe = data;
+      return;
+    default:                             /* PCS3 / PCS4 DMD strobe (I8039 renders) / etc. */
+      if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
+      return;
+  }
+}
+
+static MEMORY_READ_START(SLEIC1_80188_readmem)
+  {0x00000,0x01fff, MRA_RAM},
+  {SLEIC1_NVRAM_BASE, SLEIC1_NVRAM_BASE+SLEIC1_NVRAM_SIZE-1, sleic1_nvram_r}, /* 28C64A NVRAM (seg 0x1000) */
+  {0xa0000,0xa0fff, sleic_periph_r},                                         /* PACS peripheral read; PCS2 0xA0100 = J1 inbound switch latch (NMI F000:DF20) */
+  {0x60410,0x6340f, MRA_RAM},
+  {0x80000,0xfffff, MRA_ROM},
+MEMORY_END
+
+static MEMORY_WRITE_START(SLEIC1_80188_writemem)
+  {0x00000,0x01fff, MWA_RAM},
+  {SLEIC1_NVRAM_BASE, SLEIC1_NVRAM_BASE+SLEIC1_NVRAM_SIZE-1, sleic1_nvram_w}, /* 28C64A NVRAM (seg 0x1000) */
+  {0xa0000,0xa0fff, sleic1_periph_w},                                        /* PACS write; PCS1 0xA0080 = 80188->Z80 cmd (Z80 NMI reverse path) */
+  {0x60410,0x6340f, MWA_RAM},
+MEMORY_END
+
+/* Bike Race (SLEIC3) 80188 map. MMCS=0x01FF / MPCS=0xC0FC decode a 512 KB
+ * mid-range block based at 0, split into four 128 KB chip-selects MCS0-3:
+ *   MCS0 0x00000-0x1FFFF : work RAM (boot stack 012F:0203; the boot copies its IVT
+ *                          image from CS:00C4 to physical 0 before STI, so the
+ *                          driver must NOT overwrite the IVT)
+ *   MCS1 0x20000-0x3FFFF : graphics ROM bkcpu05
+ *   MCS2 0x40000-0x5FFFF : graphics ROM bkcpu06 (read via ES=0x5000)
+ *   MCS3 0x60000-0x7FFFF : DMD / video frame buffer RAM (panel staging at 0x60410)
+ * PACS=0xA03C -> peripheral block at 0xA0000, so sleic_periph_r/w are used.
+ * UMCS -> bkcpu04 code at 0xE0000-0xFFFFF (reset EA F000:0000). */
+
+/* Bike Race NVRAM (28C64A, 8 KB at seg 0x1040): read/written through a dedicated buffer
+ * that NVRAM_HANDLER(SLEIC3) persists via core_nvram, which zero-fills it on a fresh boot
+ * exactly like every other driver here.
+ *
+ * Nothing seeds a factory image.  On a blank NVRAM the firmware's own reset routine
+ * (bkcpu04 E97DB, reached at E520C) puts up "ESTABLECIENDO VALORES FABRICA / PULSE START"
+ * and waits (E9425/E9478) for an operator START press (J1 event 0x36), then writes the
+ * coin/credit (0x230-0x23B), high-score and audit tables itself (E9805+).  That is what a
+ * real machine does with a new battery-backed chip, so it is what the driver does: press
+ * START once at the prompt and the game seeds itself, persisting to the .nv from then on.
+ * (Sleic Pin-Ball differs -- its boot repairs a blank NVRAM silently at F000:818D.) */
+static UINT8 sleic3_nvram[0x2000];
+static READ_HANDLER(sleic3_nvram_r)  { return sleic3_nvram[offset]; }
+static WRITE_HANDLER(sleic3_nvram_w) { sleic3_nvram[offset] = data; }
+static NVRAM_HANDLER(SLEIC3) {
+  core_nvram(file, read_or_write, sleic3_nvram, sizeof sleic3_nvram, 0x00);
+}
+
+static MEMORY_READ_START(SLEIC3_80188_readmem)
+  {0x00000,0x103ff, MRA_RAM},                  /* MCS0: work RAM (IVT@0, stack, data) */
+  {0x10400,0x123ff, sleic3_nvram_r},           /* MCS0: 28C64A 8KB NVRAM (persisted by NVRAM_HANDLER(SLEIC3)) */
+  {0x12400,0x1ffff, MRA_RAM},                  /* MCS0: work RAM (rest) */
+  {0x20000,0x5ffff, MRA_ROM},                  /* MCS1/MCS2: graphics ROM (bkcpu06/05)     */
+  {0x60000,0x7ffff, MRA_RAM},                  /* MCS3: DMD / video frame buffer (0x60410) */
+  {0xa0000,0xa0fff, sleic_periph_r},          /* PACS peripheral block: J1+OKI+YM3812 */
+  {0xe0000,0xfffff, MRA_ROM},                  /* bkcpu04 game/sound code (E000/F000) */
+MEMORY_END
+
+static MEMORY_WRITE_START(SLEIC3_80188_writemem)
+  {0x00000,0x103ff, MWA_RAM},                  /* MCS0: work RAM (IVT@0, stack, data) */
+  {0x10400,0x123ff, sleic3_nvram_w},           /* MCS0: 28C64A 8KB NVRAM (seg 0x1040) */
+  {0x12400,0x1ffff, MWA_RAM},                  /* MCS0: work RAM (rest) */
+  {0x60000,0x7ffff, MWA_RAM},                  /* MCS3: DMD / video frame buffer */
+  {0xa0000,0xa0fff, sleic_periph_w},          /* PACS peripheral block: J1+OKI+YM3812 */
 MEMORY_END
 
 static MEMORY_READ_START(SLEIC_8039_readmem)
@@ -185,7 +583,9 @@ static MEMORY_WRITE_START(SLEIC_Z80_writemem)
 MEMORY_END
 
 static WRITE_HANDLER(i80188_write_port) {
-  logerror("80188 internal w %02x:%x %02x\n", offset / 2, offset % 2, data);
+  /* 80188 internal Peripheral Control Block writes (chip-selects at 0xFFA0+, timer/
+   * interrupt-controller config, EOI at 0xFF2C). The I188 core does not model these;
+   * they are no-ops here. The interrupt sources are generated by sleic3_irq_gen. */
 }
 
 static READ_HANDLER(i8039_read_test) {
@@ -238,6 +638,82 @@ static WRITE_HANDLER(z80_write_port) {
   }
 }
 
+/* Z80 I/O processor state shadow (Bike Race port handlers below). */
+static struct {
+  UINT8 swStrobe;      /* port 0x82: switch matrix column strobe (0..5 after decode) */
+  UINT8 lampCol;       /* lamp matrix column (after decode) */
+  UINT8 lampRow;       /* port 0x84: lamp row byte, latched until the 0x83 column strobe */
+  UINT8 ctrl;          /* port 0x81: control register shadow                    */
+  UINT8 sndData;       /* port 0x80: last byte written                          */
+} sleic_io;
+
+/* Bike Race (SLEIC3) Z80 I/O processor ports.  Port map from the bkio07
+ * disassembly.  Three boot-critical details: the J1 status bit is port-0x01
+ * *bit 5*; port 0x04 *bit 7* must read 1 or main_init diverts to the service
+ * loop at Z80 0x29AE and never announces readiness; the switch-matrix column
+ * strobe is port 0x82 (lamp rows on 0x83/0x84, the IRQ-timed row strobe on
+ * 0x87).  At boot (Z80 0x012A) the Z80 sends an 0x5F "I/O board ready" byte
+ * over J1, which is what the 80188's "ESPERANDO" (waiting) attract poll is
+ * waiting to receive. */
+static READ_HANDLER(sleic3_z80_read) {
+  switch (offset) {
+    case 0x00:                                                   /* J1 inbound: 80188 command byte (NMI reads it) */
+      return sleic_188_cmd;
+    case 0x01: return 0x20;   /* status: bit 5 = J1 "80188 ready" (bkio07 polls bit 5); always-ready */
+    case 0x02: return ~coreGlobals.swMatrix[1 + sleic_io.swStrobe];/* switch-matrix column return (active-low)  */
+    case 0x03: return ~coreGlobals.swMatrix[9];                     /* all 6 direct/cabinet buttons (active-low); see SWITCH_UPDATE */
+    case 0x04: return 0xff;                                         /* idle: bit7=1 normal boot, bit4=1 trough-query enable      */
+    default:   logerror("bikerace Z80 read port %02x\n", offset);
+  }
+  return 0;
+}
+
+static WRITE_HANDLER(sleic3_z80_write) {
+  switch (offset) {
+    case 0x00:  /* port 0x80: byte onto the J1 data lines toward the 80188 */
+      sleic_io.sndData = data;
+      sleic_j1_inbound = data;
+      break;
+    case 0x01:  /* port 0x81: control; bit-2 rising edge latches the J1 byte into 80188 PCS2 (0xA0100) */
+      if ((data & 0x04) && !(sleic_j1_prev_ctrl & 0x04)) {
+        sleic_j1_inbound = sleic_io.sndData;
+        sleic_j1_fresh = 1;
+        /* The port-0x81 bit-2 strobe latches the byte into PCS2 (0xA0100) AND raises the
+         * 80188 NMI. The NMI handler (E000:0272) consumes exactly ONE J1 byte per assertion,
+         * so the NMI MUST be strobe-driven here, not periodic (see sleic3_irq_gen). */
+        cpu_set_irq_line(SLEIC_MAIN_CPU, IRQ_LINE_NMI, PULSE_LINE);
+      }
+      sleic_j1_prev_ctrl = data;
+      sleic_io.ctrl = data;
+      coreGlobals.diagnosticLed = (data >> 4) & 1;
+      break;
+    case 0x02:  /* port 0x82: switch-matrix column strobe (one-hot) */
+      if (data) sleic_io.swStrobe = core_BitColToNum(data & -data);
+      break;
+    case 0x03:  /* port 0x83: lamp-matrix COLUMN strobe (one-hot 0x01..0x80 = COL0..COL7).
+                 * The lamp refresh writes the row byte to 0x84 first, then pulses the column
+                 * here, so commit on this strobe with the row from the preceding 0x84. 8x8 = 64. */
+      if (data) coreGlobals.tmpLampMatrix[core_BitColToNum(data & -data)] = sleic_io.lampRow;
+      break;
+    case 0x04:  /* port 0x84: lamp-matrix ROW data (bit b = FILA b); latched, committed on 0x83 */
+      sleic_io.lampRow = data;
+      break;
+    case 0x05:  /* port 0x85: solenoid bank 1 (active-low) */
+      /* Write the driver-local shadow, not coreGlobals.solenoids: the VBLANK handler
+       * (SLEIC_interface_update) copies locals.solenoids -> coreGlobals.solenoids each frame. */
+      locals.solenoids = (locals.solenoids & 0xffff00) | (data ^ 0xff);
+      break;
+    case 0x06:  /* port 0x86: solenoid bank 2 (active-low) */
+      locals.solenoids = (locals.solenoids & 0xff00ff) | ((data ^ 0xff) << 8);
+      break;
+    case 0x07:  /* port 0x87: switch-matrix row strobe / Z80 control bits (NOT the lamp column).
+                 * Switches are read via the 0x82 column strobe + port-0x02 data, so no action here. */
+      break;
+    default:
+      logerror("bikerace Z80 write port %02x = %02x\n", 0x80 + offset, data);
+  }
+}
+
 static PORT_READ_START(SLEIC_80188_readport)
 MEMORY_END
 
@@ -261,9 +737,211 @@ static PORT_WRITE_START(SLEIC_Z80_writeport)
   {0x80,0x87, z80_write_port},
 MEMORY_END
 
+static PORT_READ_START(SLEIC3_Z80_readport)
+  {0x00,0x07, sleic3_z80_read},
+MEMORY_END
+
+static PORT_WRITE_START(SLEIC3_Z80_writeport)
+  {0x80,0x87, sleic3_z80_write},
+MEMORY_END
+
+/* Sleic Pin-Ball (SLEIC1) Z80 I/O processor ports.  Verified against the sp04
+ * disassembly: identical I/O conventions to Bike Race.  Switch matrix is 8 comun
+ * (port-0x82 one-hot strobe) x 4 retorno (port-0x02 read, active-low/CPL'd); the
+ * Z80 sends each switch code over J1 via port 0x80 + a port-0x81 bit-2 strobe
+ * (sub_082a: out 0x80; (0x81|0x04); 0x81) which latches the byte at the 80188 PCS2
+ * (0xA0100) and raises the 80188 NMI.  Boot gate (Z80 0x1744) spins until port-0x04
+ * bit 7 = 1; port-0x01 bit 5 is the J1 ready status.  See
+ * research/sleicpin_disasm/sleicpin_input_switches.md + sleicpin_switch_map.md. */
+static READ_HANDLER(sleic1_z80_read) {
+  switch (offset) {
+    case 0x00: return sleic_188_cmd;                                 /* J1 inbound: 80188->Z80 cmd (Z80 NMI reads it) */
+    case 0x01: return 0x20;                                          /* status: bit 5 = J1 ready (sp04 0x03f6 tests bit 5) */
+    case 0x02: return ~coreGlobals.swMatrix[1 + sleic_io.swStrobe];  /* matrix retorno data for the selected comun (active-low) */
+    case 0x03: return ~coreGlobals.swMatrix[9];                      /* direct/cabinet buttons C31-C36 (active-low, CPL'd at 0x1757) */
+    case 0x04: return 0xff;                                          /* bit 7 = 1 (boot gate 0x1744), bit 0 = 1 */
+    default:   logerror("sleicpin Z80 read port %02x\n", offset);
+  }
+  return 0;
+}
+
+static WRITE_HANDLER(sleic1_z80_write) {
+  switch (offset) {
+    case 0x00:  /* port 0x80: byte onto the J1 data lines toward the 80188 */
+      sleic_io.sndData = data;
+      sleic_j1_inbound = data;
+      break;
+    case 0x01:  /* port 0x81: control; bit-2 rising edge latches the J1 byte into 80188 PCS2 (0xA0100) and raises the NMI */
+      if ((data & 0x04) && !(sleic_j1_prev_ctrl & 0x04)) {
+        sleic_j1_inbound = sleic_io.sndData;
+        sleic_j1_fresh = 1;
+        if (getenv("SLEIC_TRACE_SW")) fprintf(stderr, "[SW->188] code=%02x\n", sleic_j1_inbound); /* DEBUG */
+        cpu_set_irq_line(SLEIC_MAIN_CPU, IRQ_LINE_NMI, PULSE_LINE);   /* NMI handler F000:DF20 reads 0xA0100 */
+      }
+      sleic_j1_prev_ctrl = data;
+      sleic_io.ctrl = data;
+      coreGlobals.diagnosticLed = (data >> 4) & 1;                    /* bit 4 = NMI-ack / diag LED */
+      break;
+    case 0x02:  /* port 0x82: switch-matrix comun strobe (one-hot 0x01..0x80 = comun 0..7) */
+      if (data) sleic_io.swStrobe = core_BitColToNum(data & -data);
+      break;
+    case 0x03:  /* port 0x83: lamp-matrix column strobe; commit the row byte from the preceding 0x84 */
+      if (data) {
+        if (getenv("SLEIC_TRACE_LAMP") && sleic_io.lampRow) fprintf(stderr, "[lamp] col=%d row=%02x\n", core_BitColToNum(data & -data), sleic_io.lampRow); /* DEBUG */
+        coreGlobals.tmpLampMatrix[core_BitColToNum(data & -data)] = sleic_io.lampRow;
+      }
+      break;
+    case 0x04:  /* port 0x84: lamp-matrix row data; latched, committed on the 0x83 strobe */
+      sleic_io.lampRow = data;
+      break;
+    case 0x05:  /* port 0x85: flipper coil windings (active-low, fired bit-cleared).
+                 * Verified vs sp04: bit0=bobina 01 Flipper Izq Fuerza (sub_024a),
+                 * bit1=02 Flipper Izq Mantenimiento, bit2=03 Flipper Der Fuerza (sub_0266),
+                 * bit3=04 Flipper Der Mantenimiento; bits 4-7 unused.  -> solenoids 1-4. */
+      locals.solenoids = (locals.solenoids & ~(UINT32)0x00f) | ((UINT32)(data ^ 0xff) & 0x0f);
+      break;
+    case 0x06:  /* port 0x86: playfield coils (active-low).  Verified vs sp04 + the service
+                 * manual BOBINAS list (FIGURA 4): bit0=05 Bancada Izquierda, bit1=06 Bancada
+                 * Derecha, bit2=07 Bumper Izquierdo, bit3=08 Bumper Derecho, bit4=09 Expulsor
+                 * Izquierdo, bit5=10 Expulsor Derecho, bit6=11 Salida Bolas, bit7=12 Taca.
+                 * Mapped to solenoids 5-12 so PinMAME sol# == the manual's bobina #
+                 * (Bike Race used bits 8-15; sleicpin's 12-coil layout differs). */
+      locals.solenoids = (locals.solenoids & ~(UINT32)0xff0) | (((UINT32)(data ^ 0xff) & 0xff) << 4);
+      break;
+    case 0x07:  /* port 0x87: VDB (coil-current watchdog) scan / Z80 control bits; not a coil
+                 * output and not the matrix column (matrix uses 0x82). */
+      break;
+    default:
+      logerror("sleicpin Z80 write port %02x = %02x\n", 0x80 + offset, data);
+  }
+}
+
+static PORT_READ_START(SLEIC1_Z80_readport)
+  {0x00,0x07, sleic1_z80_read},
+MEMORY_END
+
+static PORT_WRITE_START(SLEIC1_Z80_writeport)
+  {0x80,0x87, sleic1_z80_write},
+MEMORY_END
+
 static MACHINE_INIT(SLEIC) {
   memset(&locals, 0, sizeof locals);
+  memset(&sleic_io, 0, sizeof sleic_io);
+  sleic_oki_latch = sleic_oki_prev_strobe = 0;
+  sleic_oki_pending = 0;
   core_dmd_pwm_init(core_gameData->lcdLayout, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, 0);
+  /* Ball trough / ball-detect optos live on matrix COL4 (swMatrix[5]). The Z80 cmd-0xD5
+   * ball-status query strobes COL4 (out 0x82 = 0x10), reads it into 0xC0DB and replies
+   * over J1. The set of monitored optos and reply codes DIFFERS BY VERSION -- the Z80 I/O
+   * ROM (bkio07.bin vs 07.bin) is one of the two ROMs that differ between the games:
+   *   bikerace (bkio07, handler 0x0B1D -> sub 0x0B31, replies 0x0B7C/0x0B9D): monitors
+   *     COL4 bits 0x04 (code 0x2C, key 3), 0x20 (C7 "Bola Retenida", key 8) and
+   *     0x80 (C8 "Bola fuera", key 9). Reply 0x5D "BOLAS OK" / 0x5B "FALTA 1 BOLA";
+   *     a ball at C7 OR C8 -> BOLAS OK, so standalone-test by holding key 8 (or 9).
+   *   bikerac2 (07.bin, sub 0x0B72, replies 0x0C0B/0x0C16/0x0C37): monitors the same three
+   *     PLUS bit 0x40 (code 0x30, key 7) and counts missing balls -- reply adds
+   *     0x5C "FALTA 2 BOLAS". "BOLAS OK" needs two optos INCLUDING the key-7 sensor
+   *     (combos 0x20+0x40 or 0x40+0x80), so standalone-test by holding key 7 with 8 or 9;
+   *     holding only 8+9 (no 7) never reports OK. (Verified against the disassembly of both
+   *     Z80 ROMs; the key bindings already exist in sleic3_pf_keys below.)
+   * The driver does not fabricate the ball complement -- the frontend (Visual Pinball)
+   * supplies trough state; the keys above are only for standalone testing. */
+}
+
+/* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch
+ * codes 0x0A-0x31) are read by the 80188 through swMatrix[1..5] (COL0..COL4, selected by
+ * the port-0x82 one-hot column strobe); code = 0x0A + 8*(col-1) + row. Mapping every
+ * position to a key lets the CONTACTOS self-test verify each contact. COL4 (swMatrix[5])
+ * is the trough column. The Z80 cmd-0xD5 ball-status handler monitors COL4 bits 0x04
+ * (code 0x2C, key 3), 0x20 = C7 (key 8) and 0x80 = C8 (key 9) on BOTH versions, plus
+ * bit 0x40 (code 0x30, key 7) on bikerac2 only; see the per-version breakdown in the
+ * MACHINE_INIT trough comment above. */
+static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
+  {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08},        /* COL0 0x0A-0x0D */
+  {KEYCODE_Y,1,0x10},{KEYCODE_U,1,0x20},{KEYCODE_I,1,0x40},{KEYCODE_O,1,0x80},        /* COL0 0x0E-0x11 */
+  {KEYCODE_A,2,0x01},{KEYCODE_S,2,0x02},{KEYCODE_D,2,0x04},{KEYCODE_F,2,0x08},        /* COL1 0x12-0x15 */
+  {KEYCODE_G,2,0x10},{KEYCODE_H,2,0x20},{KEYCODE_J,2,0x40},{KEYCODE_K,2,0x80},        /* COL1 0x16-0x19 */
+  {KEYCODE_Z,3,0x01},{KEYCODE_X,3,0x02},{KEYCODE_C,3,0x04},{KEYCODE_V,3,0x08},        /* COL2 0x1A-0x1D */
+  {KEYCODE_B,3,0x10},{KEYCODE_N,3,0x20},{KEYCODE_M,3,0x40},{KEYCODE_L,3,0x80},        /* COL2 0x1E-0x21 */
+  {KEYCODE_0_PAD,4,0x01},{KEYCODE_1_PAD,4,0x02},{KEYCODE_2_PAD,4,0x04},{KEYCODE_3_PAD,4,0x08}, /* COL3 0x22-0x25 */
+  {KEYCODE_4_PAD,4,0x10},{KEYCODE_5_PAD,4,0x20},{KEYCODE_6_PAD,4,0x40},{KEYCODE_7_PAD,4,0x80}, /* COL3 0x26-0x29 */
+  {KEYCODE_0,5,0x01},{KEYCODE_2,5,0x02},{KEYCODE_3,5,0x04},{KEYCODE_4,5,0x08},        /* COL4 0x2A-0x2D */
+  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_7,5,0x40},{KEYCODE_9,5,0x80},        /* COL4 0x2E; trough optos: 0x2F=C7(key8) 0x31=C8(key9) both versions, 0x30=key7 bikerac2-only (+0x2C=key3); see trough notes above */
+};
+
+static SWITCH_UPDATE(SLEIC3) {
+  unsigned i;
+  if (inports) {
+    /* Cabinet/direct buttons are all on Z80 port 0x03 (swMatrix[9]), bit -> contact:
+     *   bit0 = C17 Tilt        (code 0x32, also menu ENTER)
+     *   bit1 = C4  Test        (code 0x33 = menu ENTER)
+     *   bit2 = C5  Right flipper(code 0x34, menu SELECT)
+     *   bit3 = C1  Left flipper (code 0x35, menu scroll DOWN)
+     *   bit4 = C2  Start        (code 0x36)
+     *   bit5 = C3  Coin/Monedero(code 0x37/0x39) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x01, 9); /* TILT(T)   0x400 -> bit0 (C17 tilt, code 0x32)        */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST(End) 0x800 -> bit1 (C4 Test, code 0x33 = menu ENTER) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 1,  0x04, 9); /* R-Shift 0x002 -> bit2 (C5 right flipper) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 3,  0x08, 9); /* L-Shift 0x001 -> bit3 (C1 left flipper)  */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x10, 9); /* START 0x100 -> bit4 (C2) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x20, 9); /* COIN  0x200 -> bit5 (C3) */
+  }
+  /* playfield matrix: closed (bit set) while the key is held */
+  for (i = 0; i < sizeof(sleic3_pf_keys)/sizeof(sleic3_pf_keys[0]); i++) {
+    if (keyboard_pressed(sleic3_pf_keys[i].key))
+      coreGlobals.swMatrix[sleic3_pf_keys[i].col] |=  sleic3_pf_keys[i].bit;
+    else
+      coreGlobals.swMatrix[sleic3_pf_keys[i].col] &= ~sleic3_pf_keys[i].bit;
+  }
+  sleic_debug_switches(5, 0xE0); /* COL4: C7 0x20 | key-7 sensor 0x40 (bikerac2) | C8 0x80 */
+}
+
+/* Sleic Pin-Ball (SLEIC1) playfield-matrix test keys.  The 8 comun x 4 retorno
+ * matrix (FIGURA 24 of the service manual) -> swMatrix[1..8] (comun 0..7), bit r =
+ * retorno r.  Mapping each populated position to a key lets the CONTACTOS self-test
+ * verify every contact.  Cell -> C-number from research/sleicpin_disasm/
+ * sleicpin_switch_map.md. */
+static const struct { int key; UINT8 col; UINT8 bit; } sleic1_pf_keys[] = {
+  {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08},  /* comun0: C1,C28,C29,C6  */
+  {KEYCODE_A,2,0x01},{KEYCODE_S,2,0x02},{KEYCODE_D,2,0x04},{KEYCODE_F,2,0x08},  /* comun1: C2,C23,C27,C18 */
+  {KEYCODE_Z,3,0x01},{KEYCODE_X,3,0x02},{KEYCODE_C,3,0x04},{KEYCODE_V,3,0x08},  /* comun2: C14,C24,C10,C15*/
+  {KEYCODE_Y,4,0x01},{KEYCODE_U,4,0x02},{KEYCODE_I,4,0x04},{KEYCODE_O,4,0x08},  /* comun3: C17,C25,C11,C13*/
+  {KEYCODE_G,5,0x01},{KEYCODE_H,5,0x02},{KEYCODE_J,5,0x04},{KEYCODE_K,5,0x08},  /* comun4: C16,C7,C19,C30 */
+                     {KEYCODE_B,6,0x02},{KEYCODE_N,6,0x04},{KEYCODE_M,6,0x08},  /* comun5: C8,C20,C3      */
+                     {KEYCODE_1_PAD,7,0x02},{KEYCODE_2_PAD,7,0x04},{KEYCODE_3_PAD,7,0x08}, /* comun6: C9,C21,C4 */
+                     {KEYCODE_4_PAD,8,0x02},{KEYCODE_5_PAD,8,0x04},{KEYCODE_6_PAD,8,0x08}, /* comun7: C26,C22,C5*/
+};
+
+static SWITCH_UPDATE(SLEIC1) {
+  unsigned i;
+  if (inports) {
+    /* Cabinet/direct buttons on Z80 port 0x03 (swMatrix[9]).  port-0x03 bit -> code ->
+     * contact CONFIRMED against the sp04 cabinet dispatcher (sub_0978/sub_09fe..0a70)
+     * and the sp03 code handlers:
+     *   bit0 -> code 0x01 = C35 Pendulo de Falta (tilt): handler acts only in-game
+     *           ([0x103]!=0) with a warning counter.
+     *   bit1 -> code 0x02 = C36 Pulsador de Test: handler enters the service menu
+     *           (F000:567F sets the [0x4d1] menu-active flag).
+     *   bit2 -> code 0x03 = C32 Flipper Derecho: fires coil 03 (Flipper Der Fuerza).
+     *   bit3 -> code 0x04 = C31 Flipper Izquierdo: fires coil 01 (Flipper Izq Fuerza).
+     *   bit4 -> code 0x05 = C33 Pulsador Start (start key '1').
+     *   bit5 -> code 0x06 = C34 Monedero / coin (coin key '5').
+     * (Flippers also fire their coils in real time; codes 0x03/0x04 are only sent in
+     * menu mode for navigation.) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x01, 9); /* TILT  -> bit0 (C35 Falta)        */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST  -> bit1 (C36 Test)         */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 1,  0x04, 9); /* R-flip-> bit2 (C32 Flipper Der)  */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 3,  0x08, 9); /* L-flip-> bit3 (C31 Flipper Izq)  */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x10, 9); /* START -> bit4 (C33 Start)        */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x20, 9); /* COIN  -> bit5 (C34 Monedero)     */
+  }
+  for (i = 0; i < sizeof(sleic1_pf_keys)/sizeof(sleic1_pf_keys[0]); i++) {
+    if (keyboard_pressed(sleic1_pf_keys[i].key))
+      coreGlobals.swMatrix[sleic1_pf_keys[i].col] |=  sleic1_pf_keys[i].bit;
+    else
+      coreGlobals.swMatrix[sleic1_pf_keys[i].col] &= ~sleic1_pf_keys[i].bit;
+  }
+  sleic_debug_switches(1, 0x04); /* comun0 bit2 = C29 Salida Bolas (ball trough) */
 }
 
 static MACHINE_DRIVER_START(SLEIC)
@@ -292,6 +970,27 @@ MACHINE_DRIVER_END
 MACHINE_DRIVER_START(SLEIC1)
   MDRV_IMPORT_FROM(SLEIC)
 
+  // Sleic Pin-Ball cabinet/direct switches (C31-C36) -> swMatrix[9]; playfield
+  // matrix via sleic1_pf_keys -> swMatrix[1..8].
+  MDRV_SWITCH_UPDATE(SLEIC1)
+
+  // Battery-backed NVRAM (28C64A): persisted by NVRAM_HANDLER(SLEIC1) and mapped
+  // read==write to one buffer so the firmware's boot-time self-repair sticks and
+  // the signature re-validation passes (clears "Memoria EEPROM en mal estado").
+  // REPLACE wipes the inherited mcpu map/ports/IRQ, so all are re-stated; only the
+  // 80188 memory map changes vs. the base SLEIC (SLEIC2/iomoon keep the base map).
+  MDRV_NVRAM_HANDLER(SLEIC1)
+  MDRV_CPU_REPLACE("mcpu", I188, 8000000)
+  MDRV_CPU_MEMORY(SLEIC1_80188_readmem, SLEIC1_80188_writemem)
+  MDRV_CPU_PORTS(SLEIC_80188_readport, SLEIC_80188_writeport)
+  MDRV_CPU_VBLANK_INT(SLEIC_interface_update, 1)
+  MDRV_CPU_PERIODIC_INT(sleic1_irq_gen, 122)   // internal Timer0 (vector 0x08) ~122 Hz
+
+  // I/O Z80: drive the switch matrix / cabinet / lamps / solenoids and the J1
+  // byte-port (port-0x81 bit-2 strobe latches a switch byte + raises the 80188 NMI).
+  MDRV_CPU_MODIFY("icpu")
+  MDRV_CPU_PORTS(SLEIC1_Z80_readport, SLEIC1_Z80_writeport)
+
   // display section
   MDRV_CPU_ADD_TAG("dcpu", I8039, 2000000)
   MDRV_CPU_MEMORY(SLEIC_8039_readmem, SLEIC_8039_writemem)
@@ -312,11 +1011,37 @@ MACHINE_DRIVER_START(SLEIC2)
 MACHINE_DRIVER_END
 
 MACHINE_DRIVER_START(SLEIC3)
-  MDRV_IMPORT_FROM(SLEIC2)
+  MDRV_IMPORT_FROM(SLEIC)
+  MDRV_SWITCH_UPDATE(SLEIC3)   // Bike Race cabinet/direct switches -> swMatrix[9]/[10]
+
+  // Battery-backed NVRAM (28C64A): persisted by NVRAM_HANDLER(SLEIC3), zero-filled by
+  // core_nvram on a fresh boot.  A blank chip makes the firmware ask for an operator
+  // START at its FABRICA prompt and then seed itself, as on real hardware.
+  MDRV_NVRAM_HANDLER(SLEIC3)
+
+  // Bike Race main CPU: 80C188 at 10 MHz (work RAM at seg 0, peripherals at
+  // 0xA0000, code at 0xE0000). REPLACE wipes the inherited
+  // map/IRQ, so memory, ports and the IRQ generator are all re-stated.
+  MDRV_CPU_REPLACE("mcpu", I188, 10000000)
+  MDRV_CPU_MEMORY(SLEIC3_80188_readmem, SLEIC3_80188_writemem)
+  MDRV_CPU_PORTS(SLEIC_80188_readport, SLEIC_80188_writeport)
+  MDRV_CPU_VBLANK_INT(SLEIC_interface_update, 1)
+  MDRV_CPU_PERIODIC_INT(sleic3_irq_gen, 244)
+
+  // Bike Race I/O CPU: Z80 with the bkio07 port map (J1 byte-port link to the
+  // 80188).  The base SLEIC map's generic z80_read_port returns 0 for port 0x04,
+  // whose bit 7 must be 1 or the Z80 hangs in its service loop and never sends
+  // the 0x5F "ready" byte the 80188 waits for ("ESPERANDO").
+  MDRV_CPU_MODIFY("icpu")
+  MDRV_CPU_PORTS(SLEIC3_Z80_readport, SLEIC3_Z80_writeport)
 
   // display section
   MDRV_CPU_ADD_TAG("dcpu", I8039, 2000000)
   MDRV_CPU_MEMORY(SLEIC_8039_readmem, SLEIC_8039_writemem)
   MDRV_CPU_PORTS(SLEIC_8039_readport, SLEIC_8039_writeport)
   MDRV_CPU_PERIODIC_INT(SLEIC_irq_i8039, 2000000/8192.)
+
+  MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
+  MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)
+  MDRV_SOUND_ADD(DAC, SLEIC_dac_intf)
 MACHINE_DRIVER_END

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -12,15 +12,22 @@
 /*-- Common Inports for SLEIC Games --*/
 #define SLEIC_COMPORTS \
   PORT_START /* 0 */ \
-    /* Switch Column 1 */ \
-    COREPORT_BIT(     0x0001, "Key 1",     KEYCODE_1) \
-    COREPORT_BIT(     0x0002, "Key 2",     KEYCODE_2) \
+    /* Switch Column 1 / direct switches port 0x00 on Io Moon */ \
+    COREPORT_BIT(     0x0001, "Key 1 / L Flipper", KEYCODE_LSHIFT) \
+    COREPORT_BIT(     0x0002, "Key 2 / R Flipper", KEYCODE_RSHIFT) \
     COREPORT_BIT(     0x0004, "Key 3",     KEYCODE_3) \
     COREPORT_BIT(     0x0008, "Key 4",     KEYCODE_4) \
     COREPORT_BIT(     0x0010, "Key 5",     KEYCODE_5) \
     COREPORT_BIT(     0x0020, "Key 6",     KEYCODE_6) \
     COREPORT_BIT(     0x0040, "Key 7",     KEYCODE_7) \
     COREPORT_BIT(     0x0080, "Key 8",     KEYCODE_8) \
+    /* Io Moon direct switches port 0x03 IN (bit 3 = START, bit 2 = TEST / COIN) \
+     * and port 0x04 IN (bit 0 = TILT). Mapped into swMatrix[9] / swMatrix[10] \
+     * by the SLEIC2 driver's SWITCH_UPDATE handler. */ \
+    COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].3 */ \
+    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN/TEST -> swMatrix[9].2 */ \
+    COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT -> swMatrix[10].0 */ \
+    COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* Bike Race C4 Test = service-menu enter (code 0x33); F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
   PORT_START /* 1 */ \
     COREPORT_DIPNAME( 0x0001, 0x0000, "S1") \
       COREPORT_DIPSET(0x0000, "0" ) \
@@ -98,6 +105,8 @@ ROM_START(name) \
 #define SLEIC_ROMSTART7(name, n1, chk1, n2, chk2, n3, chk3, n4, chk4, n5, chk5, n6, chk6, n7, chk7) \
 ROM_START(name) \
   NORMALREGION(0x100000, SLEIC_MEMREG_CPU) \
+    ROM_LOAD(n6, 0x20000, 0x20000, chk6) \
+    ROM_LOAD(n5, 0x40000, 0x20000, chk5) \
     ROM_LOAD(n4, 0xe0000, 0x20000, chk4) \
   NORMALREGION(0x10000, SLEIC_MEMREG_IO) \
     ROM_LOAD(n7, 0x0000, 0x8000, chk7) \

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -42,6 +42,34 @@ SLEIC_ROMSTART7(bikerac2,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b
 SLEIC_ROMEND
 CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
+/* V4.1 -- the newest of the three known Bike Race sets (dumped by Joerg Amann).
+/  ROM 01 was not dumped; 02 and 05 are byte-identical to the parent set and are
+/  inherited from it, so only 03/04/06/07 are listed here.  Relative to bikerace,
+/  this set carries the same F000 code revision as bikerac2 (including the 4-opto
+/  trough handler that can report "FALTA 2 BOLAS"), and adds changes of its own to
+/  the OKI sample ROM (03), the character/graphics ROM (06) and the game data (04).
+/
+/  NOT WORKING: it boots and runs, but the artwork comes out as garbage, and the
+/  reason looks like a missing or differently-mapped graphics ROM rather than a
+/  driver bug.  The graphics descriptor table lives in the first 4KB of ROM 06 --
+/  the only part of that chip this revision changed -- and where the 1992 sets
+/  fetch their artwork from 0x40000 (ROM 05), V4.1's table sends the fetch to
+/  0x24000, i.e. into ROM 06 itself, whose contents from 0x1104 on are byte-for-byte
+/  the 1992 data.  Drawing from there produces the garbage.  Swapping the 05/06 bank
+/  order, and relocating ROM 05's artwork to 0x24000, both fail, so the set as dumped
+/  does not contain what its own table points at.  Resolving this needs the V4.1
+/  board's ROM complement confirmed (ROM 01 was never dumped) or its PAL. */
+INITGAME(bikerac3, sleic_dispDMD, 2)
+SLEIC_ROMSTART7(bikerac3,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
+						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
+						 "bk03.bin",    CRC(74c10536) SHA1(43a2a63494b044fe2326ee09831ef90f37d3b432),
+						 "bk04.bin",    CRC(33fd212e) SHA1(9471e34fc4280741816d65f88590febc9e8629a7),
+						 "bkcpu05.bin", CRC(072ce879) SHA1(4f6fb044592feb4c72bbdcbe5f19e063c0e49d0d),
+						 "bk06.bin",    CRC(ad48a30a) SHA1(183b04699b038811de950bba6b8a067689bdb883),
+						 "bk07.bin",    CRC(200ff3fc) SHA1(96fc8561b078c5306b15e260436e3d3ba562c51d))
+SLEIC_ROMEND
+CORE_CLONEDEFNV(bikerac3,bikerace,"Bike Race (V4.1)",1992,"Sleic (Spain)",gl_mSLEIC3,GAME_NOT_WORKING)
+
 /*-------------------------------------------------------------------
 / Sleic Pin-Ball (1993)
 /-------------------------------------------------------------------*/

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -20,7 +20,7 @@ static core_tLCDLayout sleic_dispDMD[] = {
 /*-------------------------------------------------------------------
 / Bike Race (1992)
 /-------------------------------------------------------------------*/
-INITGAME(bikerace, sleic_dispDMD, 1)
+INITGAME(bikerace, sleic_dispDMD, 2)
 SLEIC_ROMSTART7(bikerace,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bksnd03.bin", CRC(b6d00245) SHA1(f7da6f2ca681fbe62ea9cab7f92d3e501b7e867d),
@@ -29,9 +29,9 @@ SLEIC_ROMSTART7(bikerace,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b
 						 "bkcpu06.bin", CRC(9db436d4) SHA1(3869524c0490e0a019d2f8ab46546ff42727665e),
 						 "bkio07.bin",  CRC(b52a9d4f) SHA1(726a4d9b354729d7390d2a4f877dc480701ec795))
 SLEIC_ROMEND
-CORE_GAMEDEFNV(bikerace,"Bike Race",1992,"Sleic (Spain)",gl_mSLEIC3,GAME_NOT_WORKING)
+CORE_GAMEDEFNV(bikerace,"Bike Race",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
-INITGAME(bikerac2, sleic_dispDMD, 1)
+INITGAME(bikerac2, sleic_dispDMD, 2)
 SLEIC_ROMSTART7(bikerac2,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bksnd03.bin", CRC(b6d00245) SHA1(f7da6f2ca681fbe62ea9cab7f92d3e501b7e867d),
@@ -40,7 +40,7 @@ SLEIC_ROMSTART7(bikerac2,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b
 						 "bkcpu06.bin", CRC(9db436d4) SHA1(3869524c0490e0a019d2f8ab46546ff42727665e),
 						 "07.bin",      CRC(0b763a89) SHA1(8952d7b13674e1599e53cce96e57c2783899a90a))
 SLEIC_ROMEND
-CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)",gl_mSLEIC3,GAME_NOT_WORKING)
+CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
 /*-------------------------------------------------------------------
 / Sleic Pin-Ball (1993)
@@ -51,7 +51,7 @@ SLEIC_ROMSTART4(sleicpin,"sp01-1_1.rom", CRC(240015bb) SHA1(0e647718173ad59dafbf
 						 "sp03-1_1.rom", CRC(261b0ae4) SHA1(e7d9d1c2cab7776afb732701b0b8697b62a8d990),
 						 "sp04-1_1.rom", CRC(84514cfa) SHA1(6aa87b86892afa534cf963821f08286c126b4245))
 SLEIC_ROMEND
-CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,GAME_NOT_WORKING)
+CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,0)
 
 /*-------------------------------------------------------------------
 / Io Moon (1994)


### PR DESCRIPTION
> **Prerequisite: #625 must be merged before this PR.**
> **Sleic Pin-Ball faults during boot without the `CHANGE_PC` fix in https://github.com/vpinball/pinmame/pull/625, because the 80188 runs its game code at `0xD0000`-`0xFFFFF`. This branch is built on top of that fix so the games are testable today; once #625 is merged the diff here reduces to the driver commit alone.**

### What this does

Brings up three sets on the Sleic boards:

| set | board | before | after |
|---|---|---|---|
| `bikerace` | SLEIC3 | not working | playable |
| `bikerac2` | SLEIC3 | not working | playable |
| `sleicpin` | SLEIC1 | `GAME_NOT_WORKING` | playable |

Io Moon (`iomoon`, SLEIC2) is deliberately **out of scope** — I am still working on this. It needs an undumped PIC16C57 that rasters its DMD, and I would rather submit it when that is solved than ship guesses.

### What works

A coin gives a credit, start begins a game, the ball trough and playfield contacts
register and score, lamps and coils follow the ROM's own tables, the DMD renders, the
service menu is reachable from the test button, settings persist to NVRAM, and both
sound chips play — YM3812 FM music and OKI MSM6376 speech and effects.

### How the boards work

Both use an 80188 for the game, a Z80 for I/O, and a YM3812 plus an OKI MSM6376 for
sound, so the shared parts live in the `SLEIC` machine and each board overrides what
differs.

**Inter-CPU link.** The Z80 and the 80188 talk over the J1 byte port — eight data lines
and handshakes, no shared memory, no HOLD/HLDA. The Z80 writes a switch code and strobes
it; the 80188 takes it from its inbound latch at PCS2 (`0xA0100`). Cabinet buttons arrive
as codes on Z80 port `0x03`, the playfield matrix through the port-`0x82` column strobe.

**Interrupts.** Sleic Pin-Ball's firmware enables only the 80188's internal timer, so
Timer0 has to be delivered on vector `0x08` or the attract mode never runs.

**Reverse path.** PCS1 (`0xA0080`) carries the command byte going back from the 80188 to
the Z80. That is what drives lamp and solenoid updates and lets the flippers navigate the
service menu.

**Sound.** The 80188 owns both chips. The YM3812 is on PCS5, but the two boards address it
differently — Bike Race streams register/value pairs to a single address and toggles A0 in
hardware, Sleic Pin-Ball latches A0 from PCS0 bit 1 — so they are decoded separately. The
OKI takes a phrase number in its control latch and plays it on the channel selected by
bit 7.

**Maps.** Switch and coil assignments follow the service manuals: `sleicpin`'s solenoids
1-12 are bobinas 01-12 and its cabinet contacts are C31-C36. Bike Race's ball-status
handler watches different trough optos per version — `bikerace` reports BOLAS OK from one
of two, `bikerac2` counts them and needs two including its own sensor.

### Testing

Built and run on Linux/SDL. All three sets boot and run at 60 FPS, and all three were
played by hand: trough populated, credits added, game started, playfield contacts and
flippers exercised, sound confirmed on both boards. Bike Race was also checked from a
blank NVRAM through its factory prompt and back.

A few environment variables, inert unless set, help with automated checks:
`SLEIC_DMD_DUMP` writes one PGM per DMD frame, and `SLEIC_TRACE_PW` / `SLEIC_TRACE_SW` /
`SLEIC_TRACE_LAMP` / `SLEIC_TRACE_SND` trace peripheral, switch, lamp and sound writes.
Happy to drop these if you would rather the driver stayed clean of them.
