### PR TITLE
LibPinMAME: write CPU memory through the memory map

### DIFF
--- a/src/libpinmame/PinMAMEPlugin.h
+++ b/src/libpinmame/PinMAMEPlugin.h
@@ -45,6 +45,26 @@ typedef struct PinMAMEReadMemoryMsg
    uint32_t read;       // Response: bytes actually read, 0 if unavailable
 } PinMAMEReadMemoryMsg;
 
+#define PMPI_WRITE_MEMORY                    "WriteMemory:1"
+
+typedef struct PinMAMEWriteMemoryOp
+{
+   uint32_t address;       // Start address in the main CPU address space
+   uint32_t size;          // Number of bytes to write
+   const uint8_t* data;    // Caller-owned buffer, at least 'size' bytes
+} PinMAMEWriteMemoryOp;
+
+// Every op in one message is applied in a single pass on the emulation thread, so the
+// machine cannot run between them. WPC needs that: writing protected CMOS means storing
+// 0xB4 to 0x3FFD first, and the game re-locks within a frame.
+typedef struct PinMAMEWriteMemoryMsg
+{
+   int version;                      // Always 1 (to allow upgrading this message in later revisions)
+   uint32_t count;                   // Request: number of ops
+   const PinMAMEWriteMemoryOp* ops;  // Request: applied in order, atomically
+   uint32_t applied;                 // Response: count on success, 0 if unavailable
+} PinMAMEWriteMemoryMsg;
+
 
 // State groups
 // 

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -8,6 +8,9 @@
 #include <vector>
 #include <algorithm>
 #include <format>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
 
 #if (defined(_M_IX86_FP) && _M_IX86_FP >= 2) || defined(__SSE2__) || defined(_M_X64) || defined(_M_AMD64) || defined(__ia64__) || defined(__x86_64__)
  #define SSE_DISPLAY_OPT
@@ -269,6 +272,7 @@ static struct MsgLocals
 
    unsigned int onGetMachineStateId;
    unsigned int onReadMemoryId;
+   unsigned int onWriteMemoryId;
 
    struct MemMapState
    {
@@ -1807,6 +1811,114 @@ PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p
 }
 
 /******************************************************
+ * PinmameWriteMainCPUMemory
+ ******************************************************/
+
+namespace {
+
+struct PendingWrite
+{
+	const PinMAMEWriteMemoryOp* ops;
+	uint32_t count;
+	bool done;
+};
+
+std::mutex g_writeMutex;
+std::condition_variable g_writeCv;
+std::vector<PendingWrite*> g_writeQueue;
+
+} /* anonymous namespace */
+
+/* Dispatched through the memory map rather than a pointer from memory_get_write_ptr(),
+   because write handlers carry platform semantics a pointer write would bypass: WPC
+   gates CMOS on a protection register, early Bally stores only the high nibble,
+   Gottlieb System 80 mirrors each byte to 32 addresses. Applying a whole batch here
+   means the machine cannot run between the ops of one request. The CPU context is
+   installed once for the batch rather than per byte. */
+
+static void ApplyWrites(const std::vector<PendingWrite*>& batch)
+{
+	cpuintrf_push_context(0);
+
+	for (const PendingWrite* w : batch)
+	{
+		for (uint32_t op = 0; op < w->count; op++)
+		{
+			for (uint32_t i = 0; i < w->ops[op].size; i++)
+			{
+				cpunum_write_byte(0, w->ops[op].address + i, w->ops[op].data[i]);
+			}
+		}
+	}
+
+	cpuintrf_pop_context();
+}
+
+/* Called once per frame from osd_update_video_and_audio(), on the emulation thread. */
+extern "C" void libpinmame_drain_pending_writes(void)
+{
+	static std::vector<PendingWrite*> batch;   /* static, so the queue keeps its capacity */
+
+	{
+		std::lock_guard<std::mutex> lock(g_writeMutex);
+		if (g_writeQueue.empty())
+		{
+			return;
+		}
+		batch.swap(g_writeQueue);
+	}
+
+	ApplyWrites(batch);
+
+	{
+		std::lock_guard<std::mutex> lock(g_writeMutex);
+		for (PendingWrite* w : batch)
+		{
+			w->done = true;
+		}
+	}
+
+	batch.clear();
+	g_writeCv.notify_all();
+}
+
+static bool SubmitWrite(const PinMAMEWriteMemoryOp* const ops, const uint32_t count)
+{
+	PendingWrite w { ops, count, false };
+
+	/* Already on the emulation thread: apply directly rather than waiting for our own drain. */
+	if (_p_gameThread && std::this_thread::get_id() == _p_gameThread->get_id())
+	{
+		ApplyWrites({ &w });
+		return true;
+	}
+
+	std::unique_lock<std::mutex> lock(g_writeMutex);
+	g_writeQueue.push_back(&w);
+
+	/* Bounded, so a stalled or paused emulator cannot hang the caller. */
+	if (!g_writeCv.wait_for(lock, std::chrono::milliseconds(250), [&w] { return w.done; }))
+	{
+		std::erase(g_writeQueue, &w);
+		return false;
+	}
+
+	return true;
+}
+
+PINMAMEAPI int PinmameWriteMainCPUMemory(const uint32_t address, const uint8_t* const p_buffer, const int size)
+{
+	if (!_isRunning || p_buffer == nullptr || size <= 0)
+	{
+		return 0;
+	}
+
+	const PinMAMEWriteMemoryOp op { address, (uint32_t)size, p_buffer };
+
+	return SubmitWrite(&op, 1) ? size : 0;
+}
+
+/******************************************************
  * PinmameGetRawMemoryRegion
  ******************************************************/
 
@@ -1860,6 +1972,18 @@ static void OnReadMemory(const unsigned int eventId, void* userData, void* msgDa
       return;
 
    msg->read = PinmameReadMainCPUMemory(msg->address, msg->data, (int)msg->size);
+}
+
+static void OnWriteMemory(const unsigned int eventId, void* userData, void* msgData)
+{
+   if (_isRunning != 1)
+      return;
+
+   auto msg = static_cast<PinMAMEWriteMemoryMsg*>(msgData);
+   if (msg->version != 1 || msg->ops == nullptr || msg->count == 0)
+      return;
+
+   msg->applied = SubmitWrite(msg->ops, msg->count) ? msg->count : 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2702,6 +2826,8 @@ static void SetupMsgApi()
    msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
    msgLocals.onReadMemoryId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_READ_MEMORY);
    msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onReadMemoryId, OnReadMemory, nullptr);
+   msgLocals.onWriteMemoryId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_WRITE_MEMORY);
+   msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onWriteMemoryId, OnWriteMemory, nullptr);
 
    msgLocals.controllerProvider = std::make_unique<PinballPlugin::Controller::CtrlItemProvider<ControllerDef>>(msgLocals.msgApi, msgLocals.endpointId, CTLPI_CONTROLLERS_GET_MSG, CTLPI_CONTROLLERS_ON_CHG_MSG);
 
@@ -2722,10 +2848,12 @@ static void ReleaseMsgApi()
 
    msgLocals.msgApi->UnsubscribeMsg(msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
    msgLocals.msgApi->UnsubscribeMsg(msgLocals.onReadMemoryId, OnReadMemory, nullptr);
+   msgLocals.msgApi->UnsubscribeMsg(msgLocals.onWriteMemoryId, OnWriteMemory, nullptr);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onDmdCmdId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onConsoleDataId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onGetMachineStateId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onReadMemoryId);
+   msgLocals.msgApi->ReleaseMsgID(msgLocals.onWriteMemoryId);
 
    msgLocals.controllerProvider = nullptr;
 

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -486,6 +486,7 @@ PINMAMEAPI int PinmameGetNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameReadMainCPUByte(uint32_t address, uint8_t* const p_value);
 PINMAMEAPI int PinmameReadMainCPUMemory(uint32_t address, uint8_t* const p_buffer, int size);
+PINMAMEAPI int PinmameWriteMainCPUMemory(uint32_t address, const uint8_t* const p_buffer, int size);
 PINMAMEAPI const uint8_t* PinmameGetRawMemoryRegion(const int region);
 PINMAMEAPI size_t PinmameGetRawMemoryRegionLength(const int region);
 PINMAMEAPI void PinmameSetUserData(void* const p_userData);

--- a/src/libpinmame/video.c
+++ b/src/libpinmame/video.c
@@ -19,6 +19,7 @@
 #include "menu.h"
 #endif
 
+extern void libpinmame_drain_pending_writes(void);
 extern void libpinmame_log_info(const char* format, ...);
 
 //============================================================
@@ -666,6 +667,10 @@ static void update_timing()
 void osd_update_video_and_audio(struct mame_display *display)
 {
 	cycles_t cps = osd_cycles_per_second();
+
+	/* Runs once per frame on the emulation thread, which is where queued writes
+	   have to be applied. */
+	libpinmame_drain_pending_writes();
 
 	// if this is the first time through, initialize the previous time value
 	if (warming_up)


### PR DESCRIPTION
## What

There is no way for a plugin to write the emulated machine's CPU memory today. Adding one is not simply the mirror of the ranged read, because writes carry required platform-specific details that reads do not.

`memory_get_write_ptr()` returns NULL wherever the write table holds a handler rather than a direct pointer. For example, on WPC that is all of `0x0000-0x2fff`, so a pointer-based write silently no-ops on CMOS. Where it does return a pointer, writing through it bypasses whatever the handler was doing:

| Platform | Handler | What a pointer write gets wrong |
|---|---|---|
| Williams WPC | `wpc_ram_w` | Bypasses the memory protection register |
| Bally (early) | `by35_CMOS_w` | Stores 8 bits where the CMOS holds 4 |
| Gottlieb System 80 | `ram_256w` | Updates 1 of 32 mirrors, leaving 31 stale |

Two of those three fail silently, as the write reports success and stores a value the machine could never contain.

## Why a sequence rather than a single range

Lessons learned doing this on real hardware... Writing protected CMOS on WPC means storing `0xB4` to `0x3FFD` first, and the game re-locks within a frame. Two separate messages are a frame apart, so the payload arrives after the re-lock and is, therefore, dropped.

Same binary, same address, six seconds into attract mode on `ij_l7`, only the grouping differs:

```
unlock + payload in one message    read observes the write
unlock and payload as two          write is refused
```

So the message carries a list of ops applied in a _single pass_ rather than one range. If you would rather have a different mechanism, I am happy to rework it... The only requirement is that the ops are indivisible with respect to the emulated CPU.

## Implementation

Shamelessly queued and applied from `osd_update_video_and_audio()`, which runs once per frame on the emulation thread, between CPU time slices, where the active-CPU context is valid and handler dispatch is legal. It did precisely what I needed. `cpunum_write_byte()` is not safe to call from the asynchronous message thread though.`libpinmame.cpp` already notes that switching CPU context there is a pain not worth experiencing.

Everything drained in one pass is atomic with respect to the machine, which is what replaces halting the CPU. A caller blocks until the next drain, measured at 9.5 ms median and 16.5 ms maximum, bounded at 250 ms so a paused emulator cannot hang a plugin.

`PinmameWriteMainCPUMemory` follows the merged ranged read, with the buffer const since it is only read from.

## Testing

Built on macOS/arm64. Read-modify-write-verify of 8 bytes of main RAM, six seconds into attract mode, restoring the original contents afterwards:

`ij_l7` (WPC, protection unlock), `flashgdn` (Bally 4-bit, nibble mask observed), `blckhole` (Gottlieb System 80, mirror confirmed at `0x1900`), `whirl_l3` (System 11), `cueball` (Gottlieb System 3, multi-CPU) — all pass.

Also exercised end to end in VPX 10.8.1 Beta with a small test plugin loaded alongside PinMAME, ScoreView, B2SLegacy, AltSound, PUP, Serum, FlexDMD and VNI: an unprotected write is refused, the batched write lands, and the teardown is clean.

The test harness is out of this since nothing in CI runs it, but I can add it under `src/libpinmame/` if that is useful! I see there is precedent in `src/remote_debug/test_suite.sh`. Just let me know.

## Disclosure

Per CONTRIBUTING.md: I use Claude/Anthropic to check my work and provide interactive guidance as I write, mostly to keep me from causing collateral damage. It helps me navigate the codebase and tells me when I'm being stupid, and when I'm testing, helps me find my bugs. I wrote and built the change, ran the verification above, and can explain the implementation!