### PR TITLE
sdl3pinmame: command line PinMAME using SDL3 for video, input and sound

### DIFF
--- a/.github/workflows/sdl3pinmame.yml
+++ b/.github/workflows/sdl3pinmame.yml
@@ -1,0 +1,85 @@
+name: sdl3pinmame
+on:
+  push:
+  pull_request:
+
+env:
+  VERSION_START_SHA: 79345956d1807e3188f0e895379466c7c4caae72
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      revision: ${{ steps.version.outputs.revision }}
+      sha: ${{ steps.version.outputs.sha }}
+      sha7: ${{ steps.version.outputs.sha7 }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: version
+        run: |
+          VERSION_MAJOR=$(grep -Eo "VERSION_MAJOR\s+[0-9]+" src/version.h | grep -Eo "[0-9]+")
+          VERSION_MINOR=$(grep -Eo "VERSION_MINOR\s+[0-9]+" src/version.h | grep -Eo "[0-9]+")
+          VERSION_REV=$(grep -Eo "VERSION_REV\s+[0-9]+" src/version.h | grep -Eo "[0-9]+")
+          VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REV}"
+          REVISION=$(git rev-list ${{ env.VERSION_START_SHA }}..HEAD --count)
+          SHA="${GITHUB_SHA}"
+          SHA7="${SHA::7}"
+          TAG="${VERSION}-${REVISION}-${SHA7}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "revision=${REVISION}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build sdl3pinmame-${{ matrix.platform }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    needs: [ version ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-24.04, platform: linux, arch: x64 }
+          - { os: macos-15, platform: macos, arch: x64 }
+          - { os: macos-15, platform: macos, arch: arm64 }
+    steps:
+      - uses: actions/checkout@v6
+      - if: matrix.platform == 'linux'
+        name: Install SDL3 build dependencies
+        # SDL3 is built from source (see cmake/sdl3pinmame/CMakeLists.txt), these are the
+        # development packages it needs to enable its x11/wayland/pipewire/pulseaudio backends
+        run: |
+          sudo apt update
+          sudo apt install -y ninja-build libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev \
+            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
+            libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev \
+            libdbus-1-dev libibus-1.0-dev libudev-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev
+      - name: Build sdl3pinmame-${{ matrix.platform }}-${{ matrix.arch }}
+        run: |
+          cp cmake/sdl3pinmame/CMakeLists.txt CMakeLists.txt
+          cmake \
+             -DPLATFORM=${{ matrix.platform }} \
+             -DARCH=${{ matrix.arch }} \
+             -DCMAKE_BUILD_TYPE=Release \
+             -B build/Release
+          cmake --build build/Release
+      - run: |
+          mkdir tmp
+          cp build/Release/sdl3pinmame tmp
+          cp release/gamelist.txt tmp
+          cp release/license.txt tmp
+          cp release/pinmame.txt tmp
+          cp release/whatsnew.txt tmp
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdl3pinmame-${{ needs.version.outputs.tag }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: tmp

--- a/README.md
+++ b/README.md
@@ -193,6 +193,32 @@ Start PinMAME in headless mode with the debugger active:
 - `-startpaused`: Halts the CPU at the first instruction.
 - `-httpport <port>`: Sets the API/UI port (default: 8935).
 
+## Building the command line emulator on Linux and macOS (sdl3pinmame)
+
+`sdl3pinmame` is the command line emulator (xpinmame) using SDL3 for video, input, joysticks and sound
+instead of X11. SDL3 is downloaded and statically linked during the build, so nothing has to be
+installed for it. For more detailed instructions, have a look at the [ci workflow](.github/workflows/sdl3pinmame.yml).
+
+```shell
+# Linux: SDL3 needs the development packages of the backends it should support, e.g. on Ubuntu:
+sudo apt install libasound2-dev libpulse-dev libpipewire-0.3-dev libx11-dev libxext-dev libxrandr-dev \
+  libxcursor-dev libxfixes-dev libxi-dev libxkbcommon-dev libwayland-dev libdecor-0-dev libgl1-mesa-dev libegl1-mesa-dev
+cp cmake/sdl3pinmame/CMakeLists.txt CMakeLists.txt
+cmake -DPLATFORM=linux -DARCH=x64 -DCMAKE_BUILD_TYPE=Release -B build
+# macOS: -DPLATFORM=macos and -DARCH=arm64 or x64
+cmake --build build -j
+# Run The Addams Family
+./build/sdl3pinmame -rompath ~/.pinmame/roms -nvram_directory ~/.pinmame/nvram taf_l5
+```
+
+Useful options: `-fullscreen` (or Alt+Enter while running), `-windowscale <n>`, `-linear`, `-vsync`,
+`-joytype 7` for SDL joystick support, `-skip_disclaimer -skip_gameinfo`, and `-help` for all the rest.
+Add `-DSDL3PINMAME_SYSTEM_SDL=ON` to link against an SDL3 installed on the system instead.
+
+Add `-DSDL3PINMAME_MAME_DEBUG=ON` to compile in the classic MAME debugger. Start with `-debug` to
+begin in the debugger, which gets its own window next to the game one, or press the tilde key (left of 1)
+while the game runs to break into it. F1 lists the debugger keys.
+
 # Note from the PinMAME Development team
 
 We're working hard to improve this great emulator, and welcome your feedback!! Please do not hesitate to contact us with questions, bug reports, suggestions, code patches, whatever!

--- a/cmake/sdl3pinmame/CMakeLists.txt
+++ b/cmake/sdl3pinmame/CMakeLists.txt
@@ -1,0 +1,762 @@
+cmake_minimum_required(VERSION 3.25)
+
+# sdl3pinmame: the xmame based command line PinMAME (see cmake/xpinmame) using
+# SDL3 for video, input, joystick and sound instead of X11/OSS/CoreAudio.
+#
+# Usage:
+#    cp cmake/sdl3pinmame/CMakeLists.txt CMakeLists.txt
+#    cmake -DPLATFORM=linux -DARCH=x64 -DCMAKE_BUILD_TYPE=Release -B build
+#    cmake --build build
+
+set(PLATFORM "linux" CACHE STRING "Platform: linux or macos")
+set(ARCH "x64" CACHE STRING "Arch: x64 or arm64")
+
+# By default SDL3 is downloaded and built as a static library, so the resulting
+# binary has no runtime dependency on an installed SDL. Enable this to link
+# against an SDL3 provided by the system (package manager, homebrew, ...) instead.
+option(SDL3PINMAME_SYSTEM_SDL "Use the SDL3 installed on the system instead of building it" OFF)
+
+# Compile in the classic MAME debugger (src/mamedbg.c), started with -debug
+option(SDL3PINMAME_MAME_DEBUG "Enable the built-in MAME debugger (-debug)" OFF)
+
+message(STATUS "PLATFORM: ${PLATFORM}")
+message(STATUS "ARCH: ${ARCH}")
+message(STATUS "SDL3PINMAME_SYSTEM_SDL: ${SDL3PINMAME_SYSTEM_SDL}")
+message(STATUS "SDL3PINMAME_MAME_DEBUG: ${SDL3PINMAME_MAME_DEBUG}")
+
+if(PLATFORM STREQUAL "macos")
+   set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
+endif()
+
+file(READ src/version.h version)
+string(REGEX MATCH "VERSION_MAJOR[ ]+([0-9]+)" _tmp ${version})
+set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VERSION_MINOR[ ]+([0-9]+)" _tmp ${version})
+set(VERSION_MINOR "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VERSION_REV[ ]+([0-9]+)" _tmp ${version})
+set(VERSION_REV "${CMAKE_MATCH_1}")
+
+project(sdl3pinmame VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REV}"
+   DESCRIPTION "PinMAME command line emulator using SDL3")
+
+if(PLATFORM STREQUAL "macos")
+   if(ARCH STREQUAL "arm64")
+      set(CMAKE_OSX_ARCHITECTURES arm64)
+   elseif(ARCH STREQUAL "x64")
+      set(CMAKE_OSX_ARCHITECTURES x86_64)
+   endif()
+elseif(NOT PLATFORM STREQUAL "linux")
+   message(FATAL_ERROR "Unsupported PLATFORM '${PLATFORM}', expected linux or macos")
+endif()
+
+# --- SDL3
+# Built before our own compiler flags/definitions are set, so SDL is compiled with its own defaults
+if(SDL3PINMAME_SYSTEM_SDL)
+   find_package(SDL3 REQUIRED CONFIG)
+else()
+   include(FetchContent)
+
+   set(SDL_VERSION 3.4.14)
+   set(SDL_SHA256 30d4aa2b3037718142b32dffd4e72f917ebb6cc5227150e7bb9c45efb2153aeb)
+
+   set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+   set(SDL_STATIC ON CACHE BOOL "" FORCE)
+   set(SDL_TEST_LIBRARY OFF CACHE BOOL "" FORCE)
+   set(SDL_TESTS OFF CACHE BOOL "" FORCE)
+   set(SDL_EXAMPLES OFF CACHE BOOL "" FORCE)
+   set(SDL_INSTALL OFF CACHE BOOL "" FORCE)
+   # Not used by us, avoid pulling in the (GL/Vulkan/GPU) render backends' dependencies
+   set(SDL_VULKAN OFF CACHE BOOL "" FORCE)
+   set(SDL_GPU OFF CACHE BOOL "" FORCE)
+   set(SDL_CAMERA OFF CACHE BOOL "" FORCE)
+   set(SDL_SENSOR OFF CACHE BOOL "" FORCE)
+   set(SDL_HAPTIC OFF CACHE BOOL "" FORCE)
+
+   FetchContent_Declare(SDL3
+      URL https://github.com/libsdl-org/SDL/releases/download/release-${SDL_VERSION}/SDL3-${SDL_VERSION}.tar.gz
+      URL_HASH SHA256=${SDL_SHA256}
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+   )
+   FetchContent_MakeAvailable(SDL3)
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+
+# Roughly match the optimization flags used by the MSVC builds (see cmake/*/CMakeLists_win-*.txt)
+# on this GCC/clang toolchain. Mirrors cmake/libpinmame/CMakeLists.txt
+
+# /fp:fast (but contraction part only): allow fp multiply+add to fuse into fma, e.g. for the resampler
+# SSE hot loop. The reassociation/finite-math parts of /fp:fast are deliberately not enabled, as e.g. finite/NaN checks are screwed
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-ffp-contract=fast>)
+
+# /GL: whole-program / link-time optimization: Portable via CMake IPO; self-gated on
+# toolchain support and only enabled for optimized configs (leaves Debug untouched)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_MESSAGE LANGUAGES C CXX)
+if(IPO_SUPPORTED)
+   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
+else()
+   message(STATUS "IPO/LTO not supported: ${IPO_MESSAGE}")
+endif()
+
+# /GR-: no RTTI (the code uses no dynamic_cast/typeid), C++ only
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+
+# /Gy + COMDAT folding: emit per-function/data sections and let the linker strip unused ones
+add_compile_options(-ffunction-sections -fdata-sections)
+if(APPLE)
+   add_link_options(-Wl,-dead_strip)
+else()
+   add_link_options(-Wl,--gc-sections)
+endif()
+
+add_compile_definitions(
+   HAS_M6809=1
+   HAS_M6808=1
+   HAS_M6800=1
+   HAS_M6803=1
+   HAS_M6802=1
+   HAS_ADSP2101=1
+   HAS_ADSP2105=1
+   HAS_ADSP2104=1
+   HAS_Z80=1
+   HAS_M6502=1
+   HAS_M65C02=1
+   HAS_M68000=1
+   HAS_M68306=1
+   HAS_S2650=1
+   HAS_8080=1
+   HAS_8085A=1
+   HAS_I8035=1
+   HAS_I8039=1
+   HAS_I86=1
+   HAS_I88=1
+   HAS_I186=1
+   HAS_I188=1
+   HAS_4004=1
+   HAS_PPS4=1
+   HAS_SCAMP=1
+   HAS_I8051=1
+   HAS_I8752=1
+   HAS_TMS7000=1
+   HAS_AT91=1
+   HAS_ARM7=1
+   HAS_CDP1802=1
+   HAS_TMS9980=1
+   HAS_TMS9995=1
+   HAS_COP420=1
+   HAS_DAC=1
+   HAS_YM2151_YMFM=1
+   HAS_YM3812_YMFM=1
+   HAS_YM3526_YMFM=1
+   HAS_YMF262_YMFM=1
+   HAS_HC55516=1
+   HAS_MC3417=1
+   HAS_SAMPLES=1
+   HAS_TMS5220=1
+   HAS_AY8910=1
+   HAS_MSM5205=1
+   HAS_CUSTOM=1
+   HAS_BSMT2000=1
+   HAS_OKIM6295=1
+   HAS_ADPCM=1
+   HAS_VOTRAXSC01=1
+   HAS_SN76477=1
+   HAS_SN76496=1
+   HAS_DISCRETE=1
+   HAS_SP0250=1
+   HAS_TMS320AV120=1
+   HAS_M114S=1
+   HAS_S14001A=1
+   HAS_YM2203=1
+   HAS_TMS5110=1
+   HAS_SP0256=1
+   HAS_Y8950=1
+   HAS_ASTROCADE=1
+   HAS_MEA8000=1
+   HAS_SAA1099=1
+   HAS_QSOUND=1
+
+   MAMEVER=7300
+   MAMENAME="PINMAME"
+   PINMAME
+   PINMAME_NO_UNUSED
+   PINMAME_HOST_UART
+   SAM_INCLUDE_COLORED
+   NAME="sdl3pinmame"
+
+   LSB_FIRST
+   "INLINE=static __inline__"
+   PI=M_PI
+   UNIX
+   stricmp=strcasecmp
+
+   XMAME
+   SIGNED_SAMPLES
+   DISPLAY_METHOD="SDL3"
+   XMAMEROOT="/usr/local/share/sdl3pinmame"
+   # Both must be defined, otherwise src/unix/snprintf.c overrides the libc vsnprintf
+   # with an implementation that crashes on vsnprintf(NULL, 0, ...) as used by SDL
+   HAVE_SNPRINTF
+   HAVE_VSNPRINTF
+   HAVE_GETTIMEOFDAY
+
+   # SDL3 sound plugin (src/unix/sysdep/dsp-drivers/sdl3.c)
+   SYSDEP_DSP_SDL3
+   # SDL joystick support in src/unix/devices.c (-joytype 7)
+   SDL
+)
+
+if(SDL3PINMAME_MAME_DEBUG)
+   add_compile_definitions(MAME_DEBUG)
+endif()
+
+add_executable(sdl3pinmame
+   src/artwork.c
+   src/artwork.h
+   src/audit.c
+   src/audit.h
+   src/cheat.c
+   src/cheat.h
+   src/common.c
+   src/common.h
+   src/config.c
+   src/config.h
+   src/cpu/adsp2100/2100dasm.c
+   src/cpu/adsp2100/adsp2100.c
+   src/cpu/adsp2100/adsp2100.h
+   src/cpu/arm7/arm7.c
+   src/cpu/arm7/arm7.h
+   src/cpu/arm7/arm7dasm.c
+   src/cpu/at91/at91.c
+   src/cpu/at91/at91.h
+   src/cpu/at91/at91dasm.c
+   src/cpu/cdp1802/1802dasm.c
+   src/cpu/cdp1802/cdp1802.c
+   src/cpu/cdp1802/cdp1802.h
+   src/cpu/cop400/410ops.c
+   src/cpu/cop400/420ops.c
+   src/cpu/cop400/cop400.h
+   src/cpu/cop400/cop420.c
+   src/cpu/cop400/cop420ds.c
+   src/cpu/i86/i86.c
+   src/cpu/i86/i86.h
+   src/cpu/i86/i86dasm.c
+   src/cpu/i4004/4004dasm.c
+   src/cpu/i4004/i4004.c
+   src/cpu/i4004/i4004.h
+   src/cpu/i8039/8039dasm.c
+   src/cpu/i8039/i8039.c
+   src/cpu/i8039/i8039.h
+   src/cpu/i8051/8051dasm.c
+   src/cpu/i8051/i8051.c
+   src/cpu/i8051/i8051.h
+   src/cpu/i8085/8085dasm.c
+   src/cpu/i8085/i8085.c
+   src/cpu/i8085/i8085.h
+   src/cpu/m6502/6502dasm.c
+   src/cpu/m6502/m6502.c
+   src/cpu/m6502/m6502.h
+   src/cpu/m6800/6800dasm.c
+   src/cpu/m6800/m6800.c
+   src/cpu/m6800/m6800.h
+   src/cpu/m6809/6809dasm.c
+   src/cpu/m6809/m6809.c
+   src/cpu/m6809/m6809.h
+   src/cpu/m68000/generated_by_m68kmake/m68kopac.c
+   src/cpu/m68000/generated_by_m68kmake/m68kops.c
+   src/cpu/m68000/generated_by_m68kmake/m68kopdm.c
+   src/cpu/m68000/generated_by_m68kmake/m68kopnz.c
+   src/cpu/m68000/generated_by_m68kmake/m68kops.h
+   src/cpu/m68000/m68kcpu.c
+   src/cpu/m68000/m68kcpu.h
+   src/cpu/m68000/m68kdasm.c
+   src/cpu/m68000/m68kmame.c
+   src/cpu/m68000/m68kmame.h
+   src/cpu/pps4/pps4.c
+   src/cpu/pps4/pps4.h
+   src/cpu/pps4/pps4dasm.c
+   src/cpu/s2650/2650dasm.c
+   src/cpu/s2650/s2650.c
+   src/cpu/s2650/s2650.h
+   src/cpu/scamp/scamp.c
+   src/cpu/scamp/scamp.h
+   src/cpu/scamp/scampdsm.c
+   src/cpu/tms7000/7000dasm.c
+   src/cpu/tms7000/tms7000.c
+   src/cpu/tms7000/tms7000.h
+   src/cpu/tms9900/9900dasm.c
+   src/cpu/tms9900/tms9900.c
+   src/cpu/tms9900/tms9900.h
+   src/cpu/tms9900/tms9980a.c
+   src/cpu/tms9900/tms9995.c
+   src/cpu/z80/z80.c
+   src/cpu/z80/z80.h
+   src/cpu/z80/z80dasm.c
+   src/cpu/z80/z80dasm.h
+   src/cpuexec.c
+   src/cpuexec.h
+   src/cpuint.c
+   src/cpuint.h
+   src/cpuintrf.c
+   src/cpuintrf.h
+   src/datafile.c
+   src/datafile.h
+   src/drawgfx.c
+   src/drawgfx.h
+   src/driver.h
+   src/fileio.c
+   src/fileio.h
+   src/harddisk.c
+   src/harddisk.h
+   src/hash.c
+   src/hash.h
+   src/hiscore.c
+   src/hiscore.h
+   src/info.c
+   src/info.h
+   src/inptport.c
+   src/inptport.h
+   src/input.c
+   src/input.h
+   src/machine/4094.c
+   src/machine/4094.h
+   src/machine/6522via.c
+   src/machine/6522via.h
+   src/machine/6530riot.c
+   src/machine/6530riot.h
+   src/machine/6532riot.c
+   src/machine/6532riot.h
+   src/machine/6821pia.c
+   src/machine/6821pia.h
+   src/machine/8255ppi.c
+   src/machine/8255ppi.h
+   src/machine/eeprom.c
+   src/machine/eeprom.h
+   src/machine/i8155.c
+   src/machine/i8155.h
+   src/machine/mathbox.c
+   src/machine/mathbox.h
+   src/machine/pic8259.c
+   src/machine/pic8259.h
+   src/machine/ticket.c
+   src/machine/ticket.h
+   src/machine/z80fmly.c
+   src/machine/z80fmly.h
+   src/mame.c
+   src/mame.h
+   src/mamedbg.c
+   src/mamedbg.h
+   src/md5.c
+   src/md5.h
+   src/memory.c
+   src/memory.h
+   src/osdepend.h
+   src/palette.c
+   src/palette.h
+   src/pinmame.h
+   src/png.c
+   src/png.h
+   src/profiler.c
+   src/profiler.h
+   src/sha1.c
+   src/sha1.h
+   src/sndintrf.c
+   src/sndintrf.h
+   src/sound/262intf.c
+   src/sound/262intf.h
+   src/sound/2151intf.c
+   src/sound/2151intf.h
+   src/sound/2203intf.c
+   src/sound/2203intf.h
+   src/sound/3812intf.c
+   src/sound/3812intf.h
+   src/sound/5110intf.c
+   src/sound/5110intf.h
+   src/sound/5220intf.c
+   src/sound/5220intf.h
+   src/sound/adpcm.c
+   src/sound/adpcm.h
+   src/sound/astrocde.c
+   src/sound/astrocde.h
+   src/sound/ay8910.c
+   src/sound/ay8910.h
+   src/sound/bsmt2000.c
+   src/sound/bsmt2000.h
+   src/sound/dac.c
+   src/sound/dac.h
+   src/sound/discrete.c
+   src/sound/discrete.h
+   src/sound/filter.c
+   src/sound/filter.h
+   src/sound/fm.c
+   src/sound/fm.h
+   src/sound/fmopl.c
+   src/sound/fmopl.h
+   src/sound/hc55516.c
+   src/sound/hc55516.h
+   src/sound/m114s.c
+   src/sound/m114s.h
+   src/sound/mc3417.c
+   src/sound/mc3417.h
+   src/sound/mea8000.c
+   src/sound/mea8000.h
+   src/sound/mixer.c
+   src/sound/mixer.h
+   src/sound/msm5205.c
+   src/sound/msm5205.h
+   src/sound/qsound.c
+   src/sound/qsound.h
+   src/sound/s14001a.c
+   src/sound/s14001a.h
+   src/sound/saa1099.c
+   src/sound/saa1099.h
+   src/sound/samples.c
+   src/sound/samples.h
+   src/sound/sn76477.c
+   src/sound/sn76477.h
+   src/sound/sn76496.c
+   src/sound/sn76496.h
+   src/sound/sp0250.c
+   src/sound/sp0250.h
+   src/sound/sp0256.c
+   src/sound/sp0256.h
+   src/sound/streams.c
+   src/sound/streams.h
+   src/sound/tms320av120.c
+   src/sound/tms320av120.h
+   src/sound/tms5110.c
+   src/sound/tms5110.h
+   src/sound/tms5220.c
+   src/sound/tms5220.h
+   src/sound/votrax.c
+   src/sound/votrax.h
+   src/sound/ymdeltat.c
+   src/sound/ymdeltat.h
+   src/state.c
+   src/state.h
+   src/tilemap.c
+   src/tilemap.h
+   src/timer.c
+   src/timer.h
+   src/ui_text.c
+   src/ui_text.h
+   src/unzip.c
+   src/unzip.h
+   src/usrintrf.c
+   src/usrintrf.h
+   src/version.c
+   src/vidhrdw/crtc6845.c
+   src/vidhrdw/crtc6845.h
+   src/vidhrdw/generic.c
+   src/vidhrdw/generic.h
+   src/vidhrdw/tms9928a.c
+   src/vidhrdw/tms9928a.h
+   src/window.c
+   src/window.h
+   src/wpc/allied.c
+   src/wpc/alvg.c
+   src/wpc/alvg.h
+   src/wpc/alvgdmd.c
+   src/wpc/alvgdmd.h
+   src/wpc/alvggames.c
+   src/wpc/alvgs.c
+   src/wpc/alvgs.h
+   src/wpc/atari.c
+   src/wpc/atari.h
+   src/wpc/atarigames.c
+   src/wpc/atarisnd.c
+   src/wpc/barni.c
+   src/wpc/bingo.c
+   src/wpc/boomerang.c
+   src/wpc/bowarrow.c
+   src/wpc/bowlgames.c
+   src/wpc/bulb.c
+   src/wpc/bulb.h
+   src/wpc/by35.c
+   src/wpc/by35.h
+   src/wpc/by35games.c
+   src/wpc/by35snd.c
+   src/wpc/by35snd.h
+   src/wpc/by6803.c
+   src/wpc/by6803.h
+   src/wpc/by6803games.c
+   src/wpc/by68701.c
+   src/wpc/byvidgames.c
+   src/wpc/byvidpin.c
+   src/wpc/byvidpin.h
+   src/wpc/capcom.c
+   src/wpc/capcom.h
+   src/wpc/capcoms.c
+   src/wpc/capcoms.h
+   src/wpc/capgames.c
+   src/wpc/core.c
+   src/wpc/core.h
+   src/wpc/dedmd.c
+   src/wpc/dedmd.h
+   src/wpc/degames.c
+   src/wpc/desound.c
+   src/wpc/desound.h
+   src/wpc/driver.c
+   src/wpc/efo.c
+   src/wpc/efosnd.c
+   src/wpc/flicker.c
+   src/wpc/gen.h
+   src/wpc/gp.c
+   src/wpc/gp.h
+   src/wpc/gpgames.c
+   src/wpc/gpsnd.c
+   src/wpc/gpsnd.h
+   src/wpc/gts1.c
+   src/wpc/gts1.h
+   src/wpc/gts1games.c
+   src/wpc/gts3.c
+   src/wpc/gts3.h
+   src/wpc/gts3games.c
+   src/wpc/gts80.c
+   src/wpc/gts80.h
+   src/wpc/gts80games.c
+   src/wpc/gts80s.c
+   src/wpc/gts80s.h
+   src/wpc/hnkgames.c
+   src/wpc/hnks.c
+   src/wpc/hnks.h
+   src/wpc/icecoldbeer.c
+   src/wpc/idsa.c
+   src/wpc/inder.c
+   src/wpc/inder.h
+   src/wpc/indergames.c
+   src/wpc/inderp.c
+   src/wpc/jeutel.c
+   src/wpc/joctronic.c
+   src/wpc/jp.c
+   src/wpc/jp.h
+   src/wpc/jpgames.c
+   src/wpc/jvh.c
+   src/wpc/kissproto.c
+   src/wpc/lancelot.c
+   src/wpc/ltd.c
+   src/wpc/ltd.h
+   src/wpc/ltdgames.c
+   src/wpc/luckydraw.c
+   src/wpc/mac.c
+   src/wpc/mech.c
+   src/wpc/mech.h
+   src/wpc/mephisto.c
+   src/wpc/micropin.c
+   src/wpc/mrgame.c
+   src/wpc/mrgame.h
+   src/wpc/mrgamegames.c
+   src/wpc/nsm.c
+   src/wpc/nuova.c
+   src/wpc/peyper.c
+   src/wpc/peyper.h
+   src/wpc/peypergames.c
+   src/wpc/play.c
+   src/wpc/play.h
+   src/wpc/playgames.c
+   src/wpc/playsnd.c
+   src/wpc/regama.c
+   src/wpc/rfranco.c
+   src/wpc/rfranco.h
+   src/wpc/rfrancogames.c
+   src/wpc/rotation.c
+   src/wpc/rowamet.c
+   src/wpc/s3games.c
+   src/wpc/s4.c
+   src/wpc/s4.h
+   src/wpc/s4games.c
+   src/wpc/s6.c
+   src/wpc/s6.h
+   src/wpc/s6games.c
+   src/wpc/s7.c
+   src/wpc/s7.h
+   src/wpc/s7games.c
+   src/wpc/s11.c
+   src/wpc/s11.h
+   src/wpc/s11games.c
+   src/wpc/se.c
+   src/wpc/se.h
+   src/wpc/segames.c
+   src/wpc/sim.c
+   src/wpc/sim.h
+   src/wpc/sims/wpc/full/sttng.c
+   src/wpc/sims/wpc/full/fh.c
+   src/wpc/sims/wpc/full/jd.c
+   src/wpc/sims/wpc/full/bop.c
+   src/wpc/sims/wpc/full/ft.c
+   src/wpc/sims/wpc/full/gw.c
+   src/wpc/sims/wpc/full/afm.c
+   src/wpc/sims/wpc/full/tz.c
+   src/wpc/sims/wpc/full/taf.c
+   src/wpc/sims/wpc/full/pz.c
+   src/wpc/sims/wpc/full/t2.c
+   src/wpc/sims/wpc/full/ngg.c
+   src/wpc/sims/wpc/full/dd_wpc.c
+   src/wpc/sims/wpc/full/cftbl.c
+   src/wpc/sims/wpc/full/mm.c
+   src/wpc/sims/wpc/full/br.c
+   src/wpc/sims/wpc/full/wcs.c
+   src/wpc/sims/wpc/full/hd.c
+   src/wpc/sims/wpc/full/drac.c
+   src/wpc/sims/wpc/full/ss.c
+   src/wpc/sims/wpc/full/ww.c
+   src/wpc/sims/wpc/full/ij.c
+   src/wpc/sims/wpc/full/tom.c
+   src/wpc/sims/wpc/full/rs.c
+   src/wpc/sims/wpc/full/hurr.c
+   src/wpc/sims/wpc/full/gi.c
+   src/wpc/sims/wpc/full/dm.c
+   src/wpc/sims/wpc/prelim/cp.c
+   src/wpc/sims/wpc/prelim/ts.c
+   src/wpc/sims/wpc/prelim/pop.c
+   src/wpc/sims/wpc/prelim/wd.c
+   src/wpc/sims/wpc/prelim/jm.c
+   src/wpc/sims/wpc/prelim/i500.c
+   src/wpc/sims/wpc/full/nbaf.c
+   src/wpc/sims/wpc/prelim/corv.c
+   src/wpc/sims/wpc/prelim/fs.c
+   src/wpc/sims/wpc/prelim/sc.c
+   src/wpc/sims/wpc/prelim/mb.c
+   src/wpc/sims/wpc/prelim/totan.c
+   src/wpc/sims/wpc/prelim/congo.c
+   src/wpc/sims/wpc/prelim/nf.c
+   src/wpc/sims/wpc/prelim/jb.c
+   src/wpc/sims/wpc/prelim/cv.c
+   src/wpc/sims/wpc/prelim/dw.c
+   src/wpc/sims/wpc/prelim/dh.c
+   src/wpc/sims/wpc/prelim/cc.c
+   src/wpc/sims/wpc/prelim/jy.c
+   src/wpc/sims/se/prelim/monopoly.c
+   src/wpc/sims/se/prelim/elvis.c
+   src/wpc/sims/se/prelim/harley.c
+   src/wpc/sims/s11/full/dd.c
+   src/wpc/sims/s11/full/milln.c
+   src/wpc/sims/s11/prelim/eatpm.c
+   src/wpc/sims/s7/full/bk.c
+   src/wpc/sims/s7/full/tmfnt.c
+   src/wpc/slalom.c
+   src/wpc/sleic.c
+   src/wpc/sleic.h
+   src/wpc/sleicgames.c
+   src/wpc/snd_cmd.c
+   src/wpc/snd_cmd.h
+   src/wpc/sndbrd.c
+   src/wpc/sndbrd.h
+   src/wpc/spectra.c
+   src/wpc/spinb.c
+   src/wpc/spinb.h
+   src/wpc/spinbgames.c
+   src/wpc/spiritof76.c
+   src/wpc/stargame.c
+   src/wpc/stgames.c
+   src/wpc/stsnd.c
+   src/wpc/stsnd.h
+   src/wpc/tabart.c
+   src/wpc/taito.c
+   src/wpc/taito.h
+   src/wpc/taitogames.c
+   src/wpc/taitos.c
+   src/wpc/taitos.h
+   src/wpc/techno.c
+   src/wpc/uart_16c450.c
+   src/wpc/uart_16c450.h
+   src/wpc/uart_8251.c
+   src/wpc/uart_8251.h
+   src/wpc/uart_host.h
+   src/wpc/vd.c
+   src/wpc/vpintf.c
+   src/wpc/vpintf.h
+   src/wpc/wico.c
+   src/wpc/wmssnd.c
+   src/wpc/wmssnd.h
+   src/wpc/wpc.c
+   src/wpc/wpc.h
+   src/wpc/wpcgames.c
+   src/wpc/wpcsam.c
+   src/wpc/wpcsam.h
+   src/wpc/zac.c
+   src/wpc/zac.h
+   src/wpc/zacgames.c
+   src/wpc/zacproto.c
+   src/wpc/zacsnd.c
+   src/wpc/zacsnd.h
+
+   ext/vgm/vgmwrite.c
+   ext/vgm/vgmwrite.h
+
+   ext/ymfm/ymfm_opm.cpp
+   ext/ymfm/ymfm_opm.h
+   ext/ymfm/ymfm_opl.cpp
+   ext/ymfm/ymfm_opl.h
+   ext/ymfm/ymfm_adpcm.cpp
+   ext/ymfm/ymfm_adpcm.h
+   ext/ymfm/ymfm_pcm.cpp
+   ext/ymfm/ymfm_pcm.h
+
+   src/unix/main.c
+   src/unix/sound.c
+   src/unix/keyboard.c
+   src/unix/devices.c
+   src/unix/video.c
+   src/unix/mode.c
+   src/unix/fileio.c
+   src/unix/dirio.c
+   src/unix/config.c
+   src/unix/fronthlp.c
+   src/unix/ident.c
+   src/unix/network.c
+   src/unix/nec765_dummy.c
+   src/unix/effect.c
+   src/unix/ticker.c
+   src/unix/parallel.c
+   src/unix/serial.c
+   src/unix/sysdep/rc.c
+   src/unix/sysdep/misc.c
+   src/unix/sysdep/plugin_manager.c
+   src/unix/sysdep/sound_stream.c
+   src/unix/sysdep/sysdep_palette.c
+   src/unix/sysdep/sysdep_dsp.c
+   src/unix/sysdep/sysdep_mixer.c
+   src/unix/sysdep/dsp-drivers/sdl3.c
+   src/unix/video-drivers/sdl3.c
+   # legacy joystick drivers, only their (empty) option tables are used
+   src/unix/joystick-drivers/joy_i386.c
+   src/unix/joystick-drivers/joy_pad.c
+   src/unix/joystick-drivers/joy_x11.c
+   src/unix/joystick-drivers/joy_usb.c
+   src/unix/frameskip-drivers/dos.c
+   src/unix/frameskip-drivers/barath.c
+)
+
+find_package(ZLIB REQUIRED)
+
+target_include_directories(sdl3pinmame PUBLIC
+   src
+   src/wpc
+   src/cpu/m68000
+   src/cpu/m68000/generated_by_m68kmake
+   src/unix
+   src/unix/sysdep
+)
+
+target_link_libraries(sdl3pinmame PUBLIC
+   ZLIB::ZLIB
+   SDL3::SDL3
+)
+
+# --- asmjit-based ARM7 JIT backend
+# No-op on a target with no JIT backend; see cmake/asmjit.cmake
+include(${CMAKE_SOURCE_DIR}/cmake/asmjit.cmake)
+pinmame_enable_asmjit(sdl3pinmame)
+
+# --- Pinball 2000 subsystem (src/p2k)
+# On by default; -DPINMAME_P2K=OFF leaves neither the Pinball 2000 drivers nor the MediaGX
+# CPU registered and the build what it was. It needs a C++17 compiler, and must come after
+# the target's own options above - see cmake/p2k.cmake
+include(${CMAKE_SOURCE_DIR}/cmake/p2k.cmake)
+pinmame_enable_p2k(sdl3pinmame)

--- a/src/unix/sysdep/dsp-drivers/sdl3.c
+++ b/src/unix/sysdep/dsp-drivers/sdl3.c
@@ -1,0 +1,191 @@
+#ifdef SYSDEP_DSP_SDL3
+
+/* Sysdep SDL3 sound dsp driver
+
+   Successor of the SDL 1.2 dsp driver (sdl.c) by Jack Burton / Stefano
+   Ceccherini and Caz Jones.
+
+   This file and the acompanying files in this directory are free software;
+   you can redistribute them and/or modify them under the terms of the GNU
+   Library General Public License as published by the Free Software Foundation;
+   either version 2 of the License, or (at your option) any later version.
+
+   These files are distributed in the hope that they will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with these files; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+   Boston, MA 02111-1307, USA.
+*/
+
+/* The samples are pushed into an SDL_AudioStream bound to the default
+   playback device. SDL takes care of format/samplerate conversion and of
+   feeding the device from its own thread. The free space reported to the
+   sound_stream code is the difference between the wanted queue depth and
+   what is still queued in the stream, which paces the emulation the same
+   way the ALSA/OSS drivers do. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <SDL3/SDL.h>
+#include "sysdep/sysdep_dsp.h"
+#include "sysdep/sysdep_dsp_priv.h"
+#include "sysdep/plugin_manager.h"
+
+/* Minimum queue depth in seconds. The generic -bufsize option (in frames)
+   is used when it asks for more. */
+#define SDL3_DSP_MIN_QUEUE_SECONDS 0.1f
+
+struct sdl3_dsp_priv_data {
+   SDL_AudioStream *stream;
+   int bytes_per_sample;
+   int queue_samples; /* wanted queue depth in samples */
+};
+
+/* public methods prototypes */
+static void *sdl3_dsp_create(const void *flags);
+static void sdl3_dsp_destroy(struct sysdep_dsp_struct *dsp);
+static int sdl3_dsp_get_freespace(struct sysdep_dsp_struct *dsp);
+static int sdl3_dsp_write(struct sysdep_dsp_struct *dsp, unsigned char *data,
+   int count);
+
+/* public variables */
+const struct plugin_struct sysdep_dsp_sdl3 = {
+   "sdl3",
+   "sysdep_dsp",
+   "SDL3 DSP plugin",
+   NULL, /* no options */
+   NULL, /* no init */
+   NULL, /* no exit */
+   sdl3_dsp_create,
+   3     /* high priority */
+};
+
+static int sdl3_dsp_bytes_per_sample[4] = SYSDEP_DSP_BYTES_PER_SAMPLE;
+
+static void *sdl3_dsp_create(const void *flags)
+{
+   struct sdl3_dsp_priv_data *priv = NULL;
+   struct sysdep_dsp_struct *dsp = NULL;
+   const struct sysdep_dsp_create_params *params = flags;
+   SDL_AudioSpec spec;
+   float queue_seconds;
+
+   /* allocate the dsp struct */
+   if (!(dsp = calloc(1, sizeof(struct sysdep_dsp_struct))))
+   {
+      fprintf(stderr, "error malloc failed for struct sysdep_dsp_struct\n");
+      return NULL;
+   }
+
+   /* alloc private data */
+   if (!(priv = calloc(1, sizeof(struct sdl3_dsp_priv_data))))
+   {
+      fprintf(stderr, "error malloc failed for struct sdl3_dsp_priv_data\n");
+      sdl3_dsp_destroy(dsp);
+      return NULL;
+   }
+
+   /* fill in the functions and some data */
+   dsp->_priv = priv;
+   dsp->get_freespace = sdl3_dsp_get_freespace;
+   dsp->write = sdl3_dsp_write;
+   dsp->destroy = sdl3_dsp_destroy;
+   dsp->hw_info.type = params->type;
+   dsp->hw_info.samplerate = params->samplerate;
+
+   /* SDL reference counts the subsystems, the video driver may already have
+      called SDL_Init */
+   if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
+   {
+      fprintf(stderr, "SDL3 dsp: error: SDL audio init failed: %s\n", SDL_GetError());
+      sdl3_dsp_destroy(dsp);
+      return NULL;
+   }
+
+   SDL_zero(spec);
+   spec.format = (dsp->hw_info.type & SYSDEP_DSP_16BIT) ? SDL_AUDIO_S16 : SDL_AUDIO_S8;
+   spec.channels = (dsp->hw_info.type & SYSDEP_DSP_STEREO) ? 2 : 1;
+   spec.freq = dsp->hw_info.samplerate;
+
+   priv->stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+   if (!priv->stream)
+   {
+      fprintf(stderr, "SDL3 dsp: error: opening the audio device failed: %s\n", SDL_GetError());
+      sdl3_dsp_destroy(dsp);
+      return NULL;
+   }
+
+   priv->bytes_per_sample = sdl3_dsp_bytes_per_sample[dsp->hw_info.type];
+
+   queue_seconds = params->bufsize;
+   if (queue_seconds < SDL3_DSP_MIN_QUEUE_SECONDS)
+      queue_seconds = SDL3_DSP_MIN_QUEUE_SECONDS;
+   priv->queue_samples = (int)(queue_seconds * dsp->hw_info.samplerate);
+   dsp->hw_info.bufsize = priv->queue_samples;
+
+   if (!SDL_ResumeAudioStreamDevice(priv->stream))
+   {
+      fprintf(stderr, "SDL3 dsp: error: starting the audio device failed: %s\n", SDL_GetError());
+      sdl3_dsp_destroy(dsp);
+      return NULL;
+   }
+
+   fprintf(stderr, "SDL3 dsp: info: driver %s, %dbit linear %s %dHz, queue %d samples (%.0f ms)\n",
+      SDL_GetCurrentAudioDriver(),
+      (dsp->hw_info.type & SYSDEP_DSP_16BIT) ? 16 : 8,
+      (dsp->hw_info.type & SYSDEP_DSP_STEREO) ? "stereo" : "mono",
+      dsp->hw_info.samplerate, priv->queue_samples, queue_seconds * 1000.0f);
+
+   return dsp;
+}
+
+static void sdl3_dsp_destroy(struct sysdep_dsp_struct *dsp)
+{
+   struct sdl3_dsp_priv_data *priv = dsp->_priv;
+
+   if (priv)
+   {
+      if (priv->stream)
+      {
+         SDL_DestroyAudioStream(priv->stream);
+         SDL_QuitSubSystem(SDL_INIT_AUDIO);
+      }
+      free(priv);
+   }
+   free(dsp);
+}
+
+static int sdl3_dsp_get_freespace(struct sysdep_dsp_struct *dsp)
+{
+   struct sdl3_dsp_priv_data *priv = dsp->_priv;
+   int queued = SDL_GetAudioStreamQueued(priv->stream);
+
+   if (queued < 0)
+   {
+      fprintf(stderr, "SDL3 dsp: error: SDL_GetAudioStreamQueued failed: %s\n", SDL_GetError());
+      return 0;
+   }
+   queued /= priv->bytes_per_sample;
+
+   return (queued < priv->queue_samples) ? priv->queue_samples - queued : 0;
+}
+
+static int sdl3_dsp_write(struct sysdep_dsp_struct *dsp, unsigned char *data,
+   int count)
+{
+   struct sdl3_dsp_priv_data *priv = dsp->_priv;
+
+   if (!SDL_PutAudioStreamData(priv->stream, data, count * priv->bytes_per_sample))
+   {
+      fprintf(stderr, "SDL3 dsp: error: SDL_PutAudioStreamData failed: %s\n", SDL_GetError());
+      return -1;
+   }
+   return count;
+}
+
+#endif /* ifdef SYSDEP_DSP_SDL3 */

--- a/src/unix/sysdep/sysdep_dsp.c
+++ b/src/unix/sysdep/sysdep_dsp.c
@@ -101,6 +101,9 @@ static const struct plugin_struct *sysdep_dsp_plugins[] = {
 #ifdef SYSDEP_DSP_SDL
    &sysdep_dsp_sdl,
 #endif
+#ifdef SYSDEP_DSP_SDL3
+   &sysdep_dsp_sdl3,
+#endif
 #ifdef SYSDEP_DSP_WAVEOUT
    &sysdep_dsp_waveout,
 #endif

--- a/src/unix/sysdep/sysdep_dsp_plugins.h
+++ b/src/unix/sysdep/sysdep_dsp_plugins.h
@@ -57,6 +57,9 @@ extern struct plugin_struct sysdep_dsp_arts;
 #ifdef SYSDEP_DSP_SDL
 extern struct plugin_struct sysdep_dsp_sdl;
 #endif
+#ifdef SYSDEP_DSP_SDL3
+extern struct plugin_struct sysdep_dsp_sdl3;
+#endif
 #ifdef SYSDEP_DSP_WAVEOUT
 extern struct plugin_struct sysdep_dsp_waveout;
 #endif

--- a/src/unix/video-drivers/sdl3.c
+++ b/src/unix/video-drivers/sdl3.c
@@ -1,0 +1,769 @@
+/***************************************************************************
+
+ SDL3 display, input and joystick driver for xmame/PinMAME.
+
+ Successor of the SDL 1.2 driver (sdl.c) written by Tadeusz Szczyrba,
+ Ricardo Calixto Quesada, Patrice Mandin and Dan Scholnik.
+
+ The emulated bitmap is blitted (using the generic blit.h scaler/effect
+ code) into a 32bpp XRGB8888 buffer that is uploaded to a streaming texture
+ and drawn by an SDL_Renderer. The renderer takes care of scaling to the
+ window size, fullscreen letterboxing and high DPI displays, so we no
+ longer care about physical display modes like the SDL 1.2 driver did.
+
+***************************************************************************/
+#define __SDL3_C
+
+#include <SDL3/SDL.h>
+#include <stdlib.h>
+#include <string.h>
+#include "xmame.h"
+#include "devices.h"
+#include "keyboard.h"
+#include "driver.h"
+#include "effect.h"
+
+/* A display is a window with a renderer and a streaming texture of the size
+   of the (scaled) emulated bitmap. The unix video layer only ever draws to
+   one display at a time, but switches between the game and the debugger one
+   when the MAME debugger (MAME_DEBUG builds, -debug) takes or loses focus.
+   We keep both windows around, like the Windows builds, so the game and the
+   debugger are visible side by side; the inactive one just keeps showing
+   its last frame. */
+struct sdl3_display {
+   SDL_Window *window;
+   SDL_Renderer *renderer;
+   SDL_Texture *texture;
+   unsigned int *framebuffer;
+   int width;
+   int height;
+};
+
+enum { DISPLAY_GAME = 0, DISPLAY_DEBUGGER, DISPLAY_COUNT };
+static struct sdl3_display displays[DISPLAY_COUNT];
+static struct sdl3_display *current_display = NULL;
+
+static void sdl3_destroy_display(struct sdl3_display *display);
+static void sdl3_select_display(struct sdl3_display *display);
+
+/* the current display, for blit.h and the event handling */
+static SDL_Window *window = NULL;
+static unsigned int *framebuffer = NULL;
+static int vid_width = 0;
+static int vid_height = 0;
+static const int vid_depth = 32; /* we always render to XRGB8888 */
+
+/* rc options */
+static int start_fullscreen = 0;
+static int window_scale = 0;
+static int use_vsync = 0;
+static int linear_filter = 0;
+
+/* joystick instance id -> joy_data index mapping */
+static SDL_Joystick *joysticks[JOY];
+static int joystick_driver_active = 0;
+
+/* set to exit the emulation gracefully, see keyboard.c */
+extern UINT8 trying_to_quit;
+
+typedef void (*update_func_t)(struct mame_bitmap *bitmap);
+static update_func_t update_function = NULL;
+
+static int sdl3_mapkey(struct rc_option *option, const char *arg, int priority);
+
+struct rc_option display_opts[] = {
+   /* name, shortname, type, dest, deflt, min, max, func, help */
+   { "SDL3 Related",  NULL,    rc_seperator,  NULL,
+      NULL,           0,       0,             NULL,
+      NULL },
+   { "fullscreen",    NULL,    rc_bool,       &start_fullscreen,
+      "0",            0,       0,             NULL,
+      "Start fullscreen" },
+   { "windowscale",   "ws",    rc_int,        &window_scale,
+      "0",            0,       32,            NULL,
+      "Scale the window by this integer factor (rendered by the GPU, unlike -scale).\n"
+      "0 (default) picks the largest factor that keeps the window within half of the desktop" },
+   { "vsync",         NULL,    rc_bool,       &use_vsync,
+      "0",            0,       0,             NULL,
+      "Synchronize screen updates with the display refresh" },
+   { "linear",        NULL,    rc_bool,       &linear_filter,
+      "0",            0,       0,             NULL,
+      "Use linear (smooth) instead of nearest neighbour filtering when scaling" },
+   { "sdlmapkey",     "sdlmk", rc_use_function, NULL,
+      NULL,           0,       0,             sdl3_mapkey,
+      "Map an SDL scancode to a MAME keycode, as 0x<sdl scancode>,0x<mame keycode>" },
+   { NULL,            NULL,    rc_end,        NULL,
+      NULL,           0,       0,             NULL,
+      NULL }
+};
+
+/*
+ * SDL scancode (physical key position) -> xmame keycode (pc scancode).
+ * Physical positions are what MAME expects, this makes the mapping
+ * independent of the keyboard layout.
+ */
+static unsigned char scancode_to_key[SDL_SCANCODE_COUNT] = {
+   [SDL_SCANCODE_A] = KEY_A,
+   [SDL_SCANCODE_B] = KEY_B,
+   [SDL_SCANCODE_C] = KEY_C,
+   [SDL_SCANCODE_D] = KEY_D,
+   [SDL_SCANCODE_E] = KEY_E,
+   [SDL_SCANCODE_F] = KEY_F,
+   [SDL_SCANCODE_G] = KEY_G,
+   [SDL_SCANCODE_H] = KEY_H,
+   [SDL_SCANCODE_I] = KEY_I,
+   [SDL_SCANCODE_J] = KEY_J,
+   [SDL_SCANCODE_K] = KEY_K,
+   [SDL_SCANCODE_L] = KEY_L,
+   [SDL_SCANCODE_M] = KEY_M,
+   [SDL_SCANCODE_N] = KEY_N,
+   [SDL_SCANCODE_O] = KEY_O,
+   [SDL_SCANCODE_P] = KEY_P,
+   [SDL_SCANCODE_Q] = KEY_Q,
+   [SDL_SCANCODE_R] = KEY_R,
+   [SDL_SCANCODE_S] = KEY_S,
+   [SDL_SCANCODE_T] = KEY_T,
+   [SDL_SCANCODE_U] = KEY_U,
+   [SDL_SCANCODE_V] = KEY_V,
+   [SDL_SCANCODE_W] = KEY_W,
+   [SDL_SCANCODE_X] = KEY_X,
+   [SDL_SCANCODE_Y] = KEY_Y,
+   [SDL_SCANCODE_Z] = KEY_Z,
+
+   [SDL_SCANCODE_1] = KEY_1,
+   [SDL_SCANCODE_2] = KEY_2,
+   [SDL_SCANCODE_3] = KEY_3,
+   [SDL_SCANCODE_4] = KEY_4,
+   [SDL_SCANCODE_5] = KEY_5,
+   [SDL_SCANCODE_6] = KEY_6,
+   [SDL_SCANCODE_7] = KEY_7,
+   [SDL_SCANCODE_8] = KEY_8,
+   [SDL_SCANCODE_9] = KEY_9,
+   [SDL_SCANCODE_0] = KEY_0,
+
+   [SDL_SCANCODE_RETURN] = KEY_ENTER,
+   [SDL_SCANCODE_ESCAPE] = KEY_ESC,
+   [SDL_SCANCODE_BACKSPACE] = KEY_BACKSPACE,
+   [SDL_SCANCODE_TAB] = KEY_TAB,
+   [SDL_SCANCODE_SPACE] = KEY_SPACE,
+
+   [SDL_SCANCODE_MINUS] = KEY_MINUS,
+   [SDL_SCANCODE_EQUALS] = KEY_EQUALS,
+   [SDL_SCANCODE_LEFTBRACKET] = KEY_OPENBRACE,
+   [SDL_SCANCODE_RIGHTBRACKET] = KEY_CLOSEBRACE,
+   [SDL_SCANCODE_BACKSLASH] = KEY_BACKSLASH,
+   [SDL_SCANCODE_NONUSHASH] = KEY_BACKSLASH2,
+   [SDL_SCANCODE_SEMICOLON] = KEY_COLON,
+   [SDL_SCANCODE_APOSTROPHE] = KEY_QUOTE,
+   [SDL_SCANCODE_GRAVE] = KEY_TILDE,
+   [SDL_SCANCODE_COMMA] = KEY_COMMA,
+   [SDL_SCANCODE_PERIOD] = KEY_STOP,
+   [SDL_SCANCODE_SLASH] = KEY_SLASH,
+   [SDL_SCANCODE_CAPSLOCK] = KEY_CAPSLOCK,
+
+   [SDL_SCANCODE_F1] = KEY_F1,
+   [SDL_SCANCODE_F2] = KEY_F2,
+   [SDL_SCANCODE_F3] = KEY_F3,
+   [SDL_SCANCODE_F4] = KEY_F4,
+   [SDL_SCANCODE_F5] = KEY_F5,
+   [SDL_SCANCODE_F6] = KEY_F6,
+   [SDL_SCANCODE_F7] = KEY_F7,
+   [SDL_SCANCODE_F8] = KEY_F8,
+   [SDL_SCANCODE_F9] = KEY_F9,
+   [SDL_SCANCODE_F10] = KEY_F10,
+   [SDL_SCANCODE_F11] = KEY_F11,
+   [SDL_SCANCODE_F12] = KEY_F12,
+
+   [SDL_SCANCODE_PRINTSCREEN] = KEY_PRTSCR,
+   [SDL_SCANCODE_SCROLLLOCK] = KEY_SCRLOCK,
+   [SDL_SCANCODE_PAUSE] = KEY_PAUSE,
+   [SDL_SCANCODE_INSERT] = KEY_INSERT,
+   [SDL_SCANCODE_HOME] = KEY_HOME,
+   [SDL_SCANCODE_PAGEUP] = KEY_PGUP,
+   [SDL_SCANCODE_DELETE] = KEY_DEL,
+   [SDL_SCANCODE_END] = KEY_END,
+   [SDL_SCANCODE_PAGEDOWN] = KEY_PGDN,
+   [SDL_SCANCODE_RIGHT] = KEY_RIGHT,
+   [SDL_SCANCODE_LEFT] = KEY_LEFT,
+   [SDL_SCANCODE_DOWN] = KEY_DOWN,
+   [SDL_SCANCODE_UP] = KEY_UP,
+
+   [SDL_SCANCODE_NUMLOCKCLEAR] = KEY_NUMLOCK,
+   [SDL_SCANCODE_KP_DIVIDE] = KEY_SLASH_PAD,
+   [SDL_SCANCODE_KP_MULTIPLY] = KEY_ASTERISK,
+   [SDL_SCANCODE_KP_MINUS] = KEY_MINUS_PAD,
+   [SDL_SCANCODE_KP_PLUS] = KEY_PLUS_PAD,
+   [SDL_SCANCODE_KP_ENTER] = KEY_ENTER_PAD,
+   [SDL_SCANCODE_KP_1] = KEY_1_PAD,
+   [SDL_SCANCODE_KP_2] = KEY_2_PAD,
+   [SDL_SCANCODE_KP_3] = KEY_3_PAD,
+   [SDL_SCANCODE_KP_4] = KEY_4_PAD,
+   [SDL_SCANCODE_KP_5] = KEY_5_PAD,
+   [SDL_SCANCODE_KP_6] = KEY_6_PAD,
+   [SDL_SCANCODE_KP_7] = KEY_7_PAD,
+   [SDL_SCANCODE_KP_8] = KEY_8_PAD,
+   [SDL_SCANCODE_KP_9] = KEY_9_PAD,
+   [SDL_SCANCODE_KP_0] = KEY_0_PAD,
+   [SDL_SCANCODE_KP_PERIOD] = KEY_DEL_PAD,
+   [SDL_SCANCODE_NONUSBACKSLASH] = KEY_BACKSLASH2,
+   [SDL_SCANCODE_APPLICATION] = KEY_MENU,
+
+   [SDL_SCANCODE_LCTRL] = KEY_LCONTROL,
+   [SDL_SCANCODE_LSHIFT] = KEY_LSHIFT,
+   [SDL_SCANCODE_LALT] = KEY_ALT,
+   [SDL_SCANCODE_LGUI] = KEY_LWIN,
+   [SDL_SCANCODE_RCTRL] = KEY_RCONTROL,
+   [SDL_SCANCODE_RSHIFT] = KEY_RSHIFT,
+   [SDL_SCANCODE_RALT] = KEY_ALTGR,
+   [SDL_SCANCODE_RGUI] = KEY_RWIN,
+};
+
+/*
+ * keyboard remapping routine, invoked from the rc/command line handling
+ */
+static int sdl3_mapkey(struct rc_option *option, const char *arg, int priority)
+{
+   unsigned int from, to;
+
+   if (sscanf(arg, "0x%x,0x%x", &from, &to) == 2)
+   {
+      if (from < SDL_SCANCODE_COUNT && to < KEY_MAX)
+      {
+         scancode_to_key[from] = to;
+         return OSD_OK;
+      }
+      /* stderr_file isn't defined yet when we're called. */
+      fprintf(stderr, "Invalid keymapping %s. Ignoring...\n", arg);
+   }
+   return OSD_NOT_OK;
+}
+
+int sysdep_init(void)
+{
+   /* SDL_Init is called by sysdep_init as well as, for the audio subsystem,
+      by the dsp plugin. SDL reference counts subsystems, so this is fine. */
+   if (!SDL_Init(SDL_INIT_VIDEO))
+   {
+      fprintf(stderr, "SDL3: Error: %s\n", SDL_GetError());
+      return OSD_NOT_OK;
+   }
+   fprintf(stderr, "SDL3: Info: SDL %d.%d.%d initialized, video driver: %s\n",
+      SDL_VERSIONNUM_MAJOR(SDL_GetVersion()),
+      SDL_VERSIONNUM_MINOR(SDL_GetVersion()),
+      SDL_VERSIONNUM_MICRO(SDL_GetVersion()),
+      SDL_GetCurrentVideoDriver());
+   return OSD_OK;
+}
+
+void sysdep_close(void)
+{
+   int i;
+
+   sdl3_select_display(NULL);
+   for (i = 0; i < DISPLAY_COUNT; i++)
+      sdl3_destroy_display(&displays[i]);
+   SDL_Quit();
+}
+
+/* We always render to a 32bpp texture, so we can handle any bitmap depth */
+int sysdep_display_16bpp_capable(void)
+{
+   return 1;
+}
+
+static void sdl3_destroy_display(struct sdl3_display *display)
+{
+   if (display->texture)
+      SDL_DestroyTexture(display->texture);
+   if (display->renderer)
+      SDL_DestroyRenderer(display->renderer);
+   if (display->window)
+      SDL_DestroyWindow(display->window);
+   if (display->framebuffer)
+      free(display->framebuffer);
+   memset(display, 0, sizeof(*display));
+}
+
+static void sdl3_select_display(struct sdl3_display *display)
+{
+   current_display = display;
+   window = display ? display->window : NULL;
+   framebuffer = display ? display->framebuffer : NULL;
+   vid_width = display ? display->width : 0;
+   vid_height = display ? display->height : 0;
+}
+
+/* Update routines, these use the generic blit.h code */
+static void sdl3_update_16_to_32bpp(struct mame_bitmap *bitmap)
+{
+#define INDIRECT current_palette->lookup
+#define SRC_PIXEL unsigned short
+#define DEST_PIXEL unsigned int
+#define DEST framebuffer
+#define DEST_WIDTH vid_width
+#include "blit.h"
+#undef DEST_WIDTH
+#undef DEST
+#undef DEST_PIXEL
+#undef SRC_PIXEL
+#undef INDIRECT
+}
+
+static void sdl3_update_rgb_direct_32bpp(struct mame_bitmap *bitmap)
+{
+#define SRC_PIXEL unsigned int
+#define DEST_PIXEL unsigned int
+#define DEST framebuffer
+#define DEST_WIDTH vid_width
+#include "blit.h"
+#undef DEST_WIDTH
+#undef DEST
+#undef DEST_PIXEL
+#undef SRC_PIXEL
+}
+
+/* Pick a window scale factor so that the (often tiny, e.g. 128x32 for a DMD)
+   emulated display fills a reasonable part of the desktop. The scale is in
+   pixels, not in (possibly fractionally scaled) desktop points, so the
+   emulated pixels map to an integer number of screen pixels. */
+static int sdl3_auto_window_scale(SDL_Window *window, int width, int height)
+{
+   const SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+   const float density = SDL_GetWindowPixelDensity(window);
+   SDL_Rect bounds;
+   int scale = 1;
+
+   if (display && SDL_GetDisplayUsableBounds(display, &bounds))
+   {
+      const int max_w = (int)(bounds.w * density) / 2;
+      const int max_h = (int)(bounds.h * density) / 2;
+      while ((width * (scale + 1) <= max_w) && (height * (scale + 1) <= max_h))
+         scale++;
+   }
+   return scale;
+}
+
+/* (re)create the texture and framebuffer for a display size and size the window accordingly */
+static int sdl3_resize_display(struct sdl3_display *display, int width, int height)
+{
+   float density;
+   int scale, pixel_w, pixel_h;
+
+   if (display->texture)
+      SDL_DestroyTexture(display->texture);
+   if (display->framebuffer)
+      free(display->framebuffer);
+
+   display->width = width;
+   display->height = height;
+
+   /* The window size is in desktop points, and the points to pixels factor
+      (e.g. 1.75 for 175% desktop scaling on wayland, 2 on a retina mac) is
+      only known once the window exists, so size it here to get an integer
+      number of pixels per emulated pixel */
+   SDL_SyncWindow(display->window);
+   density = SDL_GetWindowPixelDensity(display->window);
+   if (density <= 0.0f)
+      density = 1.0f;
+   scale = window_scale ? window_scale : sdl3_auto_window_scale(display->window, width, height);
+   SDL_SetWindowSize(display->window,
+      (int)SDL_lroundf(width * scale / density), (int)SDL_lroundf(height * scale / density));
+   SDL_SyncWindow(display->window);
+   SDL_GetWindowSizeInPixels(display->window, &pixel_w, &pixel_h);
+   fprintf(stderr, "SDL3: Info: %dx%d display, window scale factor %d, %dx%d pixels\n",
+      width, height, scale, pixel_w, pixel_h);
+
+   /* Keep the aspect ratio when the window gets resized or goes fullscreen */
+   SDL_SetRenderLogicalPresentation(display->renderer, width, height,
+      SDL_LOGICAL_PRESENTATION_LETTERBOX);
+
+   display->texture = SDL_CreateTexture(display->renderer, SDL_PIXELFORMAT_XRGB8888,
+      SDL_TEXTUREACCESS_STREAMING, width, height);
+   if (!display->texture)
+   {
+      fprintf(stderr, "SDL3: Error: Creating texture failed: %s\n", SDL_GetError());
+      return OSD_NOT_OK;
+   }
+   /* pixel art mode keeps pixels crisp also at non integer scale factors (fractional desktop scaling) */
+   SDL_SetTextureScaleMode(display->texture, linear_filter ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_PIXELART);
+
+   display->framebuffer = calloc((size_t)width * height, sizeof(unsigned int));
+   if (!display->framebuffer)
+   {
+      fprintf(stderr, "SDL3: Error: Allocating the framebuffer failed\n");
+      return OSD_NOT_OK;
+   }
+
+   /* Present a first (black) frame right away: on Wayland a window without
+      a presented frame is not shown at all, and the game window can be
+      switched away from before it ever got a frame (e.g. when the debugger
+      takes focus at startup) */
+   SDL_SetRenderDrawColor(display->renderer, 0, 0, 0, 255);
+   SDL_RenderClear(display->renderer);
+   SDL_RenderPresent(display->renderer);
+
+   return OSD_OK;
+}
+
+/* create the window and renderer for a display */
+static int sdl3_open_display(struct sdl3_display *display, const char *window_title)
+{
+   SDL_WindowFlags window_flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
+
+   if (start_fullscreen && display == &displays[DISPLAY_GAME])
+      window_flags |= SDL_WINDOW_FULLSCREEN;
+
+   display->window = SDL_CreateWindow(window_title, 64, 64, window_flags);
+   if (!display->window)
+   {
+      fprintf(stderr, "SDL3: Error: Creating window failed: %s\n", SDL_GetError());
+      return OSD_NOT_OK;
+   }
+
+   display->renderer = SDL_CreateRenderer(display->window, NULL);
+   if (!display->renderer)
+   {
+      fprintf(stderr, "SDL3: Error: Creating renderer failed: %s\n", SDL_GetError());
+      return OSD_NOT_OK;
+   }
+   fprintf(stderr, "SDL3: Info: Using the %s renderer\n", SDL_GetRendererName(display->renderer));
+
+   if (!SDL_SetRenderVSync(display->renderer, use_vsync ? 1 : SDL_RENDERER_VSYNC_DISABLED))
+      fprintf(stderr, "SDL3: Warning: Setting vsync failed: %s\n", SDL_GetError());
+
+   return OSD_OK;
+}
+
+int sysdep_create_display(int depth)
+{
+   struct sdl3_display *display = &displays[DISPLAY_GAME];
+   int width = visual_width * widthscale;
+   int height = visual_height * heightscale;
+   char window_title[sizeof(title) + 16];
+
+   if (yarbsize)
+      height = yarbsize;
+
+   switch (depth)
+   {
+      case 16:
+         update_function = sdl3_update_16_to_32bpp;
+         break;
+      case 32:
+         update_function = sdl3_update_rgb_direct_32bpp;
+         break;
+      default:
+         fprintf(stderr, "SDL3: Error: Unsupported bitmap depth %d\n", depth);
+         return OSD_NOT_OK;
+   }
+
+   snprintf(window_title, sizeof(window_title), "%s", title);
+#ifdef MAME_DEBUG
+   /* the debugger display is recognized by its size (-debug_resolution) */
+   if (options.mame_debug && width == options.debug_width && height == options.debug_height)
+   {
+      display = &displays[DISPLAY_DEBUGGER];
+      snprintf(window_title, sizeof(window_title), "%s - debugger", title);
+   }
+#endif
+
+   /* the window is created once and reused (and resized when needed) when
+      the display is switched away from and back */
+   if (!display->window)
+   {
+      if (sdl3_open_display(display, window_title) != OSD_OK)
+      {
+         sdl3_destroy_display(display);
+         return OSD_NOT_OK;
+      }
+      if (sdl3_resize_display(display, width, height) != OSD_OK)
+      {
+         sdl3_destroy_display(display);
+         return OSD_NOT_OK;
+      }
+
+      /* put the debugger next to the game window (where the window manager allows it) */
+      if (display == &displays[DISPLAY_DEBUGGER] && displays[DISPLAY_GAME].window)
+      {
+         int x, y, w, h;
+         if (SDL_GetWindowPosition(displays[DISPLAY_GAME].window, &x, &y)
+            && SDL_GetWindowSize(displays[DISPLAY_GAME].window, &w, &h))
+            SDL_SetWindowPosition(display->window, x + w + 16, y);
+      }
+   }
+   else
+   {
+      if ((display->width != width || display->height != height)
+         && sdl3_resize_display(display, width, height) != OSD_OK)
+      {
+         sdl3_destroy_display(display);
+         return OSD_NOT_OK;
+      }
+      SDL_RaiseWindow(display->window);
+   }
+
+   sdl3_select_display(display);
+
+   /* fill the display_palette_info struct, XRGB8888 */
+   memset(&display_palette_info, 0, sizeof(struct sysdep_palette_info));
+   display_palette_info.depth = vid_depth;
+   display_palette_info.red_mask   = 0x00FF0000;
+   display_palette_info.green_mask = 0x0000FF00;
+   display_palette_info.blue_mask  = 0x000000FF;
+
+   if (display == &displays[DISPLAY_GAME])
+      SDL_HideCursor();
+   else
+      SDL_ShowCursor();
+
+   effect_init2(depth, vid_depth, vid_width);
+
+   return OSD_OK;
+}
+
+void sysdep_update_display(struct mame_bitmap *bitmap)
+{
+   struct sdl3_display *display = current_display;
+
+   if (!display)
+      return;
+
+   (*update_function)(bitmap);
+
+   SDL_UpdateTexture(display->texture, NULL, display->framebuffer, display->width * sizeof(unsigned int));
+   SDL_RenderClear(display->renderer);
+   SDL_RenderTexture(display->renderer, display->texture, NULL, NULL);
+   SDL_RenderPresent(display->renderer);
+}
+
+/* Called when the display is switched (game <-> debugger, or a size change,
+   which is handled in sysdep_create_display) and at exit. The windows are
+   kept, sysdep_close destroys them. */
+void sysdep_display_close(void)
+{
+   SDL_ShowCursor();
+   sdl3_select_display(NULL);
+}
+
+/* We only support truecolor, so nothing to do for the palette calls */
+int sysdep_display_alloc_palette(int totalcolors)
+{
+   return 0;
+}
+
+int sysdep_display_set_pen(int pen, unsigned char red, unsigned char green, unsigned char blue)
+{
+   return 0;
+}
+
+void sysdep_mouse_poll(void)
+{
+   float x, y;
+   int i;
+   SDL_MouseButtonFlags buttons = SDL_GetRelativeMouseState(&x, &y);
+
+   mouse_data[0].deltas[0] = (int)x;
+   mouse_data[0].deltas[1] = (int)y;
+   for (i = 0; i < MOUSE_BUTTONS; i++)
+      mouse_data[0].buttons[i] = (buttons & SDL_BUTTON_MASK(i + 1)) ? 1 : 0;
+}
+
+void sysdep_set_leds(int leds)
+{
+}
+
+/*
+ * Joystick support, selected with -joytype 7. Joysticks are opened here and
+ * the events are handled in sysdep_update_keyboard.
+ */
+static int sdl3_joystick_index(SDL_JoystickID id)
+{
+   int i;
+   for (i = 0; i < JOY; i++)
+      if (joysticks[i] && SDL_GetJoystickID(joysticks[i]) == id)
+         return i;
+   return -1;
+}
+
+static void sdl3_joystick_add(SDL_JoystickID id)
+{
+   int i, j;
+
+   if (sdl3_joystick_index(id) >= 0)
+      return;
+
+   for (i = 0; i < JOY; i++)
+      if (!joysticks[i])
+         break;
+   if (i == JOY)
+   {
+      fprintf(stderr, "SDL3: Warning: More than %d joysticks, ignoring joystick %u\n", JOY, id);
+      return;
+   }
+
+   joysticks[i] = SDL_OpenJoystick(id);
+   if (!joysticks[i])
+   {
+      fprintf(stderr, "SDL3: Warning: Opening joystick %u failed: %s\n", id, SDL_GetError());
+      return;
+   }
+
+   joy_data[i].fd = i;
+   joy_data[i].num_buttons = SDL_GetNumJoystickButtons(joysticks[i]);
+   joy_data[i].num_axis = SDL_GetNumJoystickAxes(joysticks[i]);
+   if (joy_data[i].num_buttons > JOY_BUTTONS)
+      joy_data[i].num_buttons = JOY_BUTTONS;
+   if (joy_data[i].num_axis > JOY_AXIS)
+      joy_data[i].num_axis = JOY_AXIS;
+   for (j = 0; j < joy_data[i].num_axis; j++)
+   {
+      joy_data[i].axis[j].min = -32768;
+      joy_data[i].axis[j].center = 0;
+      joy_data[i].axis[j].max = 32767;
+   }
+
+   fprintf(stderr, "SDL3: Info: Joystick %d: %s, %d axes, %d buttons\n", i,
+      SDL_GetJoystickName(joysticks[i]), joy_data[i].num_axis, joy_data[i].num_buttons);
+}
+
+static void sdl3_joystick_remove(SDL_JoystickID id)
+{
+   int i = sdl3_joystick_index(id);
+   if (i < 0)
+      return;
+
+   fprintf(stderr, "SDL3: Info: Joystick %d removed\n", i);
+   SDL_CloseJoystick(joysticks[i]);
+   joysticks[i] = NULL;
+   memset(&joy_data[i], 0, sizeof(joy_data[i]));
+   joy_data[i].fd = -1;
+}
+
+static void sdl3_joystick_poll(void)
+{
+   /* the axis/button values are updated by the event loop in
+      sysdep_update_keyboard, here we only derive the digital directions */
+   joy_evaluate_moves();
+}
+
+void joy_SDL_init(void)
+{
+   int i, count = 0;
+   SDL_JoystickID *ids;
+
+   if (!SDL_InitSubSystem(SDL_INIT_JOYSTICK))
+   {
+      fprintf(stderr, "SDL3: Warning: Joystick init failed: %s\n", SDL_GetError());
+      return;
+   }
+   joystick_driver_active = 1;
+
+   for (i = 0; i < JOY; i++)
+      joy_data[i].fd = -1;
+
+   ids = SDL_GetJoysticks(&count);
+   if (ids)
+   {
+      for (i = 0; i < count; i++)
+         sdl3_joystick_add(ids[i]);
+      SDL_free(ids);
+   }
+   fprintf(stderr, "SDL3: Info: %d joystick(s) found\n", count);
+
+   joy_poll_func = sdl3_joystick_poll;
+}
+
+static unsigned short sdl3_key_unicode(const SDL_KeyboardEvent *key)
+{
+   /* osd_readkey_unicode() is used for text entry in the ui, approximate the
+      typed character from the keycode and the modifiers */
+   SDL_Keycode code = SDL_GetKeyFromScancode(key->scancode, key->mod, false);
+   if (code >= 0x20 && code < 0x7f)
+      return (unsigned short)code;
+   if (code == SDLK_RETURN || code == SDLK_KP_ENTER)
+      return '\r';
+   if (code == SDLK_BACKSPACE || code == SDLK_TAB || code == SDLK_ESCAPE)
+      return (unsigned short)code;
+   return 0;
+}
+
+void sysdep_update_keyboard(void)
+{
+   struct xmame_keyboard_event kevent;
+   SDL_Event event;
+
+   if (!displays[DISPLAY_GAME].window && !displays[DISPLAY_DEBUGGER].window)
+      return;
+
+   while (SDL_PollEvent(&event))
+   {
+      switch (event.type)
+      {
+         case SDL_EVENT_KEY_DOWN:
+         case SDL_EVENT_KEY_UP:
+            if (event.key.repeat)
+               break;
+
+            /* ALT-Enter: toggle fullscreen */
+            if (event.type == SDL_EVENT_KEY_DOWN && event.key.scancode == SDL_SCANCODE_RETURN
+               && (event.key.mod & SDL_KMOD_ALT))
+            {
+               SDL_Window *key_window = SDL_GetWindowFromID(event.key.windowID);
+               if (key_window)
+                  SDL_SetWindowFullscreen(key_window, !(SDL_GetWindowFlags(key_window) & SDL_WINDOW_FULLSCREEN));
+               break;
+            }
+
+            if (event.key.scancode >= SDL_SCANCODE_COUNT)
+               break;
+            kevent.press = (event.type == SDL_EVENT_KEY_DOWN);
+            kevent.scancode = scancode_to_key[event.key.scancode];
+            kevent.unicode = kevent.press ? sdl3_key_unicode(&event.key) : 0;
+            if (kevent.scancode == KEY_NONE)
+            {
+               fprintf(stderr, "SDL3: Warning: Unmapped key %s (scancode 0x%x)\n",
+                  SDL_GetScancodeName(event.key.scancode), event.key.scancode);
+               break;
+            }
+            xmame_keyboard_register_event(&kevent);
+            break;
+
+         case SDL_EVENT_QUIT:
+         case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            /* exit cleanly (saving nvram etc), keyboard.c fakes the escape
+               presses for this */
+            trying_to_quit = 1;
+            break;
+
+         case SDL_EVENT_JOYSTICK_ADDED:
+            if (joystick_driver_active)
+               sdl3_joystick_add(event.jdevice.which);
+            break;
+
+         case SDL_EVENT_JOYSTICK_REMOVED:
+            if (joystick_driver_active)
+               sdl3_joystick_remove(event.jdevice.which);
+            break;
+
+         case SDL_EVENT_JOYSTICK_AXIS_MOTION:
+         {
+            int joy = sdl3_joystick_index(event.jaxis.which);
+            if (joy >= 0 && event.jaxis.axis < JOY_AXIS)
+               joy_data[joy].axis[event.jaxis.axis].val = event.jaxis.value;
+            break;
+         }
+
+         case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+         case SDL_EVENT_JOYSTICK_BUTTON_UP:
+         {
+            int joy = sdl3_joystick_index(event.jbutton.which);
+            if (joy >= 0 && event.jbutton.button < JOY_BUTTONS)
+               joy_data[joy].buttons[event.jbutton.button] = event.jbutton.down;
+            break;
+         }
+
+         default:
+            break;
+      }
+   }
+}

--- a/src/unix/video.c
+++ b/src/unix/video.c
@@ -908,7 +908,10 @@ void osd_update_video_and_audio(struct mame_display *display)
 	skip_this_frame = skip_next_frame;
 	skip_next_frame = (*skip_next_frame_functions[frameskipper])();
 
-	if (sound_stream && sound_enabled)
+	/* While the debugger has focus the emulation is stopped and no new samples
+	   arrive; updating the stream would just replay its last buffer over and
+	   over, so let the device run dry (silence) instead */
+	if (sound_stream && sound_enabled && !debugger_has_focus)
 		sound_stream_update(sound_stream);
 
 	/* if the visible area has changed, update it */


### PR DESCRIPTION
Supersedes #348, restarted from scratch on current master as a new `sdl3pinmame` target instead of changing xpinmame.

- New SDL3 display/input/joystick driver and SDL3 sound plugin (`src/unix/video-drivers/sdl3.c`, `src/unix/sysdep/dsp-drivers/sdl3.c`), separate files so the SDL2 based lisy build is untouched.
- One platform-agnostic cmake file (`cmake/sdl3pinmame/CMakeLists.txt`, `-DPLATFORM=linux|macos -DARCH=x64|arm64`) that fetches and statically links SDL 3.4.14 by default (`-DSDL3PINMAME_SYSTEM_SDL=ON` to use an installed one), plus a workflow for linux-x64, macos-x64 and macos-arm64.
- Optional `-DSDL3PINMAME_MAME_DEBUG=ON` build with the MAME debugger in its own window next to the game window.
- The cmake file also avoids two pitfalls inherited from the xpinmame cmake files: the unquoted `INLINE=static __inline__` define (turns `__inline__` into `1`) and the missing `HAVE_VSNPRINTF` (the vsnprintf replacement in `src/unix/snprintf.c` crashes on `vsnprintf(NULL, 0, ...)`).

Tested on Linux (Wayland and XWayland, pipewire), macOS builds are CI only so far.
