### PR TITLE
LibPinMAME: Fix SAM RGB inserts not lighting

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -2231,9 +2231,13 @@ static void SetupMsgApiGameStates()
       const bool isPhysLamp = (coreGlobals.nLamps > 0) && ((options.usemodsol & CORE_MODOUT_ENABLE_PHYSOUT_LAMPS) != 0);
       for (uint16_t i = 0; i < nLamps; i++)
       {
+         // SAM modulated LED / RGB boards (lamps >= 80) are only driven through the physics output value, never the
+         // lamp matrix, so they must be read from there even when physics output for lamps is not otherwise enabled
+         // (mirrors the backward-compatible handling in vp_getChangedLamps). Otherwise these inserts stay dark.
+         const bool usePhys = isPhysLamp || (hasSAMModulatedLeds && i >= 80);
          uint16_t l = coreData->m2lamp ? static_cast<uint16_t>(coreData->m2lamp((i / 8) + 1, i & 7)) : i;
-         addDevice(PMPI_GROUP_LAMP, fmtString("Lamp #%x%x", (i / 8) + 1, (i & 7) + 1), nullptr, l, CTLPI_STATE_FORMAT_FLOAT, CTLPI_STATE_TYPE_RELATIVE_BRIGHTNESS, isPhysLamp ? GetPhysOutState : GetLampState, nullptr, isPhysLamp ? (CORE_MODOUT_LAMP0 + i) : i);
-         addDevice(PMPI_GROUP_VPM_LAMP, fmtString("Lamp #%x%x", (i / 8) + 1, (i & 7) + 1), fmtString("FIXME define value"), l, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, isPhysLamp ? GetPhysOutVPMState : GetLampVPMState, nullptr, isPhysLamp ? (CORE_MODOUT_LAMP0 + i) : i);
+         addDevice(PMPI_GROUP_LAMP, fmtString("Lamp #%x%x", (i / 8) + 1, (i & 7) + 1), nullptr, l, CTLPI_STATE_FORMAT_FLOAT, CTLPI_STATE_TYPE_RELATIVE_BRIGHTNESS, usePhys ? GetPhysOutState : GetLampState, nullptr, usePhys ? (CORE_MODOUT_LAMP0 + i) : i);
+         addDevice(PMPI_GROUP_VPM_LAMP, fmtString("Lamp #%x%x", (i / 8) + 1, (i & 7) + 1), fmtString("FIXME define value"), l, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, usePhys ? GetPhysOutVPMState : GetLampVPMState, nullptr, usePhys ? (CORE_MODOUT_LAMP0 + i) : i);
       }
       setupGroup(PMPI_GROUP_LAMP, "Lamps", "Playfield, cabinet and backglass lamps (either matrix or directly controlled)");
       setupGroup(PMPI_GROUP_VPM_LAMP, "VPinMAME Lamps", "Backward compatible VPinMAME states (less precise, meaning depends on game driver)");


### PR DESCRIPTION
On Stern SAM games with modulated LED / RGB boards, the RGB inserts driven by the auxiliary LED nodeboard (lamps 80 and up) do not light through the message-API state path. On AC/DC (LUCI Premium) this leaves the A-X-E top rollover lane inserts dark, and they no longer track the flipper-button lane change.

## Cause

`SetupMsgApiGameStates` registers every lamp with one of two getters based on `isPhysLamp`:

- `isPhysLamp` true (physics output for lamps enabled): `GetPhysOutState`, which reads `coreGlobals.physicOutputState[...].value`.
- `isPhysLamp` false: `GetLampState`, which reads a bit out of `coreGlobals.lampMatrix`.

The SAM nodeboard writes the RGB LED brightness only to `physicOutputState[80..].value`, never to `lampMatrix`. So when `isPhysLamp` is false, lamps 80 and up resolve through the matrix getter and always read 0.

AC/DC runs with `usemodsol = 0x81` (`CORE_MODOUT_FORCE_ON | CORE_MODOUT_ENABLE_MODSOL`), which does not include `CORE_MODOUT_ENABLE_PHYSOUT_LAMPS`, so `isPhysLamp` is false and the aux-LED inserts read from the matrix and stay dark.

The legacy VPinMAME path handles this correctly. `vp_getChangedLamps` has a dedicated block that reads lamps 80 and up from `physicOutputState[...].value` for SAM modulated-LED games regardless of `isPhysLamp`. The message-API path was missing the equivalent.

## Fix

In the lamp registration loop, use the physics-output getter for the SAM modulated-LED region (lamps 80 and up) even when `isPhysLamp` is false, matching `vp_getChangedLamps`. Matrix lamps below 80 are unchanged.

```c
const bool usePhys = isPhysLamp || (hasSAMModulatedLeds && i >= 80);
```

## Verified

Confirmed on AC/DC (`acd_170h`) with an instrumented build. The nodeboard delivers the RGB values into `physicOutputState[80..127].value` correctly (for example the left top-lane channel reaches 1.0), but before the fix the lamps were registered with `GetLampState` and read 0. After the fix the A-X-E lane inserts light and follow the flipper lane change, and the standard matrix lamps are unaffected. This matches the earlier Tron LE RGB inserts report (#438), and the fix should also cover the other SAM nodeboard games (Metallica, Star Trek LE, Mustang, The Walking Dead).

Found at 6589fc57.
