### PR TITLE
LibPinMAME: read memory that is reached through a handler

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1751,19 +1751,31 @@ PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates)
 
 PINMAMEAPI int PinmameReadMainCPUByte(const uint32_t address, uint8_t* const p_value)
 {
-	if (!_isRunning || p_value == nullptr)
+	return PinmameReadMainCPUMemory(address, p_value, 1);
+}
+
+/* A NULL from memory_get_read_ptr() means the read table holds a handler rather than
+   a direct pointer, not that the address is unreadable at all, se.c routes all of
+   Whitestar/Sega main RAM through ram_r. memory_find_base() has no bounds check. */
+
+static int ReadThroughRamBase(const uint32_t address, uint8_t* const p_buffer, const int size)
+{
+	const size_t regionLength = memory_region_length(REGION_CPU1);
+	if (address >= regionLength)
 	{
 		return 0;
 	}
 
-	uint8_t* p_memory = static_cast<uint8_t*>(memory_get_read_ptr(0, address));
-	if (p_memory == nullptr)
+	const uint8_t* const p_base = static_cast<const uint8_t*>(memory_find_base(0, address));
+	if (p_base == nullptr)
 	{
 		return 0;
 	}
 
-	*p_value = *p_memory;
-	return 1;
+	const int available = (int)std::min((size_t)size, regionLength - address);
+	memcpy(p_buffer, p_base, available);
+
+	return available;
 }
 
 /******************************************************
@@ -1782,7 +1794,7 @@ PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p
 		uint8_t* p_memory = static_cast<uint8_t*>(memory_get_read_ptr(0, address + i));
 		if (p_memory == nullptr)
 		{
-			return i;
+			return i > 0 ? i : ReadThroughRamBase(address, p_buffer, size);
 		}
 
 		p_buffer[i] = *p_memory;


### PR DESCRIPTION
## What

`PinmameReadMainCPUMemory` and `PinmameReadMainCPUByte` resolve addresses with `memory_get_read_ptr()`, which returns NULL wherever the read table holds a handler rather than a direct pointer. That is not the same as the address being unreadable.

`se.c` maps all of main RAM through one:

```c
static MEMORY_READ_START(se_readmem)
  { 0x0000, 0x1fff, ram_r },
```

...so both functions return 0 bytes for every main RAM address on Stern Whitestar and Sega. Oops. `PMPI_READ_MEMORY` (#624) inherits it, and the failure is silent: a caller cannot tell "not supported" from "no data".

Reproduced on current master, any Whitestar or Sega ROM:

```c
uint8_t buf[8];
PinmameReadMainCPUMemory(0x1657, buf, 8);   /* returns 0 */
```

## Implementation

Where the pointer lookup yields nothing, resolve through `memory_find_base()` instead, bounded by `memory_region_length(REGION_CPU1)` since it does no bounds checking of its own.

A read that starts in pointer-readable memory and runs into a handler region still returns the partial count, so platforms where the existing path works are untouched. A read that gets nothing at all takes the new route.

`PinmameReadMainCPUByte` carried the same lookup and now delegates to the ranged read rather than repeating it. It returns 1 on Whitestar and Sega where it previously returned 0.

## Testing

Built on macOS/arm64. Eight bytes of main RAM through both entry points, five seconds into attract mode.

`austin` (Whitestar) at `0x1657`: 0 bytes before, 8 after — `00 2b a2 b9 a5 81 b0 46`.

Unchanged at 8/8 on `ij_l7` (WPC), `whirl_l3` (System 11), `blckhole` (Gottlieb System 80), `cueball` (Gottlieb System 3) and `flashgdn` (Bally).

## Disclosure

Per CONTRIBUTING.md: I use Claude/Anthropic to check my work and provide interactive guidance as I write, mostly to keep me from causing collateral damage. It helps me navigate the codebase and tells me when I'm being stupid, and when I'm testing, helps me find my bugs. I wrote and built the change, ran the verification above, and can explain the implementation!