### PR TITLE
LibPinMAME: report flipper solenoids full scale in modsol/physout mode

### DIFF
--- a/src/libpinmame/libpinmame.cpp
+++ b/src/libpinmame/libpinmame.cpp
@@ -1899,6 +1899,14 @@ static void GetSolenoid2VPMState(void* callContext, void* pResult)
       core_update_pwm_outputs(CORE_MODOUT_SOL0 + core_BitColToNum(srcId) + 32, 1);
    *static_cast<uint8_t*>(pResult) = (coreGlobals.solenoids2 & srcId) != 0 ? 1 : 0;
 }
+static void GetFlipperSolenoid2VPMState(void* callContext, void* pResult)
+{
+   assert(_isRunning == 1);
+   const int srcId = static_cast<StateMapping*>(callContext)->srcId;
+   if (options.usemodsol & CORE_MODOUT_FORCE_ON)
+      core_update_pwm_outputs(CORE_MODOUT_SOL0 + core_BitColToNum(srcId) + 32, 1);
+   *static_cast<uint8_t*>(pResult) = (coreGlobals.solenoids2 & srcId) != 0 ? 0xFF : 0;
+}
 static void GetCustomSolenoidState(void* callContext, void* pResult)
 {
    assert(_isRunning == 1);
@@ -2166,8 +2174,9 @@ static void SetupMsgApiGameStates()
                   case 35:mask = isFlipperCoil ? 0x40 : 0x40; break; // Power bit
                   case 36:mask = isFlipperCoil ? CORE_ULFLIPSOLBITS : 0x80; break; // Power|Hold bits
                   }
+                  const bool physOut = (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_SOLENOIDS | CORE_MODOUT_ENABLE_MODSOL | CORE_MODOUT_FORCE_ON)) != 0;
                   addDevice(PMPI_GROUP_SOLENOID, label, nullptr, i, CTLPI_STATE_FORMAT_FLOAT, CTLPI_STATE_TYPE_CUSTOM, GetSolenoid2State, nullptr, mask);
-                  addDevice(PMPI_GROUP_VPM_SOLENOID, fmtString("%s", label), nullptr, i, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, GetSolenoid2VPMState, nullptr, mask);
+                  addDevice(PMPI_GROUP_VPM_SOLENOID, fmtString("%s", label), nullptr, i, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, (isFlipperCoil && physOut) ? GetFlipperSolenoid2VPMState : GetSolenoid2VPMState, nullptr, mask);
                }
             }
          }
@@ -2220,8 +2229,9 @@ static void SetupMsgApiGameStates()
             case 47:mask = 0x04; break; // Power bit
             case 48:mask = CORE_LLFLIPSOLBITS; break; // Power|Hold bits
             }
+            const bool physOut = (options.usemodsol & (CORE_MODOUT_ENABLE_PHYSOUT_SOLENOIDS | CORE_MODOUT_ENABLE_MODSOL | CORE_MODOUT_FORCE_ON)) != 0;
             addDevice(PMPI_GROUP_SOLENOID, label, nullptr, i, CTLPI_STATE_FORMAT_FLOAT, CTLPI_STATE_TYPE_CUSTOM, GetSolenoid2State, nullptr, mask);
-            addDevice(PMPI_GROUP_VPM_SOLENOID, fmtString("%s", label), nullptr, i, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, GetSolenoid2VPMState, nullptr, mask);
+            addDevice(PMPI_GROUP_VPM_SOLENOID, fmtString("%s", label), nullptr, i, CTLPI_STATE_FORMAT_UINT8, CTLPI_STATE_TYPE_CUSTOM, physOut ? GetFlipperSolenoid2VPMState : GetSolenoid2VPMState, nullptr, mask);
          }
       }
       // 49, simulated fake plunger, not broadcasted


### PR DESCRIPTION
Found while looking into #608 (GoldenEye's radar magnet also firing the right flipper). I never got to that bug, because on the current build GoldenEye's flippers do not respond at all, so there was nothing to reproduce. This PR fixes the dead flippers.

## What is wrong

`GetSolenoid2VPMState` reports an "on" binary solenoid as `1`. When a table enables physical output (`UseVPMModSol = 2`), `core.vbs` normalizes each changed-solenoid value by the group's 0..255 range (`pwmScale = 1/255`) and thresholds at `>= 0.5`. A reported `1` becomes about `0.004` and reads as off.

Most solenoids dodge this. They either report through the physical-output path (`GetPhysOutVPMState`, already 0..255) or are consumed where `pwmScale` is `1`. The flipper coils (solenoids 33-36 and 45-48) are the exception. On hardware without modulated flippers (`hasModulatedFlippers == false`: Whitestar, System 11, Data East, pre-Fliptronic WPC, and older generations) they are read from the raw `solenoids2` bitfield through `GetSolenoid2VPMState`. If a table drives its flipper enable through one of those coils and also turns on physical output, the enable collapses to off and the flippers never engage.

## When it regressed

This came in with 04b2da8e ("LibPinMAME: update to new Controller plugin API", 2026-08-24), which moved solenoid state onto the new controller-plugin state groups. The old path (`vp_getChangedSolenoids`) ran every solenoid through `saturatedByte` (0..255) in physical mode, with no per-coil exception, so the flipper enable came through full-scale. The new `GetSolenoid2VPMState` reports binary `1` for the non-modulated flipper coils instead.

## Reproduction

GoldenEye (Sega Whitestar). `sega2.vbs` sets `GameOnSolenoid = 48`, the lower-left flipper Hold|Power coil, and the table sets `UseVPMModSol = 2`. The enable solenoid arrived as `1`, scaled to `0.004`, so the flipper circuit never switched on and the flippers were dead with the stock, unmodified script.

## Fix

Report `0xFF` for an "on" binary solenoid so the value survives the consumer's 0..255 normalization. This is the convention `GetSwitchState` and `GetDIPSwitchState` already follow.

The `hasModulatedFlippers` gate stays as is. I tried removing it so the flipper coils would take the physical-output path like everything else, but that reads from a PWM model that is not driven for these coils on non-modulated hardware, so they report nothing and the flippers go dead a different way. The gate is load-bearing. `GetSolenoid1VPMState` carries the same `1`-for-on pattern but is only ever reached through the scale-consistent `addPhysSol` path, so it has no reachable defect and I left it alone.

## Testing

Flip-tested stock tables on macOS/BGFX standalone with the PinMAME plugin.

| Table | Generation, GameOn solenoid | Before | After |
| --- | --- | --- | --- |
| GoldenEye (Sega 1996) | Whitestar, sol 48, `UseVPMModSol=2` | dead | works |
| Jurassic Park (Data East 1993) | sol 23, `UseVPMModSol=2` | works | works |
| Twister (Sega 1996) | Whitestar, sol 15 | works | works |
| Medieval Madness (Williams 1997) | Fliptronic WPC | works | works |

The three regression cases cover the other affected generations, the two other `GameOnSolenoid` values in common use (15 and 23), and a modulated-flipper generation on the untouched physical path.