### PR TITLE
LibPinMAME: read CPU memory on the emulation thread

### DIFF
--- a/src/libpinmame/PinMAMEPlugin.h
+++ b/src/libpinmame/PinMAMEPlugin.h
@@ -45,6 +45,26 @@ typedef struct PinMAMEReadMemoryMsg
    uint32_t read;       // Response: bytes actually read, 0 if unavailable
 } PinMAMEReadMemoryMsg;
 
+#define PMPI_WRITE_MEMORY                    "WriteMemory:1"
+
+typedef struct PinMAMEWriteMemoryOp
+{
+   uint32_t address;       // Start address in the main CPU address space
+   uint32_t size;          // Number of bytes to write
+   const uint8_t* data;    // Caller-owned buffer, at least 'size' bytes
+} PinMAMEWriteMemoryOp;
+
+// Every op in one message is applied in a single pass on the emulation thread, so the
+// machine cannot run between them. WPC needs that: writing protected CMOS means storing
+// 0xB4 to 0x3FFD first, and the game re-locks within a frame.
+typedef struct PinMAMEWriteMemoryMsg
+{
+   int version;                      // Always 1 (to allow upgrading this message in later revisions)
+   uint32_t count;                   // Request: number of ops
+   const PinMAMEWriteMemoryOp* ops;  // Request: applied in order, atomically
+   uint32_t applied;                 // Response: count on success, 0 if unavailable
+} PinMAMEWriteMemoryMsg;
+
 
 // State groups
 // 

--- a/src/libpinmame/PinMAMEPlugin.h
+++ b/src/libpinmame/PinMAMEPlugin.h
@@ -36,6 +36,11 @@ typedef struct PinMAMEMachineStateMsg
 
 #define PMPI_READ_MEMORY                     "ReadMemory:1"
 
+// The read is performed on the emulation thread between time slices, dispatched through the
+// memory map like a CPU read, so handler-backed RAM reads correctly and the result cannot be
+// torn by the running emulation or resolved against another CPU's bank tables. The caller
+// waits for the next frame (bounded, typically under 20 ms). 'read' is short only when the
+// range runs past the end of the address space.
 typedef struct PinMAMEReadMemoryMsg
 {
    int version;         // Always 1 (to allow upgrading this message in later revisions)

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1753,64 +1753,6 @@ PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates)
 }
 
 /******************************************************
- * PinmameReadMainCPUByte
- ******************************************************/
-
-PINMAMEAPI int PinmameReadMainCPUByte(const uint32_t address, uint8_t* const p_value)
-{
-	return PinmameReadMainCPUMemory(address, p_value, 1);
-}
-
-/* A NULL from memory_get_read_ptr() means the read table holds a handler rather than
-   a direct pointer, not that the address is unreadable at all, se.c routes all of
-   Whitestar/Sega main RAM through ram_r. memory_find_base() has no bounds check. */
-
-static int ReadThroughRamBase(const uint32_t address, uint8_t* const p_buffer, const int size)
-{
-	const size_t regionLength = memory_region_length(REGION_CPU1);
-	if (address >= regionLength)
-	{
-		return 0;
-	}
-
-	const uint8_t* const p_base = static_cast<const uint8_t*>(memory_find_base(0, address));
-	if (p_base == nullptr)
-	{
-		return 0;
-	}
-
-	const int available = (int)std::min((size_t)size, regionLength - address);
-	memcpy(p_buffer, p_base, available);
-
-	return available;
-}
-
-/******************************************************
- * PinmameReadMainCPUMemory
- ******************************************************/
-
-PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p_buffer, const int size)
-{
-	if (!_isRunning || p_buffer == nullptr || size <= 0)
-	{
-		return 0;
-	}
-
-	for (int i = 0; i < size; i++)
-	{
-		uint8_t* p_memory = static_cast<uint8_t*>(memory_get_read_ptr(0, address + i));
-		if (p_memory == nullptr)
-		{
-			return i > 0 ? i : ReadThroughRamBase(address, p_buffer, size);
-		}
-
-		p_buffer[i] = *p_memory;
-	}
-
-	return size;
-}
-
-/******************************************************
  * PinmameWriteMainCPUMemory
  ******************************************************/
 
@@ -1823,9 +1765,21 @@ struct PendingWrite
 	bool done;
 };
 
+struct PendingRead
+{
+	uint32_t address;
+	uint8_t* buffer;
+	int size;
+	int read;
+	bool done;
+};
+
+/* One mutex and one condition variable serve both queues: they are drained together, writes
+   first, so a read queued after a write observes it. */
 std::mutex g_writeMutex;
 std::condition_variable g_writeCv;
 std::vector<PendingWrite*> g_writeQueue;
+std::vector<PendingRead*> g_readQueue;
 
 } /* anonymous namespace */
 
@@ -1854,32 +1808,135 @@ static void ApplyWrites(const std::vector<PendingWrite*>& batch)
 	cpuintrf_pop_context();
 }
 
-/* Called once per frame from osd_update_video_and_audio(), on the emulation thread. */
-extern "C" void libpinmame_drain_pending_writes(void)
+/* Reads go the same way, for two reasons a pointer read cannot satisfy. First, the memory
+   map's bank tables are switched by memory_set_context() every time the emulation moves
+   between CPUs, so a pointer resolved on another thread points into whichever CPU is active
+   at that instant: on WPC a read of fixed ROM at 0x8000-0xFFFF intermittently returns a
+   whole 256-byte chunk of zeros while reporting success. Second, read handlers carry
+   platform semantics: Whitestar and Sega route all of main RAM through ram_r, so
+   memory_get_read_ptr() has nothing to return there and every read came back short. On the
+   emulation thread, between time slices, the CPU context is valid and cpunum_read_byte()
+   dispatches through the map exactly as the CPU itself would. The cost is that a caller on
+   another thread waits for the next frame, the same as a write. Reading a register through
+   its handler can have the side effect the hardware has; callers read RAM, NVRAM and ROM. */
+
+static void ApplyReads(const std::vector<PendingRead*>& batch)
 {
-	static std::vector<PendingWrite*> batch;   /* static, so the queue keeps its capacity */
+	const uint32_t addressSpace = 1u << cpunum_address_bits(0);
+
+	cpuintrf_push_context(0);
+
+	for (PendingRead* r : batch)
+	{
+		r->read = 0;
+		for (int i = 0; i < r->size; i++)
+		{
+			const uint32_t address = r->address + (uint32_t)i;
+			if (address >= addressSpace)
+			{
+				break;
+			}
+			r->buffer[i] = cpunum_read_byte(0, address);
+			r->read = i + 1;
+		}
+	}
+
+	cpuintrf_pop_context();
+}
+
+/* Called once per frame from osd_update_video_and_audio(), on the emulation thread.
+   Writes are applied before reads so that a read queued after a write observes it. */
+extern "C" void libpinmame_drain_pending_memory_ops(void)
+{
+	static std::vector<PendingWrite*> writes;   /* static, so the queues keep their capacity */
+	static std::vector<PendingRead*> reads;
 
 	{
 		std::lock_guard<std::mutex> lock(g_writeMutex);
-		if (g_writeQueue.empty())
+		if (g_writeQueue.empty() && g_readQueue.empty())
 		{
 			return;
 		}
-		batch.swap(g_writeQueue);
+		writes.swap(g_writeQueue);
+		reads.swap(g_readQueue);
 	}
 
-	ApplyWrites(batch);
+	if (!writes.empty())
+	{
+		ApplyWrites(writes);
+	}
+	if (!reads.empty())
+	{
+		ApplyReads(reads);
+	}
 
 	{
 		std::lock_guard<std::mutex> lock(g_writeMutex);
-		for (PendingWrite* w : batch)
+		for (PendingWrite* w : writes)
 		{
 			w->done = true;
 		}
+		for (PendingRead* r : reads)
+		{
+			r->done = true;
+		}
 	}
 
-	batch.clear();
+	writes.clear();
+	reads.clear();
 	g_writeCv.notify_all();
+}
+
+static int SubmitRead(const uint32_t address, uint8_t* const p_buffer, const int size)
+{
+	PendingRead r { address, p_buffer, size, 0, false };
+
+	/* Already on the emulation thread: read directly rather than waiting for our own drain. */
+	if (_p_gameThread && std::this_thread::get_id() == _p_gameThread->get_id())
+	{
+		ApplyReads({ &r });
+		return r.read;
+	}
+
+	std::unique_lock<std::mutex> lock(g_writeMutex);
+	g_readQueue.push_back(&r);
+
+	/* Bounded, so a stalled or paused emulator cannot hang the caller. */
+	if (!g_writeCv.wait_for(lock, std::chrono::milliseconds(250), [&r] { return r.done; }))
+	{
+		std::erase(g_readQueue, &r);
+		return 0;
+	}
+
+	return r.read;
+}
+
+/******************************************************
+ * PinmameReadMainCPUByte
+ ******************************************************/
+
+PINMAMEAPI int PinmameReadMainCPUByte(const uint32_t address, uint8_t* const p_value)
+{
+	if (!_isRunning || p_value == nullptr)
+	{
+		return 0;
+	}
+
+	return SubmitRead(address, p_value, 1);
+}
+
+/******************************************************
+ * PinmameReadMainCPUMemory
+ ******************************************************/
+
+PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p_buffer, const int size)
+{
+	if (!_isRunning || p_buffer == nullptr || size <= 0)
+	{
+		return 0;
+	}
+
+	return SubmitRead(address, p_buffer, size);
 }
 
 static bool SubmitWrite(const PinMAMEWriteMemoryOp* const ops, const uint32_t count)

--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -8,6 +8,9 @@
 #include <vector>
 #include <algorithm>
 #include <format>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
 
 #if (defined(_M_IX86_FP) && _M_IX86_FP >= 2) || defined(__SSE2__) || defined(_M_X64) || defined(_M_AMD64) || defined(__ia64__) || defined(__x86_64__)
  #define SSE_DISPLAY_OPT
@@ -269,6 +272,7 @@ static struct MsgLocals
 
    unsigned int onGetMachineStateId;
    unsigned int onReadMemoryId;
+   unsigned int onWriteMemoryId;
 
    struct MemMapState
    {
@@ -1807,6 +1811,114 @@ PINMAMEAPI int PinmameReadMainCPUMemory(const uint32_t address, uint8_t* const p
 }
 
 /******************************************************
+ * PinmameWriteMainCPUMemory
+ ******************************************************/
+
+namespace {
+
+struct PendingWrite
+{
+	const PinMAMEWriteMemoryOp* ops;
+	uint32_t count;
+	bool done;
+};
+
+std::mutex g_writeMutex;
+std::condition_variable g_writeCv;
+std::vector<PendingWrite*> g_writeQueue;
+
+} /* anonymous namespace */
+
+/* Dispatched through the memory map rather than a pointer from memory_get_write_ptr(),
+   because write handlers carry platform semantics a pointer write would bypass: WPC
+   gates CMOS on a protection register, early Bally stores only the high nibble,
+   Gottlieb System 80 mirrors each byte to 32 addresses. Applying a whole batch here
+   means the machine cannot run between the ops of one request. The CPU context is
+   installed once for the batch rather than per byte. */
+
+static void ApplyWrites(const std::vector<PendingWrite*>& batch)
+{
+	cpuintrf_push_context(0);
+
+	for (const PendingWrite* w : batch)
+	{
+		for (uint32_t op = 0; op < w->count; op++)
+		{
+			for (uint32_t i = 0; i < w->ops[op].size; i++)
+			{
+				cpunum_write_byte(0, w->ops[op].address + i, w->ops[op].data[i]);
+			}
+		}
+	}
+
+	cpuintrf_pop_context();
+}
+
+/* Called once per frame from osd_update_video_and_audio(), on the emulation thread. */
+extern "C" void libpinmame_drain_pending_writes(void)
+{
+	static std::vector<PendingWrite*> batch;   /* static, so the queue keeps its capacity */
+
+	{
+		std::lock_guard<std::mutex> lock(g_writeMutex);
+		if (g_writeQueue.empty())
+		{
+			return;
+		}
+		batch.swap(g_writeQueue);
+	}
+
+	ApplyWrites(batch);
+
+	{
+		std::lock_guard<std::mutex> lock(g_writeMutex);
+		for (PendingWrite* w : batch)
+		{
+			w->done = true;
+		}
+	}
+
+	batch.clear();
+	g_writeCv.notify_all();
+}
+
+static bool SubmitWrite(const PinMAMEWriteMemoryOp* const ops, const uint32_t count)
+{
+	PendingWrite w { ops, count, false };
+
+	/* Already on the emulation thread: apply directly rather than waiting for our own drain. */
+	if (_p_gameThread && std::this_thread::get_id() == _p_gameThread->get_id())
+	{
+		ApplyWrites({ &w });
+		return true;
+	}
+
+	std::unique_lock<std::mutex> lock(g_writeMutex);
+	g_writeQueue.push_back(&w);
+
+	/* Bounded, so a stalled or paused emulator cannot hang the caller. */
+	if (!g_writeCv.wait_for(lock, std::chrono::milliseconds(250), [&w] { return w.done; }))
+	{
+		std::erase(g_writeQueue, &w);
+		return false;
+	}
+
+	return true;
+}
+
+PINMAMEAPI int PinmameWriteMainCPUMemory(const uint32_t address, const uint8_t* const p_buffer, const int size)
+{
+	if (!_isRunning || p_buffer == nullptr || size <= 0)
+	{
+		return 0;
+	}
+
+	const PinMAMEWriteMemoryOp op { address, (uint32_t)size, p_buffer };
+
+	return SubmitWrite(&op, 1) ? size : 0;
+}
+
+/******************************************************
  * PinmameGetRawMemoryRegion
  ******************************************************/
 
@@ -1860,6 +1972,18 @@ static void OnReadMemory(const unsigned int eventId, void* userData, void* msgDa
       return;
 
    msg->read = PinmameReadMainCPUMemory(msg->address, msg->data, (int)msg->size);
+}
+
+static void OnWriteMemory(const unsigned int eventId, void* userData, void* msgData)
+{
+   if (_isRunning != 1)
+      return;
+
+   auto msg = static_cast<PinMAMEWriteMemoryMsg*>(msgData);
+   if (msg->version != 1 || msg->ops == nullptr || msg->count == 0)
+      return;
+
+   msg->applied = SubmitWrite(msg->ops, msg->count) ? msg->count : 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2702,6 +2826,8 @@ static void SetupMsgApi()
    msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
    msgLocals.onReadMemoryId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_READ_MEMORY);
    msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onReadMemoryId, OnReadMemory, nullptr);
+   msgLocals.onWriteMemoryId = msgLocals.msgApi->GetMsgID(PMPI_NAMESPACE, PMPI_WRITE_MEMORY);
+   msgLocals.msgApi->SubscribeMsg(msgLocals.endpointId, msgLocals.onWriteMemoryId, OnWriteMemory, nullptr);
 
    msgLocals.controllerProvider = std::make_unique<PinballPlugin::Controller::CtrlItemProvider<ControllerDef>>(msgLocals.msgApi, msgLocals.endpointId, CTLPI_CONTROLLERS_GET_MSG, CTLPI_CONTROLLERS_ON_CHG_MSG);
 
@@ -2722,10 +2848,12 @@ static void ReleaseMsgApi()
 
    msgLocals.msgApi->UnsubscribeMsg(msgLocals.onGetMachineStateId, OnGetMachineState, nullptr);
    msgLocals.msgApi->UnsubscribeMsg(msgLocals.onReadMemoryId, OnReadMemory, nullptr);
+   msgLocals.msgApi->UnsubscribeMsg(msgLocals.onWriteMemoryId, OnWriteMemory, nullptr);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onDmdCmdId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onConsoleDataId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onGetMachineStateId);
    msgLocals.msgApi->ReleaseMsgID(msgLocals.onReadMemoryId);
+   msgLocals.msgApi->ReleaseMsgID(msgLocals.onWriteMemoryId);
 
    msgLocals.controllerProvider = nullptr;
 

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -484,6 +484,8 @@ PINMAMEAPI void PinmameSetDIP(const int dipBank, const int value);
 PINMAMEAPI int PinmameGetMaxNVRAM();
 PINMAMEAPI int PinmameGetNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates);
+/* Memory reads and writes are applied on the emulation thread between time slices and dispatch
+   through the memory map. A caller on another thread waits for the next frame (bounded). */
 PINMAMEAPI int PinmameReadMainCPUByte(uint32_t address, uint8_t* const p_value);
 PINMAMEAPI int PinmameReadMainCPUMemory(uint32_t address, uint8_t* const p_buffer, int size);
 PINMAMEAPI int PinmameWriteMainCPUMemory(uint32_t address, const uint8_t* const p_buffer, int size);

--- a/src/libpinmame/libpinmame.h
+++ b/src/libpinmame/libpinmame.h
@@ -486,6 +486,7 @@ PINMAMEAPI int PinmameGetNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameGetChangedNVRAM(PinmameNVRAMState* const p_nvramStates);
 PINMAMEAPI int PinmameReadMainCPUByte(uint32_t address, uint8_t* const p_value);
 PINMAMEAPI int PinmameReadMainCPUMemory(uint32_t address, uint8_t* const p_buffer, int size);
+PINMAMEAPI int PinmameWriteMainCPUMemory(uint32_t address, const uint8_t* const p_buffer, int size);
 PINMAMEAPI const uint8_t* PinmameGetRawMemoryRegion(const int region);
 PINMAMEAPI size_t PinmameGetRawMemoryRegionLength(const int region);
 PINMAMEAPI void PinmameSetUserData(void* const p_userData);

--- a/src/libpinmame/video.c
+++ b/src/libpinmame/video.c
@@ -19,6 +19,7 @@
 #include "menu.h"
 #endif
 
+extern void libpinmame_drain_pending_writes(void);
 extern void libpinmame_log_info(const char* format, ...);
 
 //============================================================
@@ -666,6 +667,10 @@ static void update_timing()
 void osd_update_video_and_audio(struct mame_display *display)
 {
 	cycles_t cps = osd_cycles_per_second();
+
+	/* Runs once per frame on the emulation thread, which is where queued writes
+	   have to be applied. */
+	libpinmame_drain_pending_writes();
 
 	// if this is the first time through, initialize the previous time value
 	if (warming_up)

--- a/src/libpinmame/video.c
+++ b/src/libpinmame/video.c
@@ -19,7 +19,7 @@
 #include "menu.h"
 #endif
 
-extern void libpinmame_drain_pending_writes(void);
+extern void libpinmame_drain_pending_memory_ops(void);
 extern void libpinmame_log_info(const char* format, ...);
 
 //============================================================
@@ -670,7 +670,7 @@ void osd_update_video_and_audio(struct mame_display *display)
 
 	/* Runs once per frame on the emulation thread, which is where queued writes
 	   have to be applied. */
-	libpinmame_drain_pending_writes();
+	libpinmame_drain_pending_memory_ops();
 
 	// if this is the first time through, initialize the previous time value
 	if (warming_up)


### PR DESCRIPTION
Fixes #642. Rebased onto `2006ce5b` (which merged #633); replaces the pointer-path read, including the `memory_find_base` fallback #633 added, with the emulation-thread read.

## What

`PinmameReadMainCPUMemory()` and `PinmameReadMainCPUByte()` resolved a pointer with `memory_get_read_ptr()` on the caller's thread. That has two failure modes, both silent to the caller:

- The bank tables that pointer goes through are switched by `memory_set_context()` every time the emulation moves between CPUs. Resolved on another thread, the pointer points into whichever CPU is active at that instant. On `ij_l7`, reading fixed ROM `0x8000-0xFFFF` in 256-byte chunks with 50 ms between chunks returns a whole chunk of zeros in most walks, with the full count. Details, numbers and a standalone tool are in #642.
- Handler-backed RAM has no pointer to return. Whitestar and Sega route all of main RAM through `ram_r`, so every read there came back short; #633 papered over that with a `memory_find_base` fallback, which this change removes because the emulation-thread read dispatches through `ram_r` itself.

This change queues reads and applies them in the per-frame drain #634 added, on the emulation thread between time slices, with `cpunum_read_byte()` under the main CPU's context, so a read goes through the memory map exactly as the CPU's own would. Writes are applied before reads in the same drain so a read queued after a write observes it. A caller on the emulation thread reads directly. A caller elsewhere waits for the next frame, bounded at 250 ms like a write. A read is short only when the range runs past the end of the address space. `PMPI_READ_MEMORY` gets the same behaviour through the same function; its header comment now says so.

Everything is inside `src/libpinmame/`; no core file changes. The drain is renamed from `libpinmame_drain_pending_writes` to `libpinmame_drain_pending_memory_ops`.

Cost: a read from another thread now costs one frame of latency instead of returning immediately. Measured here: 384 chunk reads in about 5.4 s, so roughly 14 ms each at 60 FPS. A caller that needs many ranges per frame should batch; a message carrying a list of ranges, like `PMPI_WRITE_MEMORY` already does, is the natural follow-up and I would rather propose it separately than widen this one.

Reading a register through its handler has whatever side effect the hardware has. The callers this serves read RAM, NVRAM and ROM; the previous pointer path never reached registers at all, so this is new exposure only for a caller that asks for one.

## Verified, on this branch

| check | result |
|---|---|
| `read_walk ij_l7 0x8000 0xFFFF 5 3 --delay=50`, the reproduction shape | 5 walks, 0 zeroed chunks, 0 differing chunks (was 4 of 5 walks zeroed on master) |
| `read_test austin 0x1657 8`, Whitestar main RAM through `ram_r` (#633's case) | `ranged=8/8 byte=1`, without #633's fallback |
| `write_memory_test --rom ij_l7 --addr 0x1c93 --len 8 --settle 6 --unlock 0x3FFD 0xB4` | 11 passed, 0 failed, unchanged from #634 |
| same with `--split` (unlock and payload as two messages) | fails the read-back as before, which is the behaviour #634 documents |
| independent second harness (firmware-signature walk, same shape, unpaused) | 5 of 5 walks give the reference signature `e029a575`, 0 zeroed chunks; the same configuration on master gave five different wrong signatures |

Tools are the ones offered on #634 plus `read_walk.cpp`; happy to add them under `src/libpinmame/` if wanted.

## Disclosure

Per CONTRIBUTING.md: I use Claude/Anthropic to check my work and provide interactive guidance as I write, mostly to keep me from causing collateral damage. It helps me navigate the codebase and tells me when I'm being stupid, and when I'm testing, helps me find my bugs. I wrote and built the change, ran the verification above, and can explain the implementation!

