### PR TITLE
LibPinMAME: Fix Capcom audio dropout and ball release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.DS_Store
 .project
 build/
 /CMakeLists.txt
+/.cache/
 /.vs/
 /obj/
 /release/

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -592,7 +592,9 @@ extern "C" int osd_update_audio_stream(INT16* p_buffer)
          delete[] msg->buffer;
          delete msg;
          }, audioUpdate);
-      return samplesThisFrame;
+
+      // Re-seed the fixed per-frame quota (as osd_start_audio_stream does) instead of echoing the live count
+      return (int)(Machine->sample_rate / Machine->drv->frames_per_second);
    }
    else if (_p_Config->cb_OnAudioUpdated)
    {

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1866,6 +1866,8 @@ static void GetSolenoid1VPMState(void* callContext, void* pResult)
 {
    assert(_isRunning == 1);
    const int srcId = static_cast<StateMapping*>(callContext)->srcId;
+   if (options.usemodsol & CORE_MODOUT_FORCE_ON)
+      core_update_pwm_outputs(CORE_MODOUT_SOL0 + core_BitColToNum(srcId), 1);
    *static_cast<uint8_t*>(pResult) = (coreGlobals.solenoids & srcId) != 0 ? 1 : 0;
 }
 static void GetSolenoid2State(void* callContext, void* pResult)
@@ -1880,6 +1882,8 @@ static void GetSolenoid2VPMState(void* callContext, void* pResult)
 {
    assert(_isRunning == 1);
    const int srcId = static_cast<StateMapping*>(callContext)->srcId;
+   if (options.usemodsol & CORE_MODOUT_FORCE_ON)
+      core_update_pwm_outputs(CORE_MODOUT_SOL0 + core_BitColToNum(srcId) + 32, 1);
    *static_cast<uint8_t*>(pResult) = (coreGlobals.solenoids2 & srcId) != 0 ? 1 : 0;
 }
 static void GetCustomSolenoidState(void* callContext, void* pResult)


### PR DESCRIPTION
Two separate Capcom (Pin2K) regressions in the LibPinMAME message-API path, both in `src/libpinmame/libpinmame.cpp`. Verified on Airborne (`abv106`), Kingpin (`kpb105`), Big Bang Bar (`bbb109`), Breakshot (`bsv103`) and Pinball Magic (`pmv`) on macOS/BGFX. Also adds two macOS entries to `.gitignore`.

## Fix 1, Capcom audio goes silent after the first frame

`osd_update_audio_stream` on the message-API path returned the live `mixer_samples_this_frame()` count, and the mixer stores that return value back as its own per-frame sample count. On this path nothing else feeds that count, so it becomes a value that only depends on itself. It gets seeded once (735 = 44100/60) and after that just echoes whatever it already held.

That holds up only while a stream refills the mixer to the seeded count every frame. The Williams DAC/HC55516 do, because they synthesize samples on demand at the host rate. The Capcom TMS320AV120 does not. It is a buffered 32 kHz stream that only produces samples when the sound-board CPU clocks in MPEG frames, so the count drops to 0 after the first frame and the table goes silent.

The fix re-seeds the fixed per-frame quota (`Machine->sample_rate / Machine->drv->frames_per_second`, the same value `osd_start_audio_stream` uses) instead of echoing the live count. The buffer copy still uses the real produced-sample count.

## Fix 2, Capcom ball not released on game start (fixes vpinball/vpinball#3851)

`GetSolenoid1VPMState` and `GetSolenoid2VPMState` read the legacy `coreGlobals.solenoids` / `coreGlobals.solenoids2` bitfields directly. Their float counterparts `GetSolenoid1State` / `GetSolenoid2State` first call `core_update_pwm_outputs`; the VPM getters did not. When a driver forces PWM integration (`CORE_MODOUT_FORCE_ON`) but runs with physics-output solenoids disabled, only `core_update_pwm_outputs` refreshes those bitfields, so the VPM getters returned a stale value.

Capcom forces `CORE_MODOUT_FORCE_ON`. In the default (non-physout) config the trough kicker (solenoid 2, `SolCallback(2)="bsTrough.SolOut"`) is read through `GetSolenoid1VPMState`, the stale bitfield never showed the coil as energized, the release callback never fired, and no ball was served.

I confirmed this with an instrumented build. The broken tables ran `usemodsol=0x80` (FORCE_ON only) and read solenoid 2 through `GetSolenoid1VPMState`, where the PWM value was live but the bit in `coreGlobals.solenoids` stayed 0. The working tables ran `usemodsol=0xbc` (FORCE_ON plus the physout-enable bits), so `isPhysSol` was true and solenoid 2 went through `GetPhysOutVPMState`, which reads `physicOutputState` directly. On those the coil pulse 0, 1, 0 showed up right at serve time.

The fix adds the same `if (options.usemodsol & CORE_MODOUT_FORCE_ON) core_update_pwm_outputs(...)` call to both VPM getters, matching the float getters. `GetSolenoid2VPMState` uses the `+ 32` offset for `solenoids2`.

## Testing

| Table | Before | After |
|---|---|---|
| Airborne (`abv106`) | no ball, no sound | ball + sound |
| Kingpin (`kpb105`) | no ball | ball |
| Pinball Magic (`pmv`) | no ball | ball |
| Big Bang Bar (`bbb109`) | works | still works |
| Breakshot (`bsv103`) | works | still works |
| Alien Poker (Williams, audio control) | works | still works |

## One thing I did not touch

The Capcom `MACHINE_INIT(cc)` fallback loop in `src/wpc/capcom.c` iterates `i` but always passes `CORE_MODOUT_SOL0` (index 0) instead of `CORE_MODOUT_SOL0 + i`, so it reverts only the first solenoid rather than each non-2-state output. That affects the per-game `BULB_89` flasher typing in the default non-physout config, not the trough, so it is not part of this bug. Worth a look as a follow-up.
