### PR TITLE
Sleic Io Moon (1996): full support (gameplay, service menu, YM3812 + OKI sound)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and listen to/record the pinball game sounds with the pure PinMAME package itsel
 - *Sonic* - Odin DeLuxe (1985), Pole Position (1987), Star Wars (1987)
 - *Allied Leisure* - All games from Super Picker (1977) to Star Shooter (1979)
 - *Fascination, Int.* - Roy Clark - The Entertainer (1977), Eros One, and Circa 1933 (both 1979)
-- *Sleic* - Bike Race (1992, standard and 2-ball versions), Sleic Pin-Ball (1993)
+- *Sleic* - Bike Race (1992, standard and 2-ball versions), Sleic Pin-Ball (1993), Io Moon (1994)
 - *Playmatic* - Last Lap (1978), Antar (1979), Evil Fight (1980), Mad Race (1982), Meg-Aaton (1983), KZ-26 (1984) (*)
 - *NSM*
 - *Grand Products* - 300/Bullseye (1986)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and listen to/record the pinball game sounds with the pure PinMAME package itsel
 - *Sonic* - Odin DeLuxe (1985), Pole Position (1987), Star Wars (1987)
 - *Allied Leisure* - All games from Super Picker (1977) to Star Shooter (1979)
 - *Fascination, Int.* - Roy Clark - The Entertainer (1977), Eros One, and Circa 1933 (both 1979)
-- *Sleic* - Bike Race (1992, standard and 2-ball versions), Sleic Pin-Ball (1993), Io Moon (1994)
+- *Sleic* - Bike Race (1992, standard and 2-ball versions), Sleic Pin-Ball (1993), Io Moon (1996)
 - *Playmatic* - Last Lap (1978), Antar (1979), Evil Fight (1980), Mad Race (1982), Meg-Aaton (1983), KZ-26 (1984) (*)
 - *NSM*
 - *Grand Products* - 300/Bullseye (1986)

--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -33,6 +33,7 @@ Get rid of BASS external dependency (used for internal AltSound mode 1 support) 
 Added Pinball 2000 emulation. It works in principle, but the CPU is clocked way too low (0.33x) for performance reasons (for now)! Still, it seems to work reasonably well, most likely as the graphics/video part is not emulated cycle-accurate and thus much faster than the clock rate implies.
 Added Recreativos Franco Super Star emulation, including improved i8085 emulation
 Fixed and extended Sleic emulation, including some i86 fixes
+Sleic Io Moon now plays, and is no longer marked as not working
 Fixed a potential small problem with Bally VideoPins sound emulation
 Added physical/PWM DMD support to Capcom games (potentially leading to more brightness levels being displayed if the CPU triggers it)
 Added physical/PWM (dimmed) segment support to System 11 games

--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -115,6 +115,7 @@ Funhouse 9.07H (Ballsaver MOD), 9.05H + (Ballsaver MOD) (both are independently 
 Gorgar L-2 (most likely official, but unreleased so far, makes it the newest version available)
 High Speed G-4 (aka German PROTO4), L-1 (but coming from a Unidesa / Cirsa licensed board)
 Hurricane D-2 LED Ghost Fix + Ball Saver MOD
+Io Moon (earlier ROM revision), (PRESS START tournament MOD)
 Mata Hari (Free Play and MODified rules, 6 and 7 digit versions (latter requires DIP 19 on))
 Maverick 4.04 (German, Display 4.00)
 Monte Carlo (German) (most likely older revision than existing one, see above)

--- a/src/wpc/driver.c
+++ b/src/wpc/driver.c
@@ -1391,6 +1391,8 @@ DRIVERNV(bikerac2)      // 1992 - Bike Race (2-ball play)
 DRIVERNV(bikerac3)      // 1992 - Bike Race (V4.1)
 DRIVERNV(sleicpin)      // 1993 - Sleic Pin-Ball
 DRIVERNV(iomoon)        // 1994 - Io Moon
+DRIVERNV(iomoona)       // 1994 - Io Moon (earlier ROM revision)
+DRIVERNV(iomoont)       // 1994 - Io Moon (PRESS START tournament MOD)
                         // 1996 - Dona Elvira 2
 
 // ----------------

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -668,6 +668,116 @@ static MEMORY_WRITE_START(SLEIC1_80188_writemem)
   {0x60410,0x6340f, MWA_RAM},
 MEMORY_END
 
+/*----------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) 80188 memory map.
+/
+/  PinMAME's i86/i188 core does not emulate the 80188's internal peripheral control
+/  block, so the firmware's OUT DX,AX writes to 0xFFA0.. are inert (they land in
+/  i80188_write_port, a no-op) and the windows below are hard-wired to exactly the
+/  values the boot table programs -- the 30-entry table at D000:0041, findings F1:
+/
+/    UMCS  FFA0 = C03C   0xC0000-0xFFFFF   ROM1 code half + the reset vector (FFFF0)
+/    LMCS  FFA2 = 3FFC   0x00000-0x3FFFF   ROM1 low half: the IVT is RESIDENT IN ROM at
+/                                          physical 0 (nothing copies it), followed by the
+/                                          animation data the F5183 far-pointer table
+/                                          addresses.  Not banked (F2)
+/    PACS  FFA4 = A03C   0xA0000           peripheral block, PCS0..PCS6 on 0x80 spacing
+/    MMCS  FFA6 = 41FC   mid-range memory based at 0x40000, and MPCS FFA8 = A0FC makes
+/    MPCS  FFA8 = A0FC   that four 64 KB blocks MCS0-MCS3:
+/                          MCS0 0x40000  work RAM (UM62256 IC12; stack SS:SP = 4152:0205)
+/                          MCS1 0x50000  non-volatile store, window at 0x50400 (F10)
+/                          MCS2 0x60000  ONE 64 KB page of the graphics ROM (F2)
+/                          MCS3 0x70000  DMD staging buffer 7000:0000-03FF (F13)
+/
+/  Segments the firmware actually loads confirm the map is complete: 0000/1000/3000
+/  (LMCS), 4000/4130/4134/4137/413C (MCS0), 5040 (MCS1), 7000 (MCS3), A000 (PACS) --
+/  and 6000 never as an immediate, only through the far pointers F2 describes.
+/---------------------------------------------------------------------------------*/
+
+/* Io Moon non-volatile store (F10): a window at segment 5040 = flat 0x50400 inside
+ * MCS1, gated by the complementary PCS0 bits 3/4 (pcs0_window_open D057E /
+ * pcs0_window_close D059F).  Every access in the ROM is bracketed by that pair, so the
+ * window is mapped unconditionally here -- modelling the gate could only ever turn a
+ * correctly bracketed access into a lost one.  The part is inferred to be the 28C64A
+ * (8 KB) on the board inventory; the firmware's highest offset is 0x31D, so 8 KB backs
+ * everything it touches.  Zero-filled on a fresh boot: sub_D05C0 finds no signature,
+ * sub_D622C writes the factory defaults, and core_nvram persists them from then on */
+#define IOMOON_NVRAM_BASE 0x50400
+#define IOMOON_NVRAM_SIZE 0x2000
+static UINT8 iomoon_nvram[IOMOON_NVRAM_SIZE]; //!!
+static READ_HANDLER(iomoon_nvram_r)  { return iomoon_nvram[offset]; }
+static WRITE_HANDLER(iomoon_nvram_w) { iomoon_nvram[offset] = data; }
+static NVRAM_HANDLER(SLEIC2) {
+  core_nvram(file, read_or_write, iomoon_nvram, sizeof iomoon_nvram, 0x00);
+}
+
+/* Io Moon graphics bank (F2).  PCS0 bits 0-2 are a 3-bit page register (sub_F00A0 at
+ * F00A0, shadow [4000:1134], 17 call sites all pushing an immediate 0..6) that pages
+ * one 64 KB page of V1 3_02.bin into segment 6000.  All seven populated pages start
+ * with the same 32-row / 16-byte / 0x200-stride header anim_stream_open reads, and
+ * page 7 is blank, which is what makes page = file offset >> 16 the natural reading.
+ *
+ * That page->offset mapping is CONFIRMED; the BIT ORDER of the selector (whether bit 0
+ * is A16 or A18) is INFERRED -- only the IC7 PAL20L10 or a scope can settle the wiring.
+ * It therefore lives in this table: if the attract animations come out wrong, permuting
+ * these seven bases is the one-line fix, and nothing else has to change */
+#define IOMOON_GFX_BANK 1
+static const UINT32 iomoon_gfx_page_base[8] = {
+  0x00000, 0x10000, 0x20000, 0x30000, 0x40000, 0x50000, 0x60000,
+  0x70000  /* page 7: blank in V1 3_02.bin and never selected */
+};
+static UINT8 iomoon_pcs0; /* PCS0 (0xA0000) output shadow; boot leaves it at 0x28 */ //!!
+
+static void iomoon_set_gfx_bank(UINT8 pcs0) {
+  cpu_setbank(IOMOON_GFX_BANK, memory_region(SLEIC_MEMREG_GFX) + iomoon_gfx_page_base[pcs0 & 0x07]);
+}
+
+/* Io Moon 80188 peripheral write.  Only PCS0's page-select side effect is wired up
+ * here; the rest of the block (PCS1 J1 outbound, PCS2, PCS4, PCS5 YM3812, PCS6 OKI +
+ * NVRAM gate) is the subject of the following driver work and is only logged for now */
+static WRITE_HANDLER(sleic2_periph_w) {
+  switch (offset) {
+    case 0x000: /* PCS0: bits 0-2 graphics page (F2), 3/4 NVRAM window gate (F10), 5 = OKI /OKCS (F9) */
+      if ((data ^ iomoon_pcs0) & 0x07) iomoon_set_gfx_bank(data);
+      iomoon_pcs0 = data;
+      return;
+    default:
+#ifdef DEBUG_SLEIC
+      if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
+#endif
+      logerror("iomoon periph A000:%03X = %02x\n", offset, data);
+      return;
+  }
+}
+
+/* Io Moon 80188 peripheral read.  Nothing in the block is modelled yet: the J1 inbound
+ * byte at PCS2 0xA0100 (F4/F6) and the YM3812 status at PCS5 0xA0280 (F8) come with the
+ * link and sound work.  Deliberately NOT the base sleic_periph_r -- its 0x37 "no event"
+ * idle and 0xA0180 ready bit are Bike Race conventions that do not apply here */
+static READ_HANDLER(sleic2_periph_r) {
+  return 0;
+}
+
+static MEMORY_READ_START(SLEIC2_80188_readmem)
+  {0x00000,0x3ffff, MRA_ROM},         /* LMCS: ROM1 low half -- resident IVT + animation data */
+  {0x40000,0x4ffff, MRA_RAM},         /* MCS0: work RAM (UM62256 IC12)                        */
+  {IOMOON_NVRAM_BASE,IOMOON_NVRAM_BASE+IOMOON_NVRAM_SIZE-1, iomoon_nvram_r}, /* MCS1: seg 5040 store */
+  {0x60000,0x6ffff, MRA_BANK1},       /* MCS2: graphics ROM page (IOMOON_GFX_BANK, PCS0 bits 0-2) */
+  {0x70000,0x7ffff, MRA_RAM},         /* MCS3: DMD staging (7000:0000-03FF)                   */
+  {0xa0000,0xa0fff, sleic2_periph_r}, /* PACS: PCS0-PCS6                                      */
+  {0xc0000,0xfffff, MRA_ROM},         /* UMCS: ROM1 code half + reset vector                  */
+MEMORY_END
+
+static MEMORY_WRITE_START(SLEIC2_80188_writemem)
+  {0x40000,0x4ffff, MWA_RAM},         /* MCS0: work RAM                                       */
+  {IOMOON_NVRAM_BASE,IOMOON_NVRAM_BASE+IOMOON_NVRAM_SIZE-1, iomoon_nvram_w}, /* MCS1: seg 5040 store */
+  {0x70000,0x7ffff, MWA_RAM},         /* MCS3: DMD staging                                    */
+  {0xa0000,0xa0fff, sleic2_periph_w}, /* PACS: PCS0-PCS6                                      */
+  /* 0x00000-0x3FFFF and 0x60000-0x6FFFF are ROM and are deliberately left unmapped for
+   * writes: no instruction in the decoded ROM writes either window (F2), so a write
+   * showing up there is a bug worth seeing in the log rather than silently absorbing */
+MEMORY_END
+
 /* Bike Race (SLEIC3) 80188 map. MMCS=0x01FF / MPCS=0xC0FC decode a 512 KB
  * mid-range block based at 0, split into four 128 KB chip-selects MCS0-3:
  *   MCS0 0x00000-0x1FFFF : work RAM (boot stack 012F:0203; the boot copies its IVT
@@ -1012,6 +1122,15 @@ static MACHINE_INIT(SLEIC1) {
   locals.dmdEqualFields = 1;
 }
 
+/* Io Moon: point the segment-6000 graphics bank somewhere valid before the first
+ * instruction runs.  0x28 is the value boot_init leaves in the PCS0 shadow [4000:1134]
+ * (bit 3 = NVRAM window closed, bit 5 = OKI /OKCS idle high, page bits clear) */
+static MACHINE_INIT(SLEIC2) {
+  machine_init_SLEIC();
+  iomoon_pcs0 = 0x28;
+  iomoon_set_gfx_bank(iomoon_pcs0);
+}
+
 /* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch
  * codes 0x0A-0x31) are read by the 80188 through swMatrix[1..5] (COL0..COL4, selected by
  * the port-0x82 one-hot column strobe); code = 0x0A + 8*(col-1) + row. Mapping every
@@ -1171,6 +1290,20 @@ MACHINE_DRIVER_END
 
 MACHINE_DRIVER_START(SLEIC2)
   MDRV_IMPORT_FROM(SLEIC)
+  MDRV_CORE_INIT_RESET_STOP(SLEIC2,NULL,NULL)
+
+  // Io Moon 80188 map: LMCS ROM at 0, UMCS ROM at 0xC0000, the four MMCS blocks
+  // (work RAM / non-volatile store / banked graphics page / DMD staging) and the
+  // PACS peripheral block.  See the SLEIC2_80188_readmem comment block for the
+  // chip-select values this hard-wires and where they come from
+  MDRV_CPU_MODIFY("mcpu")
+  MDRV_CPU_MEMORY(SLEIC2_80188_readmem, SLEIC2_80188_writemem)
+
+  // Non-volatile store at segment 5040 (F10), persisted by NVRAM_HANDLER(SLEIC2) and
+  // zero-filled on a fresh boot, which is what makes the firmware seed its own factory
+  // defaults.  Replaces the base driver's generic_0fill, whose generic_nvram buffer
+  // this map does not reference
+  MDRV_NVRAM_HANDLER(SLEIC2)
 
   MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
   MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -242,6 +242,33 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * pipeline are two independent clocks on this machine (F13), which is the whole point */
 #define IOMOON_PANEL_HZ 73.0
 
+/* YM3812 (IC60) master clock phi-M.  F8 settles the ports, the write primitive and the
+ * sequencer, but it cannot settle this one: a clock is a wire, and no ROM mentions it.
+ * What the board says (011-029A inventory, IC60 row, traced on sheet 011-029-06/07) is
+ * that phi-M is fed by YACLK off the IC20 74LS393 divider in the board's 8 MHz timing
+ * domain -- the same chain whose /8192 tap is the ~977 Hz Z80 IRQ this driver already
+ * states.  A 74LS393 half offers /2 /4 /8 /16, so from 8 MHz the candidates are:
+ *
+ *     4.0 MHz (/2)   <- used here
+ *     2.0 MHz (/4)
+ *     1.0 MHz (/8), 0.5 MHz (/16)
+ *
+ * 4 MHz is picked because it is the YM3812's rated phi-M ceiling and the only tap that
+ * lands anywhere near the part's 3.58 MHz nominal -- /4 and below would run the OPL2 at
+ * half pitch or worse -- and because 4 MHz is the usual OPL2 clock in pinball (Alvin G.
+ * uses it; PinMAME's own SLEIC interface already did).  It is a WIRING INFERENCE, not a
+ * measurement: only a scope on IC60 pin 24 or the IC7 PAL dump can confirm which tap is
+ * strapped.  If the music comes out an octave low, /4 is the next candidate and this line
+ * is the whole fix.
+ *
+ * Pitch and envelope speed scale with it; musical TEMPO does not -- that comes from the
+ * sequencer's tick (F8: fm_player_tick on the INT0 odd branch, so IOMOON_INT0_HZ / 2 =
+ * 36.25 Hz here, against the ~73 Hz per visible frame IOMOON_PANEL_HZ implies on
+ * hardware).  So the emulated music runs at about half tempo for as long as INT0 has to
+ * be throttled to stay servable -- that is F3's open gap showing up in the sound, not a
+ * fault in this path, and it moves the day INT0's real rate is settled */
+#define IOMOON_YM3812_CLOCK 4000000
+
 /* Fractional tick accumulators, and one held request per source.  The request has to be
  * held because of how this i86 core delivers interrupts.  cpu_set_irq_line_and_vector does
  * not touch the CPU itself: it appends the request to a per-CPU event queue and schedules a
@@ -743,6 +770,25 @@ static struct OKIM6295interface SLEIC_okim6376_intf =
 	{ REGION_USER1 },	/* memory region */
 	{ 75 }				/* volume */
 };
+/* Io Moon (SLEIC2) YM3812 (IC60).  Same shape as the base interface, stated separately so
+ * the clock is the named constant with its derivation (IOMOON_YM3812_CLOCK) instead of a
+ * bare 4000000 shared with two machines whose boards were never traced for it.
+ *
+ * The IRQ callback stays disconnected, and for once that is a finding rather than a
+ * shrug: the OPL2's only interrupt source is its two internal timers, and NO Io Moon
+ * song stream writes registers 02, 03 or 04 -- all ten streams in the CS:0DE5 table were
+ * walked through the sequencer's own opcode rules (each 0xDD loop taken once), 22 012
+ * register writes, not one of them to a timer register -- so the chip can never assert
+ * /IRQ on this machine.  That also removes it as a candidate source for the unidentified
+ * INT0 line (F3) */
+static struct YM3812interface SLEIC2_ym3812_intf =
+{
+	1,					/* 1 chip (IC60)          */
+	IOMOON_YM3812_CLOCK,	/* phi-M -- see the constant */
+	{ 100 },			/* volume                 */
+	{ ym3812_irq },		/* never called: the firmware starts no OPL2 timer */
+};
+
 static struct OKIM6295interface SLEIC_okim6376_intf2 =
 {
 	0,					/* 1 chip (but use 0 to indicate 6376 chip) */
@@ -994,8 +1040,8 @@ static struct {
   UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
 } iomoon_j1; //!!
 
-/* Io Moon 80188 peripheral write.  PCS0's page select (F2) and the J1 outbound half
- * (PCS1 data + the PCS4 bit-5 strobe, F6) are wired; PCS5 YM3812 (F8), PCS6 OKI (F9)
+/* Io Moon 80188 peripheral write.  PCS0's page select (F2), the J1 outbound half (PCS1
+ * data + the PCS4 bit-5 strobe, F6) and PCS5's YM3812 pair (F8) are wired; PCS6 OKI (F9)
  * and the PCS0 NVRAM gate (F10) are later tasks and are only logged */
 static WRITE_HANDLER(sleic2_periph_w) {
   switch (offset) {
@@ -1022,7 +1068,26 @@ static WRITE_HANDLER(sleic2_periph_w) {
       }
       iomoon_j1.pcs4 = data;
       return;
-    default:                          /* PCS2, PCS3, PCS5 YM3812, PCS6 OKI */
+    case 0x280: /* PCS5 with A0 = 0: the YM3812's register/index port (F8).
+                 *
+                 * Io Moon uses TWO ADDRESSES, one per port -- ES:[0280] then ES:[0281]
+                 * inside the one write primitive ym3812_write D0D99 -- so A0 comes off the
+                 * address bus and the driver decodes it here.  Neither sister machine does
+                 * it this way and both were checked before this was written: Bike Race
+                 * streams every byte at 0xA0280 and toggles A0 in hardware (sleic_periph_w
+                 * alternates), and Sleic Pin-Ball streams every byte at 0xA0280 with A0
+                 * carried on PCS0 bit 1 (sleic1_ym_a0).  Three machines, three conventions;
+                 * this one is the only one the Io Moon ROM supports, and F8 confirms these
+                 * are the only two accesses to either address in the whole ROM */
+      YM3812_control_port_0_w(0, data);
+      return;
+    case 0x281: /* PCS5 with A0 = 1: the YM3812's data port (F8).  The firmware's settling
+                 * delay between the two writes (ym3812_settle_delay D0DA9, 10 iterations)
+                 * is a real-chip timing requirement with no emulated equivalent -- the core
+                 * accepts the pair back to back -- so nothing here waits */
+      YM3812_write_port_0_w(0, data);
+      return;
+    default:                          /* PCS2, PCS3, PCS6 OKI */
 #ifdef DEBUG_SLEIC
       if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
 #endif
@@ -1030,8 +1095,8 @@ static WRITE_HANDLER(sleic2_periph_w) {
   }
 }
 
-/* Io Moon 80188 peripheral read.  The J1 half is modelled (F4/F6); the YM3812 status at
- * PCS5 0xA0280 (F8) comes with the sound work.  Deliberately NOT the base sleic_periph_r
+/* Io Moon 80188 peripheral read.  The J1 half is modelled (F4/F6) and the YM3812 status
+ * port answers at PCS5 0xA0280 (F8).  Deliberately NOT the base sleic_periph_r
  * -- its 0x37 "no event" idle is a Bike Race convention that F4 rules out here: 0xA0100
  * carries Z80 bytes and nothing else */
 static READ_HANDLER(sleic2_periph_r) {
@@ -1046,6 +1111,17 @@ static READ_HANDLER(sleic2_periph_r) {
                  * gives up for this call when it is clear, so it must report that the Z80
                  * has taken the previous byte */
       return iomoon_j1.toZ80Full ? 0x00 : 0x01;
+    case 0x280: /* PCS5: the YM3812 status port, which reads back on the same address as the
+                 * index port (A0 = 0) exactly as on any OPL2.
+                 *
+                 * The Io Moon firmware never reads it -- F8 finds only the two writes in
+                 * ym3812_write, and busy is handled by the software settling delay instead
+                 * of by polling bit 7 -- so this line changes no behaviour today.  It is
+                 * here because the hardware answers here: leaving the address to the
+                 * function's default 0 would quietly invent a chip that reports "no timer
+                 * overflow, not busy" for ever, and a patched or later ROM that does poll
+                 * would then hang against a lie rather than run against the core */
+      return YM3812_status_port_0_r(0);
   }
   return 0;
 }
@@ -1919,9 +1995,24 @@ MACHINE_DRIVER_START(SLEIC2)
   MDRV_CPU_PERIODIC_INT(SLEIC_irq_z80, 8000000/8192.)
   MDRV_CPU_PORTS(SLEIC2_Z80_readport, SLEIC2_Z80_writeport)
 
-  MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
+  // Sound: two chips, both driven by the 80188 through the PACS block, and NO third
+  // device.  The YM3812 (IC60) carries the FM music at PCS5 0xA0280/0xA0281 (F8, decoded
+  // in sleic2_periph_w) and the OKI MSM6376 (IC51) the speech and effects at PCS6 (F9).
+  //
+  // The base driver's MDRV_SOUND_ADD(DAC, ...) is dropped here, and it is dropped on
+  // evidence rather than on tidiness.  Nothing on this machine is a CPU-written DAC: the
+  // only converter on board 011-029A is IC61, a YM3014B, which is the YM3812's own
+  // companion serial DAC (it takes the OPL2's serial output, not a bus byte) and is
+  // therefore already inside PinMAME's YM3812 emulation; IC62 is an LM324-class op-amp
+  // and IC63 an X9C503P digital pot for the FM-vs-OKI balance -- an output stage, not a
+  // sound source.  From the software side F8 and F9 between them enumerate every sound
+  // write the ROM makes -- 0xA0280/0xA0281, the 0xA0300 latch and the 0xA0000 bit-5
+  // /OKCS strobe -- and there is no fourth address and no sample-rate write loop anywhere
+  // for a DAC to be driven from.  Nothing in this file ever called DAC_data_w either, so
+  // the device only ever added a silent mixer channel.  (SLEIC1 and SLEIC3 keep theirs:
+  // their boards were not traced for this and are not this task's to change.)
+  MDRV_SOUND_ADD(YM3812, SLEIC2_ym3812_intf)
   MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)
-  MDRV_SOUND_ADD(DAC, SLEIC_dac_intf)
 MACHINE_DRIVER_END
 
 MACHINE_DRIVER_START(SLEIC3)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1862,10 +1862,10 @@ static MACHINE_INIT(SLEIC) {
    *     0x80 (C8 "Bola fuera", key 9). Reply 0x5D "BOLAS OK" / 0x5B "FALTA 1 BOLA";
    *     a ball at C7 OR C8 -> BOLAS OK, so standalone-test by holding key 8 (or 9).
    *   bikerac2 (07.bin, sub 0x0B72, replies 0x0C0B/0x0C16/0x0C37): monitors the same three
-   *     PLUS bit 0x40 (code 0x30, key 7) and counts missing balls -- reply adds
-   *     0x5C "FALTA 2 BOLAS". "BOLAS OK" needs two optos INCLUDING the key-7 sensor
-   *     (combos 0x20+0x40 or 0x40+0x80), so standalone-test by holding key 7 with 8 or 9;
-   *     holding only 8+9 (no 7) never reports OK. (Verified against the disassembly of both
+   *     PLUS bit 0x40 (code 0x30, key '-') and counts missing balls -- reply adds
+   *     0x5C "FALTA 2 BOLAS". "BOLAS OK" needs two optos INCLUDING the '-' sensor
+   *     (combos 0x20+0x40 or 0x40+0x80), so standalone-test by holding '-' with 8 or 9;
+   *     holding only 8+9 (no '-') never reports OK. (Verified against the disassembly of both
    *     Z80 ROMs; the key bindings already exist in sleic3_pf_keys below.)
    * The driver does not fabricate the ball complement -- the frontend (e.g. VPX)
    * supplies trough state; the keys above are only for standalone testing */
@@ -1945,7 +1945,13 @@ static MACHINE_INIT(SLEIC2) {
 
 /* Playfield test keys, one per matrix position, so the service menu's contact test can
  * exercise every contact standalone.  Columns 0-4 keep the Bike Race key layout; column 5
- * only maps the four positions whose codes (0x34-0x37) the firmware actually sends */
+ * only maps the four positions whose codes (0x34-0x37) the firmware actually sends.
+ *
+ * Two positions are deliberately NOT on the key their neighbours suggest, because those
+ * two keys already belong to a cabinet button: 7 is the test/service key (sleic.h) and T
+ * is MAME's IPT_TILT default, so col4 0x30 sits on '-' and col5 0x34 on '=' -- still the
+ * same number row, just past the digits.  Everything else here is free of both the
+ * cabinet block and the MAME UI keys */
 static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
   {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08}, /* col0 0x0A-0x0D */
   {KEYCODE_Y,1,0x10},{KEYCODE_U,1,0x20},{KEYCODE_I,1,0x40},{KEYCODE_O,1,0x80}, /* col0 0x0E-0x11 */
@@ -1956,8 +1962,8 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
   {KEYCODE_0_PAD,4,0x01},{KEYCODE_1_PAD,4,0x02},{KEYCODE_2_PAD,4,0x04},{KEYCODE_3_PAD,4,0x08}, /* col3 0x22-0x25 */
   {KEYCODE_4_PAD,4,0x10},{KEYCODE_5_PAD,4,0x20},{KEYCODE_6_PAD,4,0x40},{KEYCODE_7_PAD,4,0x80}, /* col3 0x26-0x29 */
   {KEYCODE_0,5,0x01},{KEYCODE_2,5,0x02},{KEYCODE_3,5,0x04},{KEYCODE_4,5,0x08}, /* col4 0x2A-0x2D */
-  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_7,5,0x40},{KEYCODE_9,5,0x80}, /* col4 0x2E-0x31 */
-  {KEYCODE_T,6,0x01},{KEYCODE_8_PAD,6,0x02},{KEYCODE_9_PAD,6,0x04},{KEYCODE_MINUS_PAD,6,0x08}, /* col5 0x34-0x37 */
+  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_MINUS,5,0x40},{KEYCODE_9,5,0x80}, /* col4 0x2E-0x31 */
+  {KEYCODE_EQUALS,6,0x01},{KEYCODE_8_PAD,6,0x02},{KEYCODE_9_PAD,6,0x04},{KEYCODE_MINUS_PAD,6,0x08}, /* col5 0x34-0x37 */
 };
 
 /*-------------------------------------------------------------------------------------
@@ -2234,7 +2240,7 @@ static SWITCH_UPDATE(SLEIC2) {
  * position to a key lets the CONTACTOS self-test verify each contact. COL4 (swMatrix[5])
  * is the trough column. The Z80 cmd-0xD5 ball-status handler monitors COL4 bits 0x04
  * (code 0x2C, key 3), 0x20 = C7 (key 8) and 0x80 = C8 (key 9) on BOTH versions, plus
- * bit 0x40 (code 0x30, key 7) on bikerac2 only; see the per-version breakdown in the
+ * bit 0x40 (code 0x30, key '-') on bikerac2 only; see the per-version breakdown in the
  * MACHINE_INIT trough comment above */
 static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
   {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08}, /* COL0 0x0A-0x0D */
@@ -2246,7 +2252,7 @@ static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
   {KEYCODE_0_PAD,4,0x01},{KEYCODE_1_PAD,4,0x02},{KEYCODE_2_PAD,4,0x04},{KEYCODE_3_PAD,4,0x08}, /* COL3 0x22-0x25 */
   {KEYCODE_4_PAD,4,0x10},{KEYCODE_5_PAD,4,0x20},{KEYCODE_6_PAD,4,0x40},{KEYCODE_7_PAD,4,0x80}, /* COL3 0x26-0x29 */
   {KEYCODE_0,5,0x01},{KEYCODE_2,5,0x02},{KEYCODE_3,5,0x04},{KEYCODE_4,5,0x08}, /* COL4 0x2A-0x2D */
-  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_7,5,0x40},{KEYCODE_9,5,0x80}, /* COL4 0x2E; trough optos: 0x2F=C7(key8) 0x31=C8(key9) both versions, 0x30=key7 bikerac2-only (+0x2C=key3); see trough notes above */
+  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_MINUS,5,0x40},{KEYCODE_9,5,0x80}, /* COL4 0x2E; trough optos: 0x2F=C7(key8) 0x31=C8(key9) both versions, 0x30=key'-' bikerac2-only (+0x2C=key3); 0x30 is on '-' rather than 7 because 7 is the test/service key (sleic.h); see trough notes above */
 };
 
 static SWITCH_UPDATE(SLEIC3) {
@@ -2260,7 +2266,7 @@ static SWITCH_UPDATE(SLEIC3) {
      *   bit4 = C2  Start        (code 0x36)
      *   bit5 = C3  Coin/Monedero(code 0x37/0x39) */
     CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x01, 9); /* TILT(T)   0x400 -> bit0 (C17 tilt, code 0x32) */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST(End) 0x800 -> bit1 (C4 Test, code 0x33 = menu ENTER) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST(7)   0x800 -> bit1 (C4 Test, code 0x33 = menu ENTER) */
     CORE_SETKEYSW(inports[CORE_COREINPORT] << 1,  0x04, 9); /* R-Shift 0x002 -> bit2 (C5 right flipper) */
     CORE_SETKEYSW(inports[CORE_COREINPORT] << 3,  0x08, 9); /* L-Shift 0x001 -> bit3 (C1 left flipper)  */
     CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x10, 9); /* START 0x100 -> bit4 (C2) */
@@ -2274,7 +2280,7 @@ static SWITCH_UPDATE(SLEIC3) {
       coreGlobals.swMatrix[sleic3_pf_keys[i].col] &= ~sleic3_pf_keys[i].bit;
   }
 #ifdef DEBUG_SLEIC
-  sleic_debug_switches(5, 0xE0); /* COL4: C7 0x20 | key-7 sensor 0x40 (bikerac2) | C8 0x80 */
+  sleic_debug_switches(5, 0xE0); /* COL4: C7 0x20 | '-' sensor 0x40 (bikerac2) | C8 0x80 */
 #endif
 }
 

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -261,12 +261,17 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * strapped.  If the music comes out an octave low, /4 is the next candidate and this line
  * is the whole fix.
  *
- * Pitch and envelope speed scale with it; musical TEMPO does not -- that comes from the
- * sequencer's tick (F8: fm_player_tick on the INT0 odd branch, so IOMOON_INT0_HZ / 2 =
- * 36.25 Hz here, against the ~73 Hz per visible frame IOMOON_PANEL_HZ implies on
- * hardware).  So the emulated music runs at about half tempo for as long as INT0 has to
- * be throttled to stay servable -- that is F3's open gap showing up in the sound, not a
- * fault in this path, and it moves the day INT0's real rate is settled */
+ * Pitch and envelope speed scale with it; musical TEMPO does not.  Tempo comes from the
+ * sequencer's tick, which F8 puts on the INT0 handler's odd branch: IOMOON_INT0_HZ / 2 =
+ * 36.25 Hz here, and that half is MEASURED (SLEIC_PROBE_IRQ reports INT0 served at 72.5/s).
+ * How far off hardware that is depends entirely on F3's open INT0 source, so it is stated
+ * as a range and not as a number: 2x slow if INT0 is the per-FRAME candidate (~145 Hz),
+ * 4x slow under F3's per-PLANE recommendation (~290 Hz).  Deliberately NOT derived from
+ * IOMOON_PANEL_HZ -- the panel raster and the firmware's tick are independent clocks
+ * (F13), and F3's addendum warns in as many words that 72.5 is a serviceability constant
+ * and not "145 / 2 planes".  What will settle it is the OWNER'S SOUND CHECKPOINT: play a
+ * track on the real machine beside this one and the tempo ratio names INT0's rate
+ * directly, which makes that listening test a measurement rather than an opinion */
 #define IOMOON_YM3812_CLOCK 4000000
 
 /* Fractional tick accumulators, and one held request per source.  The request has to be
@@ -1999,8 +2004,11 @@ MACHINE_DRIVER_START(SLEIC2)
   // device.  The YM3812 (IC60) carries the FM music at PCS5 0xA0280/0xA0281 (F8, decoded
   // in sleic2_periph_w) and the OKI MSM6376 (IC51) the speech and effects at PCS6 (F9).
   //
-  // The base driver's MDRV_SOUND_ADD(DAC, ...) is dropped here, and it is dropped on
-  // evidence rather than on tidiness.  Nothing on this machine is a CPU-written DAC: the
+  // The MDRV_SOUND_ADD(DAC, ...) line this block used to carry is gone, and it is dropped
+  // on evidence rather than on tidiness.  (It was this block's own line, not something
+  // inherited: MACHINE_DRIVER_START(SLEIC) adds no sound device at all -- each of SLEIC1,
+  // SLEIC2 and SLEIC3 states its own set, which is why removing it here changes nothing
+  // for the other two.)  Nothing on this machine is a CPU-written DAC: the
   // only converter on board 011-029A is IC61, a YM3014B, which is the YM3812's own
   // companion serial DAC (it takes the OPL2's serial output, not a bus byte) and is
   // therefore already inside PinMAME's YM3812 emulation; IC62 is an LM324-class op-amp

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -149,9 +149,8 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
 /  The NMI is deliberately NOT generated here.  It is not periodic: F4/F6 show the Z80
 /  raises it by strobing port-0x81 bit 2, which latches one byte into PCS2 0xA0100 for the
 /  handler to read, and 0xA0100 is read in exactly one place in the whole 80188 ROM (that
-/  handler).  Until the J1 link exists the firmware never receives the Z80's boot 0x47, so
-/  after its intro it parks in the poll at D2F59 (CALL sub_D5D1B / OR AL,AL / JE) with
-/  interrupts enabled and both ISRs still running -- a wait state, not a hang.
+/  handler).  It is raised from iomoon_z80_write instead, where the real Z80 firmware
+/  strobes it -- see the J1 byte-port block further down.
 /-----------------------------------------------------------------------------------*/
 
 /* CLKOUT.  INFERRED, not measured: IC1 is an AMD N80C188-10, and the -10 is the part's
@@ -882,16 +881,94 @@ static void iomoon_set_gfx_bank(UINT8 pcs0) {
   cpu_setbank(IOMOON_GFX_BANK, memory_region(SLEIC_MEMREG_GFX) + iomoon_gfx_page_base[pcs0 & 0x07]);
 }
 
-/* Io Moon 80188 peripheral write.  Only PCS0's page-select side effect is wired up
- * here; the rest of the block (PCS1 J1 outbound, PCS2, PCS4, PCS5 YM3812, PCS6 OKI +
- * NVRAM gate) is the subject of the following driver work and is only logged for now */
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) J1 byte port -- findings F6 (the port, both directions), F4 (what the
+/  80188 does with an inbound byte) and F5 (the switch codes the Z80 sends over it).
+/
+/  J1 is an 8-bit bidirectional byte port with handshakes: no address bus, no shared
+/  memory, no HOLD/HLDA.  Each direction is one latch plus one interrupt, and BOTH ends
+/  here run their real firmware -- the driver only carries bytes.  Nothing is synthesised:
+/  the boot 0x47, the 0x45/0x46 replies and every switch code come out of the Z80 ROM
+/  (V1 3_05.bin), and F4 rejects the old branch's invented marker stream outright.
+/
+/  Z80 -> 80188.  Two outbound channels share the data port, and both strobe the same
+/  latch (F6; 0xA0100 is the only inbound read in the whole 80188 ROM, so a second latch
+/  would be unread by construction):
+/
+/    host_send_c0fc 0116  one-byte EVENT CODE (F5)       port-0x81 bit 2
+/    host_send_c008 0144  8-bit STATE BITMASK            port-0x81 bit 5
+/
+/    IN A,($01) / BIT 1 / JR Z,self   spin until the port is free   <- port 0x01 bit 1
+/    (C001) |= 0x02, OUT ($81)        data-valid
+/    A = the byte,  OUT ($80)         onto the data lines
+/    (C001) |= 0x04, OUT ($81)        strobe: latch + 80188 NMI
+/
+/  The strobe latches the port-0x80 byte at PCS2 0xA0100 and raises the 80188 NMI, whose
+/  handler D000:016D reads that latch exactly ONCE (F4), counts the value 0x32 in
+/  [4000:1144] and appends everything else to the FIFO at 4000:1220.  The driver models
+/  the latch as a one-byte mailbox with flow control on port-0x01 bit 1: free while empty,
+/  busy from the strobe until the NMI reads 0xA0100.  That is what stops the Z80
+/  overrunning a latch the 80188 has not emptied yet -- and dropped switch bytes are
+/  exactly the failure this task exists to prevent.  It cannot deadlock: the NMI is
+/  non-maskable, the Z80's spin runs with interrupts enabled, and the send routines take
+/  the bus only after the spin.
+/
+/  80188 -> Z80.  qout_service_pcs1 D01E5, called from the INT0 ISR, writes the byte to
+/  PCS1 0xA0080 and then pulses PCS4 0xA0200 bit 6 and bit 5, releasing both after 13
+/  NOPs.  On the Z80 that strobe is an NMI (0x0066): it gates port-0x81 bit 4 on, reads
+/  IN ($00), stores into the ring at $C076 and lets host_cmd_dispatch 16D5 run the byte
+/  through the 256-entry table at $2000 (F7).  Before writing, the ISR tests PCS3
+/  0xA0180 bit 0 -- "receiver ready" -- and gives up for this call if it is clear, which
+/  is the reverse direction's flow control and is modelled the same way.
+/
+/  The Z80 NMI is taken on the bit-5 edge rather than bit 6 for a reason that is worth
+/  recording: the INBOUND NMI handler also drives PCS4, asserting bits 7, 6 and 4
+/  (OR AL,0D0) around its latch read, so bit 6 rises on every Z80->80188 byte as well and
+/  would fire a spurious Z80 NMI per inbound byte.  Bit 5 is touched by nothing but
+/  qout_service_pcs1.  WHICH J1 line each PCS4 bit actually drives is F6's own open
+/  clause (it needs the IC7/IC8 PALs); what the firmware pair needs, and what this
+/  models, is one Z80 NMI per outbound byte, after the byte is latched.
+/-----------------------------------------------------------------------------------*/
+static struct {
+  UINT8 to188;     /* Z80 port 0x80: the byte on the J1 data lines                     */
+  UINT8 latch;     /* PCS2 0xA0100: what the port-0x81 strobe captured for the 80188   */
+  UINT8 latchFull; /* set from the strobe until the NMI reads 0xA0100 (port-01 bit 1)  */
+  UINT8 ctrl;      /* Z80 port 0x81 shadow, for the bit-2 / bit-5 strobe edges         */
+  UINT8 toZ80;     /* PCS1 0xA0080: the byte the 80188 sent                            */
+  UINT8 toZ80Full; /* set until the Z80 takes it (PCS3 0xA0180 bit 0 = receiver ready) */
+  UINT8 pcs4;      /* PCS4 0xA0200 shadow, for the outbound bit-5 strobe edge          */
+  UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
+} iomoon_j1; //!!
+
+/* Io Moon 80188 peripheral write.  PCS0's page select (F2) and the J1 outbound half
+ * (PCS1 data + the PCS4 bit-5 strobe, F6) are wired; PCS5 YM3812 (F8), PCS6 OKI (F9)
+ * and the PCS0 NVRAM gate (F10) are later tasks and are only logged */
 static WRITE_HANDLER(sleic2_periph_w) {
   switch (offset) {
     case 0x000: /* PCS0: bits 0-2 graphics page (F2), 3/4 NVRAM window gate (F10), 5 = OKI /OKCS (F9) */
       if ((data ^ iomoon_pcs0) & 0x07) iomoon_set_gfx_bank(data);
       iomoon_pcs0 = data;
       return;
-    default:                          /* PCS1 J1 outbound, PCS2, PCS3, PCS4, PCS5 YM3812, PCS6 OKI */
+    case 0x080: /* PCS1: the byte on the outbound J1 data lines (qout_service_pcs1 D020F).
+                 * Writing it does NOT start a transfer -- the PCS4 bit-5 strobe below
+                 * does.  That distinction is not academic: the boot's peripheral init
+                 * writes 0x00 here long before any queue exists, and treating that as a
+                 * byte in flight would leave "receiver ready" clear for ever and stall
+                 * the whole outbound direction */
+      iomoon_j1.toZ80 = data;
+      return;
+    case 0x200: /* PCS4: J1 handshake lines.  Bit 5 is pulsed by qout_service_pcs1 alone
+                 * (D022A/D0243) -- the inbound NMI handler asserts bits 7/6/4 but never
+                 * bit 5 -- so its rising edge is the outbound strobe, and it arrives
+                 * after the PCS1 write above.  Bit 3 (the old branch's "frame strobe")
+                 * is F13/Task 11's, not this one's */
+      if ((data & 0x20) && !(iomoon_j1.pcs4 & 0x20)) {
+        iomoon_j1.toZ80Full = 1;
+        cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE); /* Z80 handler 0x0066 */
+      }
+      iomoon_j1.pcs4 = data;
+      return;
+    default:                          /* PCS2, PCS3, PCS5 YM3812, PCS6 OKI */
 #ifdef DEBUG_SLEIC
       if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
 #endif
@@ -899,11 +976,23 @@ static WRITE_HANDLER(sleic2_periph_w) {
   }
 }
 
-/* Io Moon 80188 peripheral read.  Nothing in the block is modelled yet: the J1 inbound
- * byte at PCS2 0xA0100 (F4/F6) and the YM3812 status at PCS5 0xA0280 (F8) come with the
- * link and sound work.  Deliberately NOT the base sleic_periph_r -- its 0x37 "no event"
- * idle and 0xA0180 ready bit are Bike Race conventions that do not apply here */
+/* Io Moon 80188 peripheral read.  The J1 half is modelled (F4/F6); the YM3812 status at
+ * PCS5 0xA0280 (F8) comes with the sound work.  Deliberately NOT the base sleic_periph_r
+ * -- its 0x37 "no event" idle is a Bike Race convention that F4 rules out here: 0xA0100
+ * carries Z80 bytes and nothing else */
 static READ_HANDLER(sleic2_periph_r) {
+  switch (offset) {
+    case 0x100: /* PCS2: the J1 inbound latch, read exactly once per byte by the NMI
+                 * handler D018C (F4).  The read is what frees the port for the Z80's
+                 * next byte, so clear the busy flag and leave the latch itself standing
+                 * -- a hardware latch holds its last value */
+      iomoon_j1.latchFull = 0;
+      return iomoon_j1.latch;
+    case 0x180: /* PCS3 bit 0: "receiver ready".  qout_service_pcs1 tests it (D0206) and
+                 * gives up for this call when it is clear, so it must report that the Z80
+                 * has taken the previous byte */
+      return iomoon_j1.toZ80Full ? 0x00 : 0x01;
+  }
   return 0;
 }
 
@@ -1239,6 +1328,115 @@ static PORT_WRITE_START(SLEIC1_Z80_writeport)
   {0x80,0x87, sleic1_z80_write},
 MEMORY_END
 
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) I/O Z80 ports.  The J1 half is the block above; this is the rest of
+/  the map the real V1 3_05.bin firmware drives, read out of that ROM.
+/
+/  IN  0x00  the J1 inbound byte (PCS1), taken by the NMI (0x0080, gate port-0x81 bit 4)
+/            or by the polled host_read_byte 01B6 (gate bit 6).  One latch either way
+/  IN  0x01  bit 1 = J1 port free (every host_send_* and host_read_byte spins on it,
+/            0116/0144/017E/01B6), bit 5 = the selected direct input, active LOW
+/            (direct_input_scan 0DF8/0E36)
+/  IN  0x02  switch-matrix column return, active LOW: sw_read_col0..5 2ED3..2FB9 CPL it
+/            into the per-column change masks.  6 columns x 8 = the 48 codes of F5
+/  IN  0x03  cabinet inputs, active LOW (input_port03_read 2E54 CPLs it).  Bits and the
+/            codes their handlers send: 0 -> 0x3E (sub_125B, with a 3000-tick lockout),
+/            1 -> 0x3F (sub_1278; F14: this is the byte that OPENS the service menu),
+/            4 -> 0x40 (sub_1285), 2 and 3 -> the two flipper inputs (sub_12D8 / sub_1292,
+/            which fire the port-0x85 coil pairs directly and send 0x42 / 0x41 only in
+/            test mode), 5 -> the auto-repeating 0x32 (0x33 in test mode, 0D3C/0D44)
+/  IN  0x04  cabinet/config byte -- see IOMOON_PORT04_IDLE
+/
+/  OUT 0x80  J1 data lines            OUT 0x83  lamp column strobe   } F7, Task 13
+/  OUT 0x81  J1 control (bit map F6)  OUT 0x84  lamp row data        }
+/  OUT 0x82  switch column strobe     OUT 0x85/0x86  driver latches, active low
+/                                     OUT 0x87  direct-input index + flag bits
+/-----------------------------------------------------------------------------------*/
+
+/* Port 0x04 with nothing pressed.  Three bits have to be right or the firmware misbehaves,
+ * and all three readings come from the ROM:
+ *
+ *   bit 7 = 1  selftest_wait_reset 2E42 spins on it (IN ($04) / BIT 7 / JP Z,self), so a 0
+ *              here is a hang the moment the self-test path is taken.
+ *   bit 0 = 1  disables direct_input_scan 0DBF (IN ($04) / BIT 0 / RET NZ).  That scan is
+ *              the 16-way multiplexed input behind port-0x87's low nibble and port-0x01
+ *              bit 5, sending codes 0x50-0x79; which physical contacts sit on it is part
+ *              of F5's open gap, so the honest model is "not fitted" rather than a
+ *              guessed wiring.  Turning it on is a one-bit change once that is known.
+ *   bit 5 = 0  makes the command-0xED handler 2BEB answer 0x45 at once (IN ($04) / BIT 5 /
+ *              JP Z,2C17).  With bit 5 SET the handler instead loops -- strobe column 0,
+ *              check the trough contacts, run the eject coil sequence sub_2CFB, repeat --
+ *              and its ONLY exit is those contacts closing.  That is correct hardware
+ *              behaviour (a machine waiting for its balls), but it never returns to the
+ *              command dispatcher, so the Z80 stops scanning switches entirely; with no
+ *              ball model and F5's physical map open, 0 is the state this driver can
+ *              honestly hold.  The 80188 side is happy either way: F14's prompt takes
+ *              0x45 or 0x46 and moves on.
+ *
+ * The low nibble is also reported to the 80188 verbatim as 0xF0|nibble by handler 2D9D,
+ * i.e. it is a configuration nibble; nothing in either ROM says what the bits mean */
+#define IOMOON_PORT04_IDLE 0xdf
+
+static READ_HANDLER(iomoon_z80_read) {
+  switch (offset) {
+    case 0x00: /* J1 inbound data.  Reading is what frees the outbound latch, which is
+                * what PCS3 0xA0180 bit 0 reports back to qout_service_pcs1 */
+      iomoon_j1.toZ80Full = 0;
+      return iomoon_j1.toZ80;
+    case 0x01: /* bit 1 = J1 free (clear while the 80188 has not read the latch yet),
+                * bit 5 = direct input, 1 = open.  The scan that reads bit 5 is gated off
+                * by IOMOON_PORT04_IDLE bit 0 anyway */
+      return (UINT8)((iomoon_j1.latchFull ? 0x00 : 0x02) | 0x20);
+    case 0x02: /* switch matrix: 6 columns -> swMatrix[1..6], active low */
+      return (UINT8)~coreGlobals.swMatrix[1 + iomoon_j1.swCol];
+    case 0x03: /* cabinet inputs -> swMatrix[9], active low */
+      return (UINT8)~coreGlobals.swMatrix[9];
+    case 0x04: /* cabinet/config byte; swMatrix[10] pulls a bit low when closed */
+      return (UINT8)(IOMOON_PORT04_IDLE & ~coreGlobals.swMatrix[10]);
+    default:
+      logerror("iomoon Z80 read port %02x\n", offset);
+  }
+  return 0;
+}
+
+static WRITE_HANDLER(iomoon_z80_write) {
+  switch (offset) {
+    case 0x00: /* port 0x80: the byte onto the J1 data lines (written before the strobe) */
+      iomoon_j1.to188 = data;
+      break;
+    case 0x01: /* port 0x81: J1 control.  Bit 2 (event codes) and bit 5 (the C008 state
+                * bitmask) are the two outbound strobes and reach the same latch (F6);
+                * bit 1 is data-valid, bits 4/6 gate the two inbound read paths, bit 3 is
+                * the free-running-ish toggle F3 lists as an INT0 candidate and bit 0 is
+                * unproven -- none of those four need an action here */
+      { const UINT8 rise = (UINT8)(data & ~iomoon_j1.ctrl);
+        if (rise & 0x24) {
+          iomoon_j1.latch = iomoon_j1.to188;
+          iomoon_j1.latchFull = 1;
+          cpu_set_irq_line(SLEIC_MAIN_CPU, IRQ_LINE_NMI, PULSE_LINE); /* handler D000:016D */
+        }
+      }
+      iomoon_j1.ctrl = data;
+      break;
+    case 0x02: /* port 0x82: switch-matrix column strobe, one-hot 0x01..0x20 = column 0..5 */
+      if (data) { const unsigned col = core_BitColToNum(data & -data);
+                  if (col < 6) iomoon_j1.swCol = (UINT8)col; }
+      break;
+    default:   /* 0x83/0x84 lamps, 0x85/0x86 drivers, 0x87 direct-input index: F7, Task 13.
+                * Silently ignored rather than logged -- the lamp refresh writes on every
+                * one of the Z80's ~977 interrupts per second */
+      break;
+  }
+}
+
+static PORT_READ_START(SLEIC2_Z80_readport)
+  {0x00,0x07, iomoon_z80_read},
+MEMORY_END
+
+static PORT_WRITE_START(SLEIC2_Z80_writeport)
+  {0x80,0x87, iomoon_z80_write},
+MEMORY_END
+
 static MACHINE_INIT(SLEIC) {
   /* The memset covers everything in locals -- the DMD latch and its TTL, the OKI
    * phrase/strobe state, the J1 link latches, the YM3812 A0 select and the SLEIC3
@@ -1283,6 +1481,75 @@ static MACHINE_INIT(SLEIC2) {
   iomoon_set_gfx_bank(iomoon_pcs0);
   iomoon_int0_acc = iomoon_t0_acc = 0.0;
   iomoon_int0_pend = iomoon_t0_pend = 0;
+  /* J1 idle: both latches empty, so port-0x01 bit 1 reads free for the Z80's very first
+   * send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
+   * that routine spins on the bit before it does anything else */
+  memset(&iomoon_j1, 0, sizeof iomoon_j1);
+}
+
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) switch input.  Where each byte comes from is F5; which physical
+/  contact sits behind each code is F5's own open gap, so what is claimed here is the
+/  code map (exact, out of the Z80 ROM) and not a contact list.
+/
+/    swMatrix[1..6]  the 6 x 8 matrix, column c selected by the port-0x82 one-hot strobe
+/                    and read back on port 0x02.  Code = 0x0A + 8c + b for c = 0..4 and
+/                    0x34 + b for c = 5 -- exactly regular, 48 positions.
+/    swMatrix[9]     the six port-0x03 cabinet inputs (bit -> code above iomoon_z80_read)
+/    swMatrix[10]    the port-0x04 config byte (see IOMOON_PORT04_IDLE); nothing is mapped
+/                    into it, because bit 7 must stay high and the rest is unknown
+/
+/  FIVE of the 48 matrix positions never produce a byte, and that is firmware, not a gap
+/  in the driver: codes 0x13 and 0x38-0x3B dispatch to sub_1348, which is a bare RET.
+/  (0x38-0x3B do reach the 80188, but only as command-table re-sends -- F5.)
+/-----------------------------------------------------------------------------------*/
+
+/* Playfield test keys, one per matrix position, so the service menu's contact test can
+ * exercise every contact standalone.  Columns 0-4 keep the Bike Race key layout; column 5
+ * only maps the four positions whose codes (0x34-0x37) the firmware actually sends */
+static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
+  {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08}, /* col0 0x0A-0x0D */
+  {KEYCODE_Y,1,0x10},{KEYCODE_U,1,0x20},{KEYCODE_I,1,0x40},{KEYCODE_O,1,0x80}, /* col0 0x0E-0x11 */
+  {KEYCODE_A,2,0x01},{KEYCODE_S,2,0x02},{KEYCODE_D,2,0x04},{KEYCODE_F,2,0x08}, /* col1 0x12-0x15 (0x13 = RET) */
+  {KEYCODE_G,2,0x10},{KEYCODE_H,2,0x20},{KEYCODE_J,2,0x40},{KEYCODE_K,2,0x80}, /* col1 0x16-0x19 */
+  {KEYCODE_Z,3,0x01},{KEYCODE_X,3,0x02},{KEYCODE_C,3,0x04},{KEYCODE_V,3,0x08}, /* col2 0x1A-0x1D */
+  {KEYCODE_B,3,0x10},{KEYCODE_N,3,0x20},{KEYCODE_M,3,0x40},{KEYCODE_L,3,0x80}, /* col2 0x1E-0x21 */
+  {KEYCODE_0_PAD,4,0x01},{KEYCODE_1_PAD,4,0x02},{KEYCODE_2_PAD,4,0x04},{KEYCODE_3_PAD,4,0x08}, /* col3 0x22-0x25 */
+  {KEYCODE_4_PAD,4,0x10},{KEYCODE_5_PAD,4,0x20},{KEYCODE_6_PAD,4,0x40},{KEYCODE_7_PAD,4,0x80}, /* col3 0x26-0x29 */
+  {KEYCODE_0,5,0x01},{KEYCODE_2,5,0x02},{KEYCODE_3,5,0x04},{KEYCODE_4,5,0x08}, /* col4 0x2A-0x2D */
+  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_7,5,0x40},{KEYCODE_9,5,0x80}, /* col4 0x2E-0x31 */
+  {KEYCODE_T,6,0x01},{KEYCODE_8_PAD,6,0x02},{KEYCODE_9_PAD,6,0x04},{KEYCODE_MINUS_PAD,6,0x08}, /* col5 0x34-0x37 */
+};
+
+static SWITCH_UPDATE(SLEIC2) {
+  unsigned i;
+  if (inports) {
+    /* Cabinet inputs -> swMatrix[9] = Z80 port 0x03, one bit per input.  The bit -> CODE
+     * map is exact (F5/F14, see iomoon_z80_read); the bit -> BUTTON map below is what a
+     * driver has to choose without the wiring diagram, and each choice has a reason:
+     *   bit 1 -> TEST, because its code 0x3F is the one that opens the service menu (F14)
+     *   bit 0 -> COIN, because sub_125B arms a 3000-tick lockout before sending 0x3E
+     *   bit 4 -> START, because the 80188 dispatches its code 0x40 immediately next to
+     *            the menu key (D7ADA -> sub_D8066)
+     *   bits 3/2 -> left/right flipper: those two handlers (sub_1292 / sub_12D8) fire the
+     *            port-0x85 coil pairs directly, and Sleic Pin-Ball's verified map puts the
+     *            left flipper on the first pair.  INFERRED
+     *   bit 5 -> TILT: its 0x32 auto-repeats while held and the 80188 COUNTS it in
+     *            [4000:1144] instead of queueing it (F4), which is how a plumb bob
+     *            behaves and how Bike Race numbers its tilt.  INFERRED */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 9,  0x01, 9); /* COIN  0x0200 -> bit0 (code 0x3E) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST  0x0800 -> bit1 (code 0x3F) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 1,  0x04, 9); /* R-flip 0x0002 -> bit2            */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] << 3,  0x08, 9); /* L-flip 0x0001 -> bit3            */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x10, 9); /* START 0x0100 -> bit4 (code 0x40) */
+    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 5,  0x20, 9); /* TILT  0x0400 -> bit5 (code 0x32) */
+  }
+  for (i = 0; i < sizeof(iomoon_pf_keys)/sizeof(iomoon_pf_keys[0]); i++) {
+    if (keyboard_pressed(iomoon_pf_keys[i].key))
+      coreGlobals.swMatrix[iomoon_pf_keys[i].col] |=  iomoon_pf_keys[i].bit;
+    else
+      coreGlobals.swMatrix[iomoon_pf_keys[i].col] &= ~iomoon_pf_keys[i].bit;
+  }
 }
 
 /* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch
@@ -1449,6 +1716,12 @@ MACHINE_DRIVER_START(SLEIC2)
   MDRV_IMPORT_FROM(SLEIC)
   MDRV_CORE_INIT_RESET_STOP(SLEIC2,NULL,NULL)
 
+  // Io Moon switch input: the 6x8 matrix on swMatrix[1..6] (Z80 port-0x82 column strobe,
+  // port 0x02 return), the six cabinet inputs on swMatrix[9] (port 0x03) and the port-0x04
+  // config byte on swMatrix[10].  Replaces the base handler, which only fills swMatrix[0]
+  // -- a row nothing on this machine reads
+  MDRV_SWITCH_UPDATE(SLEIC2)
+
   // Io Moon main CPU: the 80C188 at IC1 is an N80C188-10, and CLKOUT = 10 MHz is what
   // the timer-0 rate below is computed from, so the emulated clock matches it rather
   // than the base driver's 8 MHz.  REPLACE only re-states type and clock; the map is
@@ -1478,8 +1751,15 @@ MACHINE_DRIVER_START(SLEIC2)
   // 8000000/8192 to keep that derivation visible.  (Both ROMs are silent on it -- the
   // source is external to each -- so this is the board inventory's reading, not the
   // disassembly's.)  It replaces the inherited 2500000/2048 Bike Race / Sleic Pin-Ball rate
+  //
+  // The I/O Z80 also gets its own port map: the J1 byte-port link to the 80188 (port 0x80
+  // data + the port-0x81 strobes in, port 0x00 + the PCS1/PCS4 pair out) and the switch
+  // matrix.  The base map's z80_read_port returns 0 for port 0x04, whose bit 7 the Z80
+  // spins on in selftest_wait_reset, and 0 for port 0x01, whose bit 1 every J1 send waits
+  // for -- either alone hangs the I/O board before it can announce itself
   MDRV_CPU_MODIFY("icpu")
   MDRV_CPU_PERIODIC_INT(SLEIC_irq_z80, 8000000/8192.)
+  MDRV_CPU_PORTS(SLEIC2_Z80_readport, SLEIC2_Z80_writeport)
 
   MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
   MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -135,14 +135,14 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
 /  Timer 0's rate is fixed by that same boot table and is arithmetic, not a guess:
 /    T0CON  FF56 = E003 = EN | INH | INT, CONT=1, ALT=1, and prescaler bit 3 = 0, so the
 /                  counter is clocked at CLKOUT/4 and requests an interrupt on every
-/                  terminal count;
+/                  terminal count (an assumption -- see IOMOON_T0_MAXCOUNT);
 /    T0CMPA FF52 = T0CMPB FF54 = 0x6276 = 25206 -- both max counts are loaded with the
 /                  same value, so alternating between them does not change the period;
 /    timers 1 and 2 are disabled (FF5E = FF66 = 0).
 /  =>  (10 MHz / 4) / 25206  =  2 500 000 / 25206  =  99.18 Hz.
-/  The divisor and the count are confirmed; the frequency inherits the CLKOUT = 10 MHz
-/  reading of IC1 (an AMD N80C188-10), which no ROM states -- hence IOMOON_CPU_CLOCK is
-/  the one place to change if the crystal ever turns out to be something else.
+/  The divisor and the count are confirmed.  The two things that are not are the CLKOUT
+/  figure (see IOMOON_CPU_CLOCK) and the every-terminal-count reading of ALT mode (see
+/  IOMOON_T0_MAXCOUNT); each is a clean factor on the result.
 /
 /  INT0's rate is the one genuinely open number in the model -- see IOMOON_INT0_HZ.
 /
@@ -154,10 +154,19 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
 /  interrupts enabled and both ISRs still running -- a wait state, not a hang.
 /-----------------------------------------------------------------------------------*/
 
-/* IC1 is an AMD N80C188-10; CLKOUT = 10 MHz is what the timer-0 arithmetic above assumes,
- * so the emulated CPU runs at the same figure rather than the base driver's 8 MHz */
+/* CLKOUT.  INFERRED, not measured: IC1 is an AMD N80C188-10, and the -10 is the part's
+ * speed GRADE -- the maximum clock it is rated for -- not a reading of the crystal fitted
+ * on this board, and no ROM states the clock.  10 MHz is what the timer-0 arithmetic above
+ * assumes, so the emulated CPU is given the same figure rather than the base driver's
+ * 8 MHz, and this one constant moves both together if the crystal is ever measured */
 #define IOMOON_CPU_CLOCK   10000000
-#define IOMOON_T0_MAXCOUNT 0x6276  /* 25206, T0CMPA = T0CMPB from the boot table */
+
+/* 25206 = T0CMPA = T0CMPB, straight out of the boot table.  The period it implies rests on
+ * one ASSUMPTION, which findings F1 makes too: that with ALT = 1 the timer requests an
+ * interrupt on EVERY terminal count, so one max count is one period.  If the part instead
+ * only interrupts on max count B, the rate halves to 49.59 Hz -- a factor of two, not a
+ * detail.  Both max counts hold the same value here, so nothing else would change */
+#define IOMOON_T0_MAXCOUNT 0x6276
 #define IOMOON_TIMER0_HZ   ((IOMOON_CPU_CLOCK / 4.0) / (double)IOMOON_T0_MAXCOUNT) /* 99.18 */
 
 /* INT0 (vector 0x0C) rate.  NOT CONFIRMED, and the one genuinely open number in the model
@@ -169,25 +178,35 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * and because it is the only candidate whose implied outbound J1 byte rate (INT0/8, see
  * qout_service_pcs1) carries 64 lamps and 13 drivers at a playable rate.
  *
- * That recommendation cannot stand as a rate, and the firmware's own handler is what
- * refutes it.  The composite branch sub_F08A5 is two 512-iteration byte loops of 7-9
- * instructions each -- about 65 000 clocks, 6.5 ms at 10 MHz -- and the blit branch
- * sub_F08EB is a 512-iteration loop plus the animation dispatch.  Measured over a headless
- * boot the handler averages 7.5 ms, so a 290 Hz (3.45 ms) or even a 145 Hz (6.9 ms) period
- * cannot contain it.  Nothing about that is an emulation artefact: the same instruction
- * count on a real 80186 gives the same milliseconds, and the 80188's 8-bit bus makes it
- * slower still.  And because INT0 outranks the timer on the interrupt controller, a
- * permanently-pending INT0 does not merely run late, it starves timer 0 completely -- at
- * 290 Hz the driver measures timer 0 at 0 interrupts per second and the firmware never
- * leaves its frame-delay loop at D5611, which is a hang, not a slow machine.
+ * Neither of the two PIC rates can be run here, and the handler they would be driving is
+ * why.  The composite branch sub_F08A5 is two 512-iteration byte loops of 7-9 instructions
+ * each -- about 65 000 clocks, 6.5 ms at 10 MHz -- and the blit branch sub_F08EB is a
+ * 512-iteration loop plus the animation dispatch; measured over a headless boot the
+ * handler averages 7.5 ms.  A 290 Hz period is 3.45 ms and a 145 Hz period 6.9 ms, so
+ * neither contains it, and because INT0 outranks timer 0 on the controller a
+ * permanently-pending INT0 does not merely run late -- it starves the timer outright.  At
+ * 290 Hz the probe measures timer 0 at zero interrupts per second and the firmware never
+ * leaves its frame-delay loop at D5611: a hang, not a slow machine.
  *
- * So this ships at the rate the firmware can actually sustain: 72.5 Hz, the 145 Hz DMD
- * wire rate divided by the two bitplanes -- which is also the INT0 rate the Bike Race
- * machine in this same driver uses.  There the handler is serviced in full, timer 0 runs
- * at 92 of its 99.18 Hz, the CPU spends 55% of its time in ISRs, and the firmware boots
- * through its intro to the J1 wait.  DMD refresh, FM tempo and the outbound queue rate all
- * scale with this number, which is why it is one named constant: an IC23 dump, a scope on
- * the line, or the frame-clock work is what would settle it */
+ * So what ships here is 72.5 Hz, and it is important to be plain about what that number is
+ * and is not.  It is an EMULATION-SERVICEABILITY figure that corresponds to NO F3
+ * candidate and is not derived from the panel at all.  It cannot be: a per-plane pulse
+ * MULTIPLIES the frame rate rather than dividing it, which is precisely why F3's
+ * per-plane candidate is 290 Hz -- twice the 145 Hz wire rate -- and half of 145 is not a
+ * rate any candidate produces.  72.5 Hz was chosen empirically, by sweeping the rate and
+ * taking the highest one at which both handlers stay served: timer 0 falls to 66/s at
+ * INT0 = 100 Hz, to 34/s at 145 Hz and to nothing at 290 Hz, whereas at 72.5 Hz INT0 is
+ * serviced in full, timer 0 runs at 92 of its 99.18 Hz, the CPU spends 55% of its time in
+ * ISRs, and the firmware boots through its intro to the J1 wait.
+ *
+ * The corollary points past the rate, and is the more interesting half.  If the handler
+ * costs anything like 7 ms on silicon as well -- and the instruction count says it should,
+ * since a real 80186 needs the same clocks and the 80188's 8-bit bus needs more -- then no
+ * ~290 Hz source can be driving it, so the measurement weakens F3's SOURCE hypothesis (the
+ * PIC per-plane pulse) and not just its number.  That is an emulation-side result, so it
+ * does not close F3's gap: what would settle the source and the rate is an IC23 dump or a
+ * scope on the line.  DMD refresh, FM tempo and the outbound queue rate all scale with
+ * this constant, which is why it stays one named number */
 #define IOMOON_INT0_HZ 72.5
 
 /* One periodic generator drives both sources, and it has to tick a good deal faster than
@@ -198,10 +217,14 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
 #define IOMOON_IRQ_TICK_HZ 2000.0
 
 /* Fractional tick accumulators, and one held request per source.  The request has to be
- * held because of how this i86 core delivers interrupts: it takes a vectored interrupt at
- * the instant the line is asserted -- inside cpu_set_irq_line_and_vector -- and only if IF
- * is set right then; it never re-examines the line afterwards, so HOLD_LINE does not
- * actually hold anything and a request raised while an ISR is running would just vanish.
+ * held because of how this i86 core delivers interrupts.  cpu_set_irq_line_and_vector does
+ * not touch the CPU itself: it appends the request to a per-CPU event queue and schedules a
+ * TIME_NOW timer, and cpu_empty_event_queue (src/cpuint.c) is what asserts the line --
+ * still before the CPU executes another instruction, which is why testing IF in this
+ * generator is a valid proxy for IF at delivery.  i86_set_irq_line then takes the interrupt
+ * right there if IF is set, and otherwise does nothing at all: the execute loop never
+ * re-examines irq_state, so HOLD_LINE does not actually hold anything and a request raised
+ * while an ISR is running would just vanish.
  * That is not what the 80188's interrupt controller does: it latches the request and
  * serves it when the firmware re-enables interrupts.  Measured on Io Moon the difference
  * is not cosmetic -- the INT0 handler's DMD work is long enough that raising the two
@@ -1394,9 +1417,11 @@ MACHINE_DRIVER_START(SLEIC1)
   // Battery-backed NVRAM (28C64A): persisted by NVRAM_HANDLER(SLEIC1) and mapped
   // read==write to one buffer so the firmware's boot-time self-repair sticks and
   // the signature re-validation passes (clears "Memoria EEPROM en mal estado").
-  // REPLACE wipes the inherited mcpu map/ports/IRQ, so all are re-stated; only the
-  // 80188 memory map changes vs. the base SLEIC (Bike Race and Io Moon each state
-  // their own map in the SLEIC3 / SLEIC2 blocks below)
+  // REPLACE only re-states the CPU type and clock (driver.h: it assigns cpu_type and
+  // cpu_clock and nothing else) -- the inherited map, ports and IRQ survive it.  They are
+  // spelled out again below anyway, because only the 80188 memory map actually differs
+  // from the base SLEIC (Bike Race and Io Moon each state their own map in the SLEIC3 /
+  // SLEIC2 blocks below)
   MDRV_NVRAM_HANDLER(SLEIC1)
   MDRV_CPU_REPLACE("mcpu", I188, 8000000)
   MDRV_CPU_MEMORY(SLEIC1_80188_readmem, SLEIC1_80188_writemem)
@@ -1471,8 +1496,9 @@ MACHINE_DRIVER_START(SLEIC3)
   MDRV_NVRAM_HANDLER(SLEIC3)
 
   // Bike Race main CPU: 80C188 at 10 MHz (work RAM at seg 0, peripherals at
-  // 0xA0000, code at 0xE0000). REPLACE wipes the inherited
-  // map/IRQ, so memory, ports and the IRQ generator are all re-stated
+  // 0xA0000, code at 0xE0000). REPLACE only re-states the CPU type and clock; the
+  // memory, ports and IRQ generator below are stated because they all differ from
+  // the base SLEIC, not because REPLACE cleared them
   MDRV_CPU_REPLACE("mcpu", I188, 10000000)
   MDRV_CPU_MEMORY(SLEIC3_80188_readmem, SLEIC3_80188_writemem)
   MDRV_CPU_PORTS(SLEIC_80188_readport, SLEIC_80188_writeport)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -12,6 +12,11 @@
 		DISPLAY: DMD 128x32
 		SOUND:   YM3812 (OPL2 FM music) + OKI MSM6376 (ADPCM speech/FX),
 		         both driven by the 80188
+
+   The F1..F15 citations throughout this file refer to the findings contract in the SLEIC
+   IO Moon reverse-engineering repository (https://github.com/gerwout/sleic-iomoon, file
+   asm/baseline-2026-09/findings.md), as do paths such as docs/dmd_wire_protocol.md and
+   asm/pic16c57_annotated.asm.
  ************************************************************************************************/
 
 #include "driver.h"
@@ -90,6 +95,9 @@ static void sleic_dmd_dump(const UINT8 *frame) {
 static int SLEIC_sw2m(int no) { return (no/10 - 4)*8 + no%10; }
 static int SLEIC_m2sw(int col, int row) { return 40 + col*10 + row; }
 
+/* The base machine's placeholder: a vector-less pulse of IRQ line 0.  Every concrete
+ * machine below now overrides it (sleic1_irq_gen / iomoon_irq_gen / sleic3_irq_gen), so
+ * nothing that ships reaches this */
 static INTERRUPT_GEN(SLEIC_irq_i80188) {
   cpu_set_irq_line(SLEIC_MAIN_CPU, 0, PULSE_LINE);
 }
@@ -183,7 +191,7 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * handler averages 7.5 ms.  A 290 Hz period is 3.45 ms and a 145 Hz period 6.9 ms, so
  * neither contains it, and because INT0 outranks timer 0 on the controller a
  * permanently-pending INT0 does not merely run late -- it starves the timer outright.  At
- * 290 Hz the probe measures timer 0 at zero interrupts per second and the firmware never
+ * 290 Hz measurement shows timer 0 at zero interrupts per second and the firmware never
  * leaves its frame-delay loop at D5611: a hang, not a slow machine.
  *
  * So what ships here is 72.5 Hz, and it is important to be plain about what that number is
@@ -221,7 +229,7 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * It is deliberately NOT changed yet.  Everything measured for the J1 link -- the switch
  * scan cadence, the handshake spins, the byte rates -- was measured at 2.5 MHz, and a 1.6x
  * change to the I/O board's speed re-times all of it at once.  Revisit it against the real
- * machine (or a scope on X10) as its own step, with the switch-delivery probe re-run
+ * machine (or a scope on X10) as its own step, with switch-delivery testing re-run
  * either side of the change; that is an owner checkpoint, not a silent edit */
 #define IOMOON_Z80_CLOCK 2500000
 
@@ -263,7 +271,7 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  *
  * Pitch and envelope speed scale with it; musical TEMPO does not.  Tempo comes from the
  * sequencer's tick, which F8 puts on the INT0 handler's odd branch: IOMOON_INT0_HZ / 2 =
- * 36.25 Hz here, and that half is MEASURED (SLEIC_PROBE_IRQ reports INT0 served at 72.5/s).
+ * 36.25 Hz here, and that half is MEASURED (INT0 served at 72.5/s over a headless boot).
  * How far off hardware that is depends entirely on F3's open INT0 source, so it is stated
  * as a range and not as a number: 2x slow if INT0 is the per-FRAME candidate (~145 Hz),
  * 4x slow under F3's per-PLANE recommendation (~290 Hz).  Deliberately NOT derived from
@@ -1067,11 +1075,12 @@ static void iomoon_set_gfx_bank(UINT8 pcs0) {
 /  the latch as a one-byte mailbox with flow control on port-0x01 bit 1: free while empty,
 /  busy from the strobe until the NMI reads 0xA0100.  That is what stops the Z80
 /  overrunning a latch the 80188 has not emptied yet -- and dropped switch bytes are
-/  exactly the failure this task exists to prevent.
+/  exactly the failure that flow control exists to prevent.
 /
-/  It cannot deadlock, and NOT because of anything on the Z80 side: host_send_c0fc is
-/  reached from the IRQ handler as well, so its spin can run with IFF1 = 0 and no Z80
-/  interrupt will break it.  What clears the latch is the other CPU, on two mechanisms
+/  It cannot deadlock, and NOT because of anything on the Z80 side: host_send_c008, the
+/  sibling sender at Z80 0144, is also reached from the IRQ handler (call sites at 0B49
+/  and 0C7E), so its spin can run with IFF1 = 0 and no Z80 interrupt will break it.  What
+/  clears the latch is the other CPU, on two mechanisms
 /  that hold regardless: (a) the 80188 NMI is non-maskable, so the handler that reads
 /  0xA0100 always runs; and (b) cpu_set_irq_line called from Z80 context queues the
 /  request for CPU 0 and schedules it with timer_set(TIME_NOW), which calls
@@ -1219,7 +1228,7 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * (D022A/D0243) -- the inbound NMI handler asserts bits 7/6/4 but never
                  * bit 5 -- so its rising edge is the outbound strobe, and it arrives
                  * after the PCS1 write above.  Bit 3 (the old branch's "frame strobe")
-                 * is F13/Task 11's, not this one's.
+                 * belongs to the DMD frame path (F13), not to this handshake.
                  *
                  * Bits 0-2 are deliberately ignored: sub_D03C0 / sub_D0401 bit-bang them
                  * as a three-wire serial port (CS, U/D, INC) for the X9C503P digital

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1880,6 +1880,12 @@ MACHINE_DRIVER_START(SLEIC2)
   // real model of findings F1/F3 -- timer 0 on vector 0x08 at 99.18 Hz and INT0 on
   // vector 0x0C at IOMOON_INT0_HZ, both interleaved on one tick.  The NMI is not
   // periodic and is not generated here; see the comment block above iomoon_irq_gen
+  //
+  // The base block's MDRV_CPU_VBLANK_INT(SLEIC_interface_update, 1) is DELIBERATELY left
+  // inherited (REPLACE does not clear it): that handler is what copies tmpLampMatrix ->
+  // lampMatrix and locals.solenoids -> coreGlobals.solenoids once a frame, so the lamp and
+  // driver decode in iomoon_z80_write writes the driver-local shadows only, exactly as the
+  // SLEIC1 and SLEIC3 port handlers do.  Do not re-state or drop it here
   MDRV_CPU_REPLACE("mcpu", I188, IOMOON_CPU_CLOCK)
   MDRV_CPU_MEMORY(SLEIC2_80188_readmem, SLEIC2_80188_writemem)
   MDRV_CPU_PERIODIC_INT(iomoon_irq_gen, IOMOON_IRQ_TICK_HZ)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -17,6 +17,7 @@
 #include "driver.h"
 #include "core.h"
 #include "cpu/i8039/i8039.h"
+#include "cpu/i86/i86intf.h" /* I86_FLAGS: the IF bit gates Io Moon's interrupt delivery */
 #include "sound/adpcm.h"
 #include "sound/3812intf.h"
 #include "sleic.h"
@@ -105,6 +106,132 @@ static INTERRUPT_GEN(SLEIC_irq_i80188) {
  * forever -> blank DMD.  Deliver vector 0x08 like the working Bike Race path */
 static INTERRUPT_GEN(sleic1_irq_gen) {
   cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x08);
+}
+
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) interrupt model -- findings F1 (the timer programming) and F3 (the
+/  vectors and what each handler does).
+/
+/  The IVT is RESIDENT IN ROM at physical 0, inside the LMCS window (F2/F3): the firmware
+/  installs nothing, and the image contains no IVT copy loop at all (no MOVSW/MOVSB
+/  anywhere).  So the driver must NOT seed a table -- the vectors are simply read out of
+/  ROM1, and the three live ones are:
+/
+/    type 02  NMI     -> D000:016D  inbound J1 byte: reads PCS2 0xA0100, counts 0x32,
+/                                   appends everything else to the 4000:1220 FIFO
+/    type 08  timer 0 -> D000:024F  OKI duration counters, deferred triggers and the
+/                                   general down-counters [1139]/[113B]/[113D]/[113F]/[1140]
+/    type 0C  INT0    -> D000:0343  alternating half-frames ([4000:1142] toggles on entry):
+/                                   even = DMD blit + animation dispatch, odd = DMD
+/                                   composite + fm_player_tick + qout_service_pcs1
+/
+/  Only these two vectored sources exist, because the boot table unmasks only timer 0 and
+/  INT0 (F1: IMASK/priority words FF32 = 0001 for the timer, FF38 = 0000 for INT0 --
+/  edge-triggered and the HIGHER priority of the two, since 0 is the top level -- with
+/  DMA0/DMA1/INT1/INT2/INT3 all masked and PRIMSK FF2A = 1) and nothing reprograms any of
+/  it after boot.  The two handlers agree: the one entered from vector 08 clears INSERV
+/  bit 0 (the timer) and the one entered from vector 0C clears INSERV bit 4 (INT0).
+/
+/  Timer 0's rate is fixed by that same boot table and is arithmetic, not a guess:
+/    T0CON  FF56 = E003 = EN | INH | INT, CONT=1, ALT=1, and prescaler bit 3 = 0, so the
+/                  counter is clocked at CLKOUT/4 and requests an interrupt on every
+/                  terminal count;
+/    T0CMPA FF52 = T0CMPB FF54 = 0x6276 = 25206 -- both max counts are loaded with the
+/                  same value, so alternating between them does not change the period;
+/    timers 1 and 2 are disabled (FF5E = FF66 = 0).
+/  =>  (10 MHz / 4) / 25206  =  2 500 000 / 25206  =  99.18 Hz.
+/  The divisor and the count are confirmed; the frequency inherits the CLKOUT = 10 MHz
+/  reading of IC1 (an AMD N80C188-10), which no ROM states -- hence IOMOON_CPU_CLOCK is
+/  the one place to change if the crystal ever turns out to be something else.
+/
+/  INT0's rate is the one genuinely open number in the model -- see IOMOON_INT0_HZ.
+/
+/  The NMI is deliberately NOT generated here.  It is not periodic: F4/F6 show the Z80
+/  raises it by strobing port-0x81 bit 2, which latches one byte into PCS2 0xA0100 for the
+/  handler to read, and 0xA0100 is read in exactly one place in the whole 80188 ROM (that
+/  handler).  Until the J1 link exists the firmware never receives the Z80's boot 0x47, so
+/  after its intro it parks in the poll at D2F59 (CALL sub_D5D1B / OR AL,AL / JE) with
+/  interrupts enabled and both ISRs still running -- a wait state, not a hang.
+/-----------------------------------------------------------------------------------*/
+
+/* IC1 is an AMD N80C188-10; CLKOUT = 10 MHz is what the timer-0 arithmetic above assumes,
+ * so the emulated CPU runs at the same figure rather than the base driver's 8 MHz */
+#define IOMOON_CPU_CLOCK   10000000
+#define IOMOON_T0_MAXCOUNT 0x6276  /* 25206, T0CMPA = T0CMPB from the boot table */
+#define IOMOON_TIMER0_HZ   ((IOMOON_CPU_CLOCK / 4.0) / (double)IOMOON_T0_MAXCOUNT) /* 99.18 */
+
+/* INT0 (vector 0x0C) rate.  NOT CONFIRMED, and the one genuinely open number in the model
+ * -- findings F3 lists the INT0 source as its unresolved gap: neither ROM says which line
+ * feeds INT0, and the three candidates imply very different rates (IC23's per-plane pulse
+ * ~290 Hz, its per-frame pulse ~145 Hz, or the Z80's port-0x81 bit-3 toggle, which is not
+ * even free-running).  F3 recommends the per-plane pulse at ~290 Hz, because the handler's
+ * two alternating bodies are exactly blit-then-composite -- one interrupt per DMD plane --
+ * and because it is the only candidate whose implied outbound J1 byte rate (INT0/8, see
+ * qout_service_pcs1) carries 64 lamps and 13 drivers at a playable rate.
+ *
+ * That recommendation cannot stand as a rate, and the firmware's own handler is what
+ * refutes it.  The composite branch sub_F08A5 is two 512-iteration byte loops of 7-9
+ * instructions each -- about 65 000 clocks, 6.5 ms at 10 MHz -- and the blit branch
+ * sub_F08EB is a 512-iteration loop plus the animation dispatch.  Measured over a headless
+ * boot the handler averages 7.5 ms, so a 290 Hz (3.45 ms) or even a 145 Hz (6.9 ms) period
+ * cannot contain it.  Nothing about that is an emulation artefact: the same instruction
+ * count on a real 80186 gives the same milliseconds, and the 80188's 8-bit bus makes it
+ * slower still.  And because INT0 outranks the timer on the interrupt controller, a
+ * permanently-pending INT0 does not merely run late, it starves timer 0 completely -- at
+ * 290 Hz the driver measures timer 0 at 0 interrupts per second and the firmware never
+ * leaves its frame-delay loop at D5611, which is a hang, not a slow machine.
+ *
+ * So this ships at the rate the firmware can actually sustain: 72.5 Hz, the 145 Hz DMD
+ * wire rate divided by the two bitplanes -- which is also the INT0 rate the Bike Race
+ * machine in this same driver uses.  There the handler is serviced in full, timer 0 runs
+ * at 92 of its 99.18 Hz, the CPU spends 55% of its time in ISRs, and the firmware boots
+ * through its intro to the J1 wait.  DMD refresh, FM tempo and the outbound queue rate all
+ * scale with this number, which is why it is one named constant: an IC23 dump, a scope on
+ * the line, or the frame-clock work is what would settle it */
+#define IOMOON_INT0_HZ 72.5
+
+/* One periodic generator drives both sources, and it has to tick a good deal faster than
+ * their sum: a request that comes due while the firmware is inside an ISR can only be
+ * handed over on a later tick (see the note on the accumulators below), so the tick period
+ * is also the delay between an ISR returning and the next interrupt being delivered.
+ * 2 kHz = 0.5 ms of granularity against ISRs measured in milliseconds */
+#define IOMOON_IRQ_TICK_HZ 2000.0
+
+/* Fractional tick accumulators, and one held request per source.  The request has to be
+ * held because of how this i86 core delivers interrupts: it takes a vectored interrupt at
+ * the instant the line is asserted -- inside cpu_set_irq_line_and_vector -- and only if IF
+ * is set right then; it never re-examines the line afterwards, so HOLD_LINE does not
+ * actually hold anything and a request raised while an ISR is running would just vanish.
+ * That is not what the 80188's interrupt controller does: it latches the request and
+ * serves it when the firmware re-enables interrupts.  Measured on Io Moon the difference
+ * is not cosmetic -- the INT0 handler's DMD work is long enough that raising the two
+ * sources blind loses about two thirds of the timer-0 ticks, which would stretch every
+ * firmware timeout by the same factor.  So: integrate time every tick, latch at most one
+ * request per source (as the hardware does -- a second one arriving before the first is
+ * served is lost, not queued), and hand it over on the first tick where IF is set */
+static double iomoon_int0_acc, iomoon_t0_acc; //!!
+static int    iomoon_int0_pend, iomoon_t0_pend; //!!
+
+static INTERRUPT_GEN(iomoon_irq_gen) {
+  iomoon_int0_acc += IOMOON_INT0_HZ   / IOMOON_IRQ_TICK_HZ;
+  iomoon_t0_acc   += IOMOON_TIMER0_HZ / IOMOON_IRQ_TICK_HZ;
+  if (iomoon_int0_acc >= 1.0) { iomoon_int0_acc -= 1.0; iomoon_int0_pend = 1; }
+  if (iomoon_t0_acc   >= 1.0) { iomoon_t0_acc   -= 1.0; iomoon_t0_pend   = 1; }
+
+  /* IF clear = the firmware is inside an ISR: keep both requests latched and try again */
+  if (!(activecpu_get_reg(I86_FLAGS) & 0x200)) return;
+
+  /* Only one vector can be delivered at a time, so when both are pending INT0 goes first:
+   * it is the higher-priority source on the real controller (level 0 against the timer's
+   * 1), and the timer takes the next tick */
+  if (iomoon_int0_pend) {
+    iomoon_int0_pend = 0;
+    cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x0c); /* INT0    -> D000:0343 */
+  }
+  else if (iomoon_t0_pend) {
+    iomoon_t0_pend = 0;
+    cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x08); /* timer 0 -> D000:024F */
+  }
 }
 
 /* Bike Race (SLEIC3): Timer0 (type 0x08) = 99.18 Hz (T0CON/T0CMP); INT0
@@ -741,11 +868,10 @@ static WRITE_HANDLER(sleic2_periph_w) {
       if ((data ^ iomoon_pcs0) & 0x07) iomoon_set_gfx_bank(data);
       iomoon_pcs0 = data;
       return;
-    default:
+    default:                          /* PCS1 J1 outbound, PCS2, PCS3, PCS4, PCS5 YM3812, PCS6 OKI */
 #ifdef DEBUG_SLEIC
       if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
 #endif
-      logerror("iomoon periph A000:%03X = %02x\n", offset, data);
       return;
   }
 }
@@ -760,7 +886,10 @@ static READ_HANDLER(sleic2_periph_r) {
 
 static MEMORY_READ_START(SLEIC2_80188_readmem)
   {0x00000,0x3ffff, MRA_ROM},         /* LMCS: ROM1 low half -- resident IVT + animation data */
-  {0x40000,0x4ffff, MRA_RAM},         /* MCS0: work RAM (UM62256 IC12)                        */
+  {0x40000,0x4ffff, MRA_RAM},         /* MCS0: work RAM.  The chip-select block is 64 KB; the
+                                       * UM62256 at IC12 behind it is 32 KB, so this window is
+                                       * a superset -- harmless, because the firmware's highest
+                                       * work-RAM segment is 413C (flat 0x41496, F5)           */
   {IOMOON_NVRAM_BASE,IOMOON_NVRAM_BASE+IOMOON_NVRAM_SIZE-1, iomoon_nvram_r}, /* MCS1: seg 5040 store */
   {0x60000,0x6ffff, MRA_BANK1},       /* MCS2: graphics ROM page (IOMOON_GFX_BANK, PCS0 bits 0-2) */
   {0x70000,0x7ffff, MRA_RAM},         /* MCS3: DMD staging (7000:0000-03FF)                   */
@@ -1129,6 +1258,8 @@ static MACHINE_INIT(SLEIC2) {
   machine_init_SLEIC();
   iomoon_pcs0 = 0x28;
   iomoon_set_gfx_bank(iomoon_pcs0);
+  iomoon_int0_acc = iomoon_t0_acc = 0.0;
+  iomoon_int0_pend = iomoon_t0_pend = 0;
 }
 
 /* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch
@@ -1264,7 +1395,8 @@ MACHINE_DRIVER_START(SLEIC1)
   // read==write to one buffer so the firmware's boot-time self-repair sticks and
   // the signature re-validation passes (clears "Memoria EEPROM en mal estado").
   // REPLACE wipes the inherited mcpu map/ports/IRQ, so all are re-stated; only the
-  // 80188 memory map changes vs. the base SLEIC (SLEIC2/iomoon keep the base map)
+  // 80188 memory map changes vs. the base SLEIC (Bike Race and Io Moon each state
+  // their own map in the SLEIC3 / SLEIC2 blocks below)
   MDRV_NVRAM_HANDLER(SLEIC1)
   MDRV_CPU_REPLACE("mcpu", I188, 8000000)
   MDRV_CPU_MEMORY(SLEIC1_80188_readmem, SLEIC1_80188_writemem)
@@ -1292,18 +1424,37 @@ MACHINE_DRIVER_START(SLEIC2)
   MDRV_IMPORT_FROM(SLEIC)
   MDRV_CORE_INIT_RESET_STOP(SLEIC2,NULL,NULL)
 
-  // Io Moon 80188 map: LMCS ROM at 0, UMCS ROM at 0xC0000, the four MMCS blocks
-  // (work RAM / non-volatile store / banked graphics page / DMD staging) and the
-  // PACS peripheral block.  See the SLEIC2_80188_readmem comment block for the
-  // chip-select values this hard-wires and where they come from
-  MDRV_CPU_MODIFY("mcpu")
+  // Io Moon main CPU: the 80C188 at IC1 is an N80C188-10, and CLKOUT = 10 MHz is what
+  // the timer-0 rate below is computed from, so the emulated clock matches it rather
+  // than the base driver's 8 MHz.  REPLACE only re-states type and clock; the map is
+  // set separately: LMCS ROM at 0, UMCS ROM at 0xC0000, the four MMCS blocks (work RAM /
+  // non-volatile store / banked graphics page / DMD staging) and the PACS peripheral
+  // block -- see the SLEIC2_80188_readmem comment block for the chip-select values this
+  // hard-wires and where they come from.
+  //
+  // Interrupts: iomoon_irq_gen replaces the base driver's vector-less 120 Hz IRQ0 pulse
+  // (which, having no vector, took an IVT filler entry and derailed the boot) with the
+  // real model of findings F1/F3 -- timer 0 on vector 0x08 at 99.18 Hz and INT0 on
+  // vector 0x0C at IOMOON_INT0_HZ, both interleaved on one tick.  The NMI is not
+  // periodic and is not generated here; see the comment block above iomoon_irq_gen
+  MDRV_CPU_REPLACE("mcpu", I188, IOMOON_CPU_CLOCK)
   MDRV_CPU_MEMORY(SLEIC2_80188_readmem, SLEIC2_80188_writemem)
+  MDRV_CPU_PERIODIC_INT(iomoon_irq_gen, IOMOON_IRQ_TICK_HZ)
 
   // Non-volatile store at segment 5040 (F10), persisted by NVRAM_HANDLER(SLEIC2) and
   // zero-filled on a fresh boot, which is what makes the firmware seed its own factory
   // defaults.  Replaces the base driver's generic_0fill, whose generic_nvram buffer
   // this map does not reference
   MDRV_NVRAM_HANDLER(SLEIC2)
+
+  // I/O Z80 periodic IRQ, ~977 Hz.  The rate is not derived from the Z80's own clock: it
+  // is the 8 MHz board crystal divided by 8192 in the IC20/IC21 (74LS393) + IC22 (74LS27)
+  // chain on the 16-bit board, delivered to the Z80 board over J3, so it is stated as
+  // 8000000/8192 to keep that derivation visible.  (Both ROMs are silent on it -- the
+  // source is external to each -- so this is the board inventory's reading, not the
+  // disassembly's.)  It replaces the inherited 2500000/2048 Bike Race / Sleic Pin-Ball rate
+  MDRV_CPU_MODIFY("icpu")
+  MDRV_CPU_PERIODIC_INT(SLEIC_irq_z80, 8000000/8192.)
 
   MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
   MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1905,25 +1905,50 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
 static SWITCH_UPDATE(SLEIC2) {
   unsigned i;
   if (inports) {
+    const UINT16 in = inports[CORE_COREINPORT];
     /* Cabinet inputs -> swMatrix[9] = Z80 port 0x03, one bit per input.  The bit -> CODE
-     * map is exact (F5/F14, see iomoon_z80_read); the bit -> BUTTON map below is what a
-     * driver has to choose without the wiring diagram, and each choice has a reason:
-     *   bit 1 -> TEST, because its code 0x3F is the one that opens the service menu (F14)
-     *   bit 0 -> COIN, because sub_125B arms a 3000-tick lockout before sending 0x3E
-     *   bit 4 -> START, because the 80188 dispatches its code 0x40 immediately next to
-     *            the menu key (D7ADA -> sub_D8066)
+     * map is exact (F5/F14, see iomoon_z80_read).  The bit -> BUTTON map is no longer a
+     * choice for four of the six: the 80188 firmware says outright what it does with each
+     * code, and for COIN and TILT it says the OPPOSITE of what this driver assumed until
+     * now.  What each code reaches, traced from the code that consumes it:
+     *
+     *   bit 5 -> COIN.  Its code 0x32 is the ONE code the NMI does not queue: D000:0190
+     *            tests for it and counts it in [4000:1144] instead.  sub_D800A D800A then
+     *            folds that count into the pulse accumulator 413C:00D5 and hands it to the
+     *            per-country pricing routine (sub_DCD9E / sub_DD03D, chosen on the country
+     *            byte [4000:1001]), which divides the pulses by the coin values at
+     *            413C:00AD/00AE/00AF, multiplies by the credit values at 413C:00A9/00AA/
+     *            00AB and calls sub_DCFAB / sub_DD1C1 to bank the result.  That is a
+     *            single-line coin validator emitting a pulse train per coin, and it is the
+     *            only path in the ROM that adds credits from a switch.  The award itself
+     *            is nvstore_write_triple_83 (F10) with the running total cached in
+     *            413C:00D4, and sub_D0B70(0x0A) is the coin sound on the partial.
+     *   bit 0 -> TILT ("falta").  Its code 0x3E dispatches through the in-game table at
+     *            CS:0527 (entry 48) to sub_D9EBB, which counts down the warning counter
+     *            [4134:0033] -- loaded at every ball start from NVRAM byte 0x42 minus one
+     *            (DBE17, DBF7F), i.e. the FALTA adjustment -- and on the last one stops the
+     *            music (fm_song_select(0)), clears both sprite and background planes,
+     *            plays sound 0x0E and pushes the driver-disable command 0xF2.  The Z80's
+     *            own 3000-tick lockout in sub_125B is the tilt debounce, not a coin
+     *            lockout.  Bike Race puts its tilt on the same port-0x03 bit 0.
+     *   bit 1 -> TEST, because its code 0x3F is the one that opens the service menu (F14).
+     *   bit 4 -> START, because code 0x40 reaches sub_D8066, which is the start handler:
+     *            it refuses in attract, refuses at 4 players, refuses on zero credits,
+     *            then decrements the NVRAM credit triple and, on the first player, calls
+     *            sub_D8154 -> mode 3 -> the in-game song.
      *   bits 3/2 -> left/right flipper: those two handlers (sub_1292 / sub_12D8) fire the
-     *            port-0x85 coil pairs directly, and Sleic Pin-Ball's verified map puts the
-     *            left flipper on the first pair.  INFERRED
-     *   bit 5 -> TILT: its 0x32 auto-repeats while held and the 80188 COUNTS it in
-     *            [4000:1144] instead of queueing it (F4), which is how a plumb bob
-     *            behaves and how Bike Race numbers its tilt.  INFERRED */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 9,  0x01, 9); /* COIN  0x0200 -> bit0 (code 0x3E) */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 10, 0x02, 9); /* TEST  0x0800 -> bit1 (code 0x3F) */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] << 1,  0x04, 9); /* R-flip 0x0002 -> bit2            */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] << 3,  0x08, 9); /* L-flip 0x0001 -> bit3            */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 4,  0x10, 9); /* START 0x0100 -> bit4 (code 0x40) */
-    CORE_SETKEYSW(inports[CORE_COREINPORT] >> 5,  0x20, 9); /* TILT  0x0400 -> bit5 (code 0x32) */
+     *            port-0x85 coil pairs directly (sub_05C7 / sub_05ED), and Sleic Pin-Ball's
+     *            verified map puts the left flipper on the first pair.  Which of the two
+     *            is left is still INFERRED; that they are the flipper buttons is not.
+     *            Their codes 0x41/0x42 are also the service menu's scroll and select
+     *            (sub_DD480's dispatch at DD501), which is what a flipper button does in
+     *            every pinball service menu. */
+    CORE_SETKEYSW(in >> 10, 0x01, 9); /* TILT   0x0400 -> bit0 (code 0x3E) */
+    CORE_SETKEYSW(in >> 10, 0x02, 9); /* TEST   0x0800 -> bit1 (code 0x3F) */
+    CORE_SETKEYSW(in << 1,  0x04, 9); /* R-flip 0x0002 -> bit2 (code 0x42) */
+    CORE_SETKEYSW(in << 3,  0x08, 9); /* L-flip 0x0001 -> bit3 (code 0x41) */
+    CORE_SETKEYSW(in >> 4,  0x10, 9); /* START  0x0100 -> bit4 (code 0x40) */
+    CORE_SETKEYSW(in >> 4,  0x20, 9); /* COIN   0x0200 -> bit5 (code 0x32) */
   }
   for (i = 0; i < sizeof(iomoon_pf_keys)/sizeof(iomoon_pf_keys[0]); i++) {
     if (keyboard_pressed(iomoon_pf_keys[i].key))

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1105,6 +1105,12 @@ static struct {
   UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
 } iomoon_j1; //!!
 
+/* The ball trough (defined with the model further down): the 80188 -> Z80 strobe hands
+ * every command byte here, and 0xE9 is the one that moves a ball; the reset is the
+ * machine init's */
+static void iomoon_ball_command(UINT8 cmd);
+static void iomoon_ball_reset(void);
+
 /*-------------------------------------------------------------------------------------
 /  Io Moon (SLEIC2) OKI MSM6376 speech and effects -- finding F9.
 /
@@ -1226,6 +1232,7 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * YM3812 channel by a wiper position the schematic has not been read for */
       if ((data & 0x20) && !(iomoon_j1.pcs4 & 0x20)) {
         iomoon_j1.toZ80Full = 1;
+        iomoon_ball_command(iomoon_j1.toZ80);         /* the ball trough, 0xE9 = serve */
         cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE); /* Z80 handler 0x0066 */
       }
       iomoon_j1.pcs4 = data;
@@ -1909,6 +1916,9 @@ static MACHINE_INIT(SLEIC2) {
    * send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
    * that routine spins on the bit before it does anything else */
   memset(&iomoon_j1, 0, sizeof iomoon_j1);
+  /* The ball trough starts EMPTY here and is filled by the first SWITCH_UPDATE, because
+   * the ball complement comes from an input port and the ports are not readable yet */
+  iomoon_ball_reset();
 }
 
 /*-------------------------------------------------------------------------------------
@@ -1945,10 +1955,210 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
   {KEYCODE_T,6,0x01},{KEYCODE_8_PAD,6,0x02},{KEYCODE_9_PAD,6,0x04},{KEYCODE_MINUS_PAD,6,0x08}, /* col5 0x34-0x37 */
 };
 
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) ball trough.
+/
+/  This is the one piece of playfield state the driver has to keep, because the firmware
+/  BLOCKS on it.  Four of the 48 matrix contacts are ball-handling contacts rather than
+/  playfield events, and both CPUs stop dead until they read right:
+/
+/    swMatrix[1] bits 0-2   the three trough contacts, codes 0x0A-0x0C
+/    swMatrix[1] bit 3      the ball-exit contact, code 0x0D
+/
+/  That these four are ball handling and not playfield is the ROM's statement, not an
+/  inference from the manual: the in-game switch dispatcher sub_D7636 subtracts 0x0E
+/  before its 55-entry table (D7652: SUB AX,0000E / CMP BX,00036), so codes 0x0A-0x0D
+/  reach no playfield handler at all and exist only for the four commands below.  The
+/  service manual's matrix list agreeing -- its first four entries are "contacto salida
+/  bolas 1/2/3" and "bola fuera" -- is corroboration for the group, not for which contact
+/  is which; the ROM settles that on its own further down.
+/
+/  The four commands, Z80 handlers out of the 256-entry table at $2000:
+/
+/    0xEA -> 2A45  count the trough.  Counts the CLOSED contacts among C0DB bits 0-2 and
+/                  adds bit 3, then answers 0x48 (none) 0x38 (1) 0x39 (2) 0x3A (3).  The
+/                  80188 stores that in [413C:00F9] through the reply table at CS:04EE4
+/                  (sub_DC10D DC144-DC17D).
+/    0xEB -> 2AB0  the same count on column 4 for the second ball device -> [413C:00F8].
+/    0xE9 -> 2B03  SERVE.  If C0DB bit 3 is already closed it answers 0x45 at once;
+/                  otherwise it reports driver state 0 busy (sub_08A7) and polls column 0
+/                  until bit 3 closes, five tries of 0x3E8 ticks each, then gives up with
+/                  0x4A.  So the machine expects the trough kicker to put a ball ON the
+/                  ball-exit contact.
+/    0xEF -> 2BC7  BALLS HOME.  A closed loop -- test the trough (sub_2C1F), run the
+/                  ball-search coil sequence (sub_2CFB), wait, repeat -- whose ONLY exit
+/                  is sub_2C1F returning 0, i.e. three adjacent trough contacts closed
+/                  (2C2B: AND 007 / 2C35: AND 00E, either one all-zero).  It answers 0x45
+/                  and returns only then.
+/
+/  and the ball-start path that drives them, sub_DC4C9:
+/
+/    DC4D0: CALL sub_DC410            ; 0xEA, count the trough -> [00F9]
+/    DC4D4: CALL sub_DC2FC            ; 0xEB, count device 2   -> [00F8]
+/    DC4DC: CMP ES:000F9,0 / JE DC4FE ; nothing in the trough -> ball search
+/    DC4F9: CMP DX,3 / JNL DC522      ; [00F9]+[00F8] >= 3 -> skip the search
+/    DC4FE: PUSH 0EF / CALL qout_push
+/    DC507: CALL sub_DC075 / OR AX,AX / JE DC507   ; wait for 0x45 -- NO TIMEOUT
+/    DC514: MOV ES:000F9, 003         ; after a search the trough IS the three balls
+/    DC522: CALL sub_DC47E            ; 0xE9, serve one ball
+/    DC52B: DEC [00F9]
+/
+/  With no ball modelled at all the trough answers 0x48, DC4DC takes the search branch,
+/  and the two CPUs deadlock: the 80188 spins at DC507 for a reply the Z80 will never
+/  send, and the Z80 never leaves 2BC7, so main_loop 0D4C stops running and with it
+/  input_port03_read_tick 2E62 and the whole switch scan.  That is why cabinet buttons
+/  and flippers die the moment a game starts, and it is why this model exists.
+/
+/  THE DRAIN.  The first trough contact is also the ball-over sensor, and that is what
+/  fixes which end of the trough is which.  Its per-bit routine is not like the other
+/  47: instead of sending its own code it sends 0x43, and only while the game has armed
+/  it --
+/
+/    316D: LD A,#$0A / LD (C0FC),A / JP sub_161E
+/    161E: LD A,(C068) / AND A / JP NZ,1642   ; test mode: send 0x0A like any contact
+/    1625: LD A,(C054) / AND A / RET Z        ; not armed -> report NOTHING
+/    162A: LD A,(C04B) / AND A / RET NZ       ; 200-tick lockout still running
+/    162F: C049 = 0x00C8 / C04B = 0xFF        ; re-arm the lockout
+/    163A: LD A,#$43 / LD (C0FC),A / JP host_send_c0fc
+/
+/  C054 is armed by 80188 command 0xF3 (Z80 2A3A) and disarmed by 0xF4 (2A40), and
+/  sub_DC74B pushes 0xF3 immediately after serving the ball (DC779).  On the 80188 side
+/  0x43 is not an ordinary event: BOTH in-game tables send it to sub_D92C0, the ball-over
+/  routine -- the dispatch table at CS:0527 (sub_D7636, entry for 0x43 -> D7666) and the
+/  ball-in-play wait table at CS:07AE (sub_D7A12, 0x43 -> D7A3E), where every other
+/  playfield code merely returns 1.  Note also that 161E's normal-play path never calls
+/  sub_3394, so unlike contacts 1-3 (sub_164A / sub_165A / sub_166A, which set the
+/  reported mask C0E8 and go quiet) this contact re-reports for as long as it is closed.
+/
+/  So contact 0 is the trough ENTRY: a ball only rests on it when it is home, and a ball
+/  arriving there is the drain.  Balls therefore fill the trough from contact 2 down, and
+/  the contact a served ball vacates is contact 0.
+/
+/  What is modelled, and why each transition is here:
+/
+/    at rest            three balls on the trough contacts.  The complement comes from the
+/                       "Balls" setting of the standard simulator input port, which the
+/                       game already carries; the firmware's own number is 3 (DC514 and
+/                       DC14D both store 3).  Setting it to 0 turns the whole model off,
+/                       which is the escape hatch for a frontend that wants to own these
+/                       contacts itself.
+/    serve              on command 0xE9 reaching the Z80, after a short mechanical delay,
+/                       one ball leaves the trough and closes the ball-exit contact.  That
+/                       is what 2B03 is waiting for and it is what makes it answer 0x45.
+/    launch             the ball rolls off the exit contact into play.  "Shoot Ball" does
+/                       it at once; otherwise it happens on its own after a delay, because
+/                       the firmware demands it: with bit 3 held closed the ball-start path
+/                       runs again every ~4 s (measured) instead of settling into play.
+/                       WHICH of the two the real cabinet does -- a plunger the player
+/                       pulls or a coil that launches by itself -- is not in either ROM,
+/                       so both are offered and neither is claimed.
+/    drain              the ball in play returns to the trough and closes contact 0, which
+/                       is what the firmware reads as ball-over (above).  This is the ONE
+/                       thing a ball does not do by itself, so it is an input: "Drain ball
+/                       in play" on the cabinet port (sleic.h).  The driver does not
+/                       announce the ball over -- it puts the ball back in the trough and
+/                       lets the Z80's own 161E send the 0x43.
+/
+/  Nothing here writes firmware memory; it only presents contacts, and every contact it
+/  presents is one the real machine has.
+/-----------------------------------------------------------------------------------*/
+#define IOMOON_TROUGH_COL   1     /* swMatrix index of Z80 switch column 0              */
+#define IOMOON_TROUGH_BITS  0x07  /* bits 0-2, codes 0x0A-0x0C                          */
+#define IOMOON_EXIT_BIT     0x08  /* bit 3, code 0x0D                                   */
+#define IOMOON_TROUGH_MAX   3     /* three contacts, so three balls can rest on them     */
+
+/* Frame counts at the 60 Hz VBLANK this runs on.  Both are the mechanical time a ball
+ * takes, not a firmware requirement, so both are generous against the firmware's own
+ * windows: the serve has 0x3E8 Z80 ticks ~ 1.0 s per try before 2B03 gives up, and the
+ * ball-start path re-runs about every 4 s if the exit contact never clears */
+#define IOMOON_KICK_FRAMES    8   /* kicker fires -> ball on the exit contact  (~0.13 s) */
+#define IOMOON_LAUNCH_FRAMES 90   /* ball sits at the exit -> into play        (~1.5 s)  */
+
+static struct {
+  int inTrough;   /* balls resting on the trough contacts                              */
+  int atExit;     /* a ball on the ball-exit contact                                    */
+  int inPlay;     /* balls on the playfield                                             */
+  int kick;       /* frames left before the served ball reaches the exit contact        */
+  int dwell;      /* frames the ball has been sitting on the exit contact               */
+  int drainHeld;  /* previous state of the drain input, so one press = one ball         */
+  int seeded;     /* the complement has been taken from the input port                  */
+} iomoon_balls;
+
+/* Called from MACHINE_INIT.  The complement is not known here -- the input ports are not
+ * readable this early -- so the first SWITCH_UPDATE fills the trough */
+static void iomoon_ball_reset(void) {
+  memset(&iomoon_balls, 0, sizeof iomoon_balls);
+}
+
+/* Called from the 80188 -> Z80 strobe with the command byte, i.e. exactly when the Z80's
+ * NMI takes it.  0xE9 is the only command that moves a ball; 0xEF cannot be served by
+ * moving one, since its exit condition is the trough being FULL and the balls it is
+ * looking for are the ones already in play */
+static void iomoon_ball_command(UINT8 cmd) {
+  if (cmd == 0xe9 && iomoon_balls.seeded && !iomoon_balls.atExit && !iomoon_balls.kick
+      && iomoon_balls.inTrough > 0)
+    iomoon_balls.kick = IOMOON_KICK_FRAMES;
+}
+
+/* Called once a frame from SWITCH_UPDATE(SLEIC2) AFTER the playfield key loop, and it ORs
+ * its contacts in rather than assigning them: a key held on one of those four positions is
+ * a contact stuck closed, which is exactly what the service menu's contact test wants to
+ * see, and the model has no business overriding it.
+ *
+ * shoot = the simulator port's "Shoot Ball", drain = the cabinet port's "Drain ball in
+ * play", balls = its "Balls" setting (0 = model off) */
+static void iomoon_ball_update(int balls, int shoot, int drain) {
+  UINT8 bits;
+  if (balls <= 0) { iomoon_balls.seeded = 0; return; }   /* frontend owns the trough */
+  if (!iomoon_balls.seeded) {
+    iomoon_balls.seeded   = 1;
+    iomoon_balls.inTrough = balls > IOMOON_TROUGH_MAX ? IOMOON_TROUGH_MAX : balls;
+  }
+
+  if (iomoon_balls.kick && --iomoon_balls.kick == 0 && iomoon_balls.inTrough > 0) {
+    iomoon_balls.inTrough--;          /* the kicker has thrown it clear of the trough */
+    iomoon_balls.atExit = 1;
+    iomoon_balls.dwell  = 0;
+  }
+  if (iomoon_balls.atExit) {
+    iomoon_balls.dwell++;
+    if (shoot || iomoon_balls.dwell >= IOMOON_LAUNCH_FRAMES) {
+      iomoon_balls.atExit = 0;
+      iomoon_balls.inPlay++;
+    }
+  }
+  /* One press, one ball: the drain is an event, not a level */
+  if (drain && !iomoon_balls.drainHeld && iomoon_balls.inPlay > 0) {
+    iomoon_balls.inPlay--;
+    if (iomoon_balls.inTrough < IOMOON_TROUGH_MAX) iomoon_balls.inTrough++;
+  }
+  iomoon_balls.drainHeld = drain ? 1 : 0;
+
+  /* Balls stack AWAY from the entry, so contact 0 is the last to fill and the first to
+   * empty: n balls close the TOP n of the three contacts.  That order is not a choice --
+   * the Z80's per-bit routine for contact 0 is the one that reports a drained ball
+   * (sub_161E, see above), so contact 0 has to be the one a returning ball closes and
+   * therefore the one that is open while a ball is out on the playfield.  Filling from
+   * the other end instead reports a drain the instant the game arms the monitor, and the
+   * ball ends about a second after it starts -- measured, before this was understood. */
+  bits = (UINT8)(((1u << iomoon_balls.inTrough) - 1u)
+                 << (IOMOON_TROUGH_MAX - iomoon_balls.inTrough)) & IOMOON_TROUGH_BITS;
+  if (iomoon_balls.atExit) bits |= IOMOON_EXIT_BIT;
+  coreGlobals.swMatrix[IOMOON_TROUGH_COL] |= bits;
+}
+
 static SWITCH_UPDATE(SLEIC2) {
   unsigned i;
+  int balls = IOMOON_TROUGH_MAX, shoot = 0, drain = 0;
   if (inports) {
     const UINT16 in = inports[CORE_COREINPORT];
+    /* The ball trough's three inputs, acted on after the key loop below.  "Balls" and
+     * "Shoot Ball" are the standard simulator port the game already carries (sim.h,
+     * SLEIC2_INPUT_PORTS_START); "Drain ball in play" is Io Moon's own cabinet bit
+     * 0x1000 (sleic.h), which is how a run gets through a whole ball */
+    balls = SIM_BALLS(inports[CORE_SIMINPORT]);
+    shoot = (inports[CORE_SIMINPORT] & SIM_SHOOTERKEY) ? 1 : 0;
+    drain = (in & 0x1000) ? 1 : 0;
     /* Cabinet inputs -> swMatrix[9] = Z80 port 0x03, one bit per input.  The bit -> CODE
      * map is exact (F5/F14, see iomoon_z80_read).  The bit -> BUTTON map is no longer a
      * choice for four of the six: the 80188 firmware says outright what it does with each
@@ -1999,6 +2209,9 @@ static SWITCH_UPDATE(SLEIC2) {
     else
       coreGlobals.swMatrix[iomoon_pf_keys[i].col] &= ~iomoon_pf_keys[i].bit;
   }
+  /* After the key loop, because it ORs its four contacts in on top: a key held on one of
+   * them is a contact stuck closed and the model must not override it */
+  iomoon_ball_update(balls, shoot, drain);
 }
 
 /* Bike Race (SLEIC3) playfield-matrix test keys. The 40 matrix positions (Z80 switch

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -208,6 +208,24 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * this constant, which is why it stays one named number */
 #define IOMOON_INT0_HZ 72.5
 
+/* I/O Z80 clock.  This is the INHERITED Bike Race / Sleic Pin-Ball figure, not an Io Moon
+ * reading, and it is named here only so that it stops being invisible: the SLEIC2 block
+ * used to reach the Z80 through MDRV_CPU_MODIFY, which leaves the base MDRV_CPU_ADD_TAG's
+ * 2.5 MHz standing while the comment beside it talks about an 8 MHz crystal.
+ *
+ * The likely correction is 4 MHz, and the argument is short: IC1 on the I/O board is a
+ * Goldstar Z8400A, i.e. a Z80A, whose speed GRADE is 4 MHz -- so the board inventory's
+ * "8 MHz" cannot be the CPU clock.  It is X10, the board crystal, and halving it is the
+ * ordinary arrangement; the same crystal divided by 8192 gives the ~977 Hz Z80 IRQ this
+ * driver already states.  Neither ROM says anything about either figure.
+ *
+ * It is deliberately NOT changed yet.  Everything measured for the J1 link -- the switch
+ * scan cadence, the handshake spins, the byte rates -- was measured at 2.5 MHz, and a 1.6x
+ * change to the I/O board's speed re-times all of it at once.  Revisit it against the real
+ * machine (or a scope on X10) as its own step, with the switch-delivery probe re-run
+ * either side of the change; that is an owner checkpoint, not a silent edit */
+#define IOMOON_Z80_CLOCK 2500000
+
 /* One periodic generator drives both sources, and it has to tick a good deal faster than
  * their sum: a request that comes due while the firmware is inside an ISR can only be
  * handed over on a later tick (see the note on the accumulators below), so the tick period
@@ -909,9 +927,16 @@ static void iomoon_set_gfx_bank(UINT8 pcs0) {
 /  the latch as a one-byte mailbox with flow control on port-0x01 bit 1: free while empty,
 /  busy from the strobe until the NMI reads 0xA0100.  That is what stops the Z80
 /  overrunning a latch the 80188 has not emptied yet -- and dropped switch bytes are
-/  exactly the failure this task exists to prevent.  It cannot deadlock: the NMI is
-/  non-maskable, the Z80's spin runs with interrupts enabled, and the send routines take
-/  the bus only after the spin.
+/  exactly the failure this task exists to prevent.
+/
+/  It cannot deadlock, and NOT because of anything on the Z80 side: host_send_c0fc is
+/  reached from the IRQ handler as well, so its spin can run with IFF1 = 0 and no Z80
+/  interrupt will break it.  What clears the latch is the other CPU, on two mechanisms
+/  that hold regardless: (a) the 80188 NMI is non-maskable, so the handler that reads
+/  0xA0100 always runs; and (b) cpu_set_irq_line called from Z80 context queues the
+/  request for CPU 0 and schedules it with timer_set(TIME_NOW), which calls
+/  activecpu_abort_timeslice (src/timer.c) -- so the 80188 is given the CPU almost
+/  immediately, long before the Z80 has spun for any meaningful time.
 /
 /  80188 -> Z80.  qout_service_pcs1 D01E5, called from the INT0 ISR, writes the byte to
 /  PCS1 0xA0080 and then pulses PCS4 0xA0200 bit 6 and bit 5, releasing both after 13
@@ -1374,7 +1399,17 @@ MEMORY_END
  *              0x45 or 0x46 and moves on.
  *
  * The low nibble is also reported to the 80188 verbatim as 0xF0|nibble by handler 2D9D,
- * i.e. it is a configuration nibble; nothing in either ROM says what the bits mean */
+ * i.e. it is a configuration nibble; nothing in either ROM says what the bits mean.
+ *
+ * Two structural notes, because the read is "IDLE & ~swMatrix[10]" and an AND can only
+ * ever CLEAR bits:
+ *   - swMatrix[10] cannot RAISE bit 5.  Modelling the trough therefore means changing
+ *     this CONSTANT to 0xFF, not mapping a switch -- and that is the change to make once
+ *     the trough contacts are identified (F5's open gap), since bit 5 = 1 is what puts
+ *     the 0xED handler on its real "wait for the balls" path.
+ *   - anything mapped into swMatrix[10] bit 7 would pull that bit low and hang
+ *     selftest_wait_reset 2E42.  Nothing writes row 10 today; keep it that way unless
+ *     the bit is understood. */
 #define IOMOON_PORT04_IDLE 0xdf
 
 static READ_HANDLER(iomoon_z80_read) {
@@ -1411,6 +1446,13 @@ static WRITE_HANDLER(iomoon_z80_write) {
                 * unproven -- none of those four need an action here */
       { const UINT8 rise = (UINT8)(data & ~iomoon_j1.ctrl);
         if (rise & 0x24) {
+          /* A strobe arriving on a latch the NMI has not read yet would overwrite an
+           * undelivered byte -- a lost switch code, silently.  Port-0x01 bit 1 is what
+           * stops the firmware getting here, so this is unreachable as the ROM stands;
+           * it is a tripwire for any future change to the port-0x81 handling */
+          if (iomoon_j1.latchFull)
+            logerror("iomoon J1: strobe %02x over undelivered byte %02x\n",
+                     iomoon_j1.to188, iomoon_j1.latch);
           iomoon_j1.latch = iomoon_j1.to188;
           iomoon_j1.latchFull = 1;
           cpu_set_irq_line(SLEIC_MAIN_CPU, IRQ_LINE_NMI, PULSE_LINE); /* handler D000:016D */
@@ -1717,9 +1759,10 @@ MACHINE_DRIVER_START(SLEIC2)
   MDRV_CORE_INIT_RESET_STOP(SLEIC2,NULL,NULL)
 
   // Io Moon switch input: the 6x8 matrix on swMatrix[1..6] (Z80 port-0x82 column strobe,
-  // port 0x02 return), the six cabinet inputs on swMatrix[9] (port 0x03) and the port-0x04
-  // config byte on swMatrix[10].  Replaces the base handler, which only fills swMatrix[0]
-  // -- a row nothing on this machine reads
+  // port 0x02 return) and the six cabinet inputs on swMatrix[9] (port 0x03).  Row 10 backs
+  // the port-0x04 config byte but nothing is mapped into it -- see IOMOON_PORT04_IDLE for
+  // why, and for what has to change instead.  Replaces the base handler, which only fills
+  // swMatrix[0] -- a row nothing on this machine reads
   MDRV_SWITCH_UPDATE(SLEIC2)
 
   // Io Moon main CPU: the 80C188 at IC1 is an N80C188-10, and CLKOUT = 10 MHz is what
@@ -1757,7 +1800,14 @@ MACHINE_DRIVER_START(SLEIC2)
   // matrix.  The base map's z80_read_port returns 0 for port 0x04, whose bit 7 the Z80
   // spins on in selftest_wait_reset, and 0 for port 0x01, whose bit 1 every J1 send waits
   // for -- either alone hangs the I/O board before it can announce itself
-  MDRV_CPU_MODIFY("icpu")
+  //
+  // REPLACE rather than MODIFY, purely so the CLOCK is stated.  In this tree REPLACE sets
+  // the CPU type and clock and nothing else (driver.h), so the map, ports and IRQ are
+  // unaffected -- but MODIFY left the Z80 running on the base block's 2.5 MHz Bike Race
+  // figure, silently, three lines under a comment about an 8 MHz crystal.  The value is
+  // unchanged; IOMOON_Z80_CLOCK is where it now lives, with why 4 MHz is the likely
+  // correction and why it is not being made in the same breath
+  MDRV_CPU_REPLACE("icpu", Z80, IOMOON_Z80_CLOCK)
   MDRV_CPU_PERIODIC_INT(SLEIC_irq_z80, 8000000/8192.)
   MDRV_CPU_PORTS(SLEIC2_Z80_readport, SLEIC2_Z80_writeport)
 

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -67,6 +67,47 @@ static struct {
   /* YM3812 A0 line: 0 = register/index port, 1 = data port.  SLEIC1 drives it
    * from PCS0 bit 1, Bike Race toggles it per write (these use different peripheral write handlers, so serves both) */
   UINT8  ymA0;
+
+  /* ---- Io Moon (SLEIC2) only, from here down ---------------------------------------
+   * Io Moon runs its own interrupt generator, peripheral handlers and Z80 port map, so
+   * none of the members above serve it; these are its equivalents.  They are in locals
+   * for the same reason as everything else here: MACHINE_INIT's memset is what zeroes
+   * them at every machine start, and MACHINE_INIT(SLEIC2) then states only the values
+   * that are NOT zero (see it for the 0x28 PCS0 shadow and the trough/coin resets) */
+
+  /* Interrupt-rate accumulators and the one-deep pending latch per source, see iomoon_irq_gen */
+  double iomInt0Acc, iomT0Acc;
+  int    iomInt0Pend, iomT0Pend;
+  double iomPanelAcc;  /* the free-running IC23 panel raster rides the same tick */
+
+  UINT8  iomPcs0;      /* PCS0 (0xA0000) output shadow; also selects the graphics page */
+  UINT8  iomOkiLatch;  /* PCS6 (0xA0300): bit 7 = CH2, bits 0-6 = phrase number        */
+
+  /* J1 byte port, both directions; see the block comment above iomoon_z80_write */
+  struct {
+    UINT8 to188;     /* Z80 port 0x80: the byte on the J1 data lines                     */
+    UINT8 latch;     /* PCS2 0xA0100: what the port-0x81 strobe captured for the 80188   */
+    UINT8 latchFull; /* set from the strobe until the NMI reads 0xA0100 (port-01 bit 1)  */
+    UINT8 ctrl;      /* Z80 port 0x81 shadow, for the bit-2 / bit-5 strobe edges         */
+    UINT8 toZ80;     /* PCS1 0xA0080: the byte the 80188 sent                            */
+    UINT8 toZ80Full; /* set until the Z80 takes it (PCS3 0xA0180 bit 0 = receiver ready) */
+    UINT8 pcs4;      /* PCS4 0xA0200 shadow, for the outbound bit-5 strobe edge          */
+    UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
+  } iomJ1;
+
+  /* Opt-in ball trough model, see the block comment above iomoon_ball_reset */
+  struct {
+    int inTrough;   /* balls resting on the trough contacts                              */
+    int atExit;     /* a ball on the ball-exit contact                                    */
+    int inPlay;     /* balls on the playfield                                             */
+    int kick;       /* frames left before the served ball reaches the exit contact        */
+    int dwell;      /* frames the ball has been sitting on the exit contact               */
+    int drainHeld;  /* previous state of the drain input, so one press = one ball         */
+    int seeded;     /* the model is ON and the complement has been taken from the port    */
+  } iomBalls;
+
+  /* Coin mechanism pulse train, see the block comment above iomoon_coin_reset */
+  struct { int pending, phase; UINT16 lastKeys; } iomCoin;
 } locals;
 
 #ifdef DEBUG_SLEIC
@@ -341,27 +382,25 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * sources blind loses about two thirds of the timer-0 ticks, which would stretch every
  * firmware timeout by the same factor.  So: integrate time every tick, latch at most one
  * request per source (as the hardware does -- a second one arriving before the first is
- * served is lost, not queued), and hand it over on the first tick where IF is set */
-static double iomoon_int0_acc, iomoon_t0_acc; //!!
-static int    iomoon_int0_pend, iomoon_t0_pend; //!!
+ * served is lost, not queued), and hand it over on the first tick where IF is set
+ * -> locals.iomInt0Acc / locals.iomT0Acc and locals.iomInt0Pend / locals.iomT0Pend */
 
 /* The panel raster rides on the same tick (F13): IC23 free-runs and sends the 80188 no
  * frame signal at all, so the DMD is sampled on a clock of its own rather than on
- * anything the firmware does.  Defined with the Io Moon DMD block further down */
-static double iomoon_panel_acc; //!!
+ * anything the firmware does -> locals.iomPanelAcc */
 static void iomoon_submit_dmd_frame(void);
 
 static INTERRUPT_GEN(iomoon_irq_gen) {
   /* The panel raster is not an interrupt source and is serviced first: IC23 scans segment
    * 7000 whatever the 80188 is doing, so the display stays live regardless of what the
    * interrupt model below does */
-  iomoon_panel_acc += IOMOON_PANEL_HZ / IOMOON_IRQ_TICK_HZ;
-  if (iomoon_panel_acc >= 1.0) { iomoon_panel_acc -= 1.0; iomoon_submit_dmd_frame(); }
+  locals.iomPanelAcc += IOMOON_PANEL_HZ / IOMOON_IRQ_TICK_HZ;
+  if (locals.iomPanelAcc >= 1.0) { locals.iomPanelAcc -= 1.0; iomoon_submit_dmd_frame(); }
 
-  iomoon_int0_acc += IOMOON_INT0_HZ   / IOMOON_IRQ_TICK_HZ;
-  iomoon_t0_acc   += IOMOON_TIMER0_HZ / IOMOON_IRQ_TICK_HZ;
-  if (iomoon_int0_acc >= 1.0) { iomoon_int0_acc -= 1.0; iomoon_int0_pend = 1; }
-  if (iomoon_t0_acc   >= 1.0) { iomoon_t0_acc   -= 1.0; iomoon_t0_pend   = 1; }
+  locals.iomInt0Acc += IOMOON_INT0_HZ   / IOMOON_IRQ_TICK_HZ;
+  locals.iomT0Acc   += IOMOON_TIMER0_HZ / IOMOON_IRQ_TICK_HZ;
+  if (locals.iomInt0Acc >= 1.0) { locals.iomInt0Acc -= 1.0; locals.iomInt0Pend = 1; }
+  if (locals.iomT0Acc   >= 1.0) { locals.iomT0Acc   -= 1.0; locals.iomT0Pend   = 1; }
 
   /* IF clear = the firmware is inside an ISR: keep both requests latched and try again */
   if (!(activecpu_get_reg(I86_FLAGS) & 0x200)) return;
@@ -369,12 +408,12 @@ static INTERRUPT_GEN(iomoon_irq_gen) {
   /* Only one vector can be delivered at a time, so when both are pending INT0 goes first:
    * it is the higher-priority source on the real controller (level 0 against the timer's
    * 1), and the timer takes the next tick */
-  if (iomoon_int0_pend) {
-    iomoon_int0_pend = 0;
+  if (locals.iomInt0Pend) {
+    locals.iomInt0Pend = 0;
     cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x0c); /* INT0    -> D000:0343 */
   }
-  else if (iomoon_t0_pend) {
-    iomoon_t0_pend = 0;
+  else if (locals.iomT0Pend) {
+    locals.iomT0Pend = 0;
     cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x08); /* timer 0 -> D000:024F */
   }
 }
@@ -1019,7 +1058,11 @@ MEMORY_END
  * sub_D622C writes the factory defaults, and core_nvram persists them from then on */
 #define IOMOON_NVRAM_BASE 0x50400
 #define IOMOON_NVRAM_SIZE 0x2000
-static UINT8 iomoon_nvram[IOMOON_NVRAM_SIZE]; //!!
+/* Not part of locals, same as sleic1_nvram and sleic3_nvram: NVRAM_HANDLER(SLEIC2) below
+ * fills this from the .nv file (or zero-fills it) at every machine start, and it must
+ * survive locals' memset -- mame.c loads NVRAM before cpu_run(), and MACHINE_INIT runs
+ * from inside it */
+static UINT8 iomoon_nvram[IOMOON_NVRAM_SIZE];
 static READ_HANDLER(iomoon_nvram_r)  { return iomoon_nvram[offset]; }
 static WRITE_HANDLER(iomoon_nvram_w) { iomoon_nvram[offset] = data; }
 static NVRAM_HANDLER(SLEIC2) {
@@ -1041,8 +1084,8 @@ static const UINT32 iomoon_gfx_page_base[8] = {
   0x00000, 0x10000, 0x20000, 0x30000, 0x40000, 0x50000, 0x60000,
   0x70000  /* page 7: blank in V1 3_02.bin and never selected */
 };
-static UINT8 iomoon_pcs0; /* PCS0 (0xA0000) output shadow; boot leaves it at 0x28 */ //!!
-
+/* The PCS0 (0xA0000) output shadow that selects the page above is locals.iomPcs0;
+ * boot leaves it at 0x28 (see MACHINE_INIT(SLEIC2)) */
 static void iomoon_set_gfx_bank(UINT8 pcs0) {
   cpu_setbank(IOMOON_GFX_BANK, memory_region(SLEIC_MEMREG_GFX) + iomoon_gfx_page_base[pcs0 & 0x07]);
 }
@@ -1102,17 +1145,9 @@ static void iomoon_set_gfx_bank(UINT8 pcs0) {
 /  qout_service_pcs1.  WHICH J1 line each PCS4 bit actually drives is F6's own open
 /  clause (it needs the IC7/IC8 PALs); what the firmware pair needs, and what this
 /  models, is one Z80 NMI per outbound byte, after the byte is latched.
+/
+/  The latches and shadows it needs are locals.iomJ1, declared with the locals struct.
 /-----------------------------------------------------------------------------------*/
-static struct {
-  UINT8 to188;     /* Z80 port 0x80: the byte on the J1 data lines                     */
-  UINT8 latch;     /* PCS2 0xA0100: what the port-0x81 strobe captured for the 80188   */
-  UINT8 latchFull; /* set from the strobe until the NMI reads 0xA0100 (port-01 bit 1)  */
-  UINT8 ctrl;      /* Z80 port 0x81 shadow, for the bit-2 / bit-5 strobe edges         */
-  UINT8 toZ80;     /* PCS1 0xA0080: the byte the 80188 sent                            */
-  UINT8 toZ80Full; /* set until the Z80 takes it (PCS3 0xA0180 bit 0 = receiver ready) */
-  UINT8 pcs4;      /* PCS4 0xA0200 shadow, for the outbound bit-5 strobe edge          */
-  UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
-} iomoon_j1; //!!
 
 /* The ball trough (defined with the model further down): the 80188 -> Z80 strobe hands
  * every command byte here, and 0xE9 is the one that moves a ball; the reset is the
@@ -1179,13 +1214,14 @@ static void iomoon_coin_reset(void);
 /  voices mix to the same output at the same volume and the firmware never reads the chip
 /  back, so swapping them changes nothing audible -- only which voice number a phrase
 /  occupies -- and no dump is needed to settle something with no observable difference.
+/
+/  The PCS6 0xA0300 latch itself (bit 7 = CH2, bits 0-6 = phrase number) is
+/  locals.iomOkiLatch.
 /-----------------------------------------------------------------------------------*/
-static UINT8 iomoon_oki_latch; /* PCS6 0xA0300: bit 7 = CH2, bits 0-6 = phrase number */ //!!
-
 static void iomoon_oki_strobe(void) {
-  const UINT8 phrase = iomoon_oki_latch & 0x7f;
+  const UINT8 phrase = locals.iomOkiLatch & 0x7f;
   /* CH2 -> the core's voice bit: bit 4 = voice 0, bit 5 = voice 1 (adpcm.c, data >> 4) */
-  const UINT8 voice  = (iomoon_oki_latch & 0x80) ? 1 : 0;
+  const UINT8 voice  = (locals.iomOkiLatch & 0x80) ? 1 : 0;
 
   /* The test is on the PHRASE, not on the whole latch, and the two are the same test here:
    * the only latch value with phrase 0 that sub_D0CB8 can leave is 0x00 itself, because the
@@ -1210,14 +1246,14 @@ static void iomoon_oki_strobe(void) {
 static WRITE_HANDLER(sleic2_periph_w) {
   switch (offset) {
     case 0x000: /* PCS0: bits 0-2 graphics page (F2), 3/4 NVRAM window gate (F10), 5 = OKI /OKCS (F9) */
-      if ((data ^ iomoon_pcs0) & 0x07) iomoon_set_gfx_bank(data);
+      if ((data ^ locals.iomPcs0) & 0x07) iomoon_set_gfx_bank(data);
       /* bit 5 = the OKI's ST input, idle high (F9).  Only the three OKI routines ever move
        * it -- okcs_strobe D0CE2, pcs0_bit5_clear D0CFC and pcs0_bit5_set_far D0D09 -- while
        * the page select F00A0 and the NVRAM gate D0596/D05B7 write the same shadow byte
        * with bit 5 untouched, so an edge here is always an OKI event and never a side
        * effect of the other two fields sharing this register */
-      if ((iomoon_pcs0 & 0x20) && !(data & 0x20)) iomoon_oki_strobe();
-      iomoon_pcs0 = data;
+      if ((locals.iomPcs0 & 0x20) && !(data & 0x20)) iomoon_oki_strobe();
+      locals.iomPcs0 = data;
       return;
     case 0x080: /* PCS1: the byte on the outbound J1 data lines (qout_service_pcs1 D020F).
                  * Writing it does NOT start a transfer -- the PCS4 bit-5 strobe below
@@ -1225,7 +1261,7 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * writes 0x00 here long before any queue exists, and treating that as a
                  * byte in flight would leave "receiver ready" clear for ever and stall
                  * the whole outbound direction */
-      iomoon_j1.toZ80 = data;
+      locals.iomJ1.toZ80 = data;
       return;
     case 0x200: /* PCS4: J1 handshake lines.  Bit 5 is pulsed by qout_service_pcs1 alone
                  * (D022A/D0243) -- the inbound NMI handler asserts bits 7/6/4 but never
@@ -1242,12 +1278,12 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * bar and stores the setting in NVRAM 0x1BC-0x1BE (sub_D098C) -- it just
                  * does not change what comes out, and modelling it would mean scaling the
                  * YM3812 channel by a wiper position the schematic has not been read for */
-      if ((data & 0x20) && !(iomoon_j1.pcs4 & 0x20)) {
-        iomoon_j1.toZ80Full = 1;
-        iomoon_ball_command(iomoon_j1.toZ80);         /* the ball trough, 0xE9 = serve */
+      if ((data & 0x20) && !(locals.iomJ1.pcs4 & 0x20)) {
+        locals.iomJ1.toZ80Full = 1;
+        iomoon_ball_command(locals.iomJ1.toZ80);         /* the ball trough, 0xE9 = serve */
         cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE); /* Z80 handler 0x0066 */
       }
-      iomoon_j1.pcs4 = data;
+      locals.iomJ1.pcs4 = data;
       return;
     case 0x280: /* PCS5 with A0 = 0: the YM3812's register/index port (F8).
                  *
@@ -1257,7 +1293,7 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * it this way and both were checked before this was written: Bike Race
                  * streams every byte at 0xA0280 and toggles A0 in hardware (sleic_periph_w
                  * alternates), and Sleic Pin-Ball streams every byte at 0xA0280 with A0
-                 * carried on PCS0 bit 1 (sleic1_ym_a0).  Three machines, three conventions;
+                 * carried on PCS0 bit 1 (locals.ymA0).  Three machines, three conventions;
                  * this one is the only one the Io Moon ROM supports, and F8 confirms these
                  * are the only two accesses to either address in the whole ROM */
       YM3812_control_port_0_w(0, data);
@@ -1271,7 +1307,7 @@ static WRITE_HANDLER(sleic2_periph_w) {
     case 0x300: /* PCS6: the OKI MSM6376's data/CH2 latch (F9).  Latching alone starts
                  * nothing -- the PCS0 bit-5 pulse above does -- which is why the boot's
                  * 0x80 (D00C6) and trigger_b's trailing rewrite (D0CAE) are silent here */
-      iomoon_oki_latch = data;
+      locals.iomOkiLatch = data;
       return;
     default:                          /* PCS2, PCS3 */
 #ifdef DEBUG_SLEIC
@@ -1291,12 +1327,12 @@ static READ_HANDLER(sleic2_periph_r) {
                  * handler D018C (F4).  The read is what frees the port for the Z80's
                  * next byte, so clear the busy flag and leave the latch itself standing
                  * -- a hardware latch holds its last value */
-      iomoon_j1.latchFull = 0;
-      return iomoon_j1.latch;
+      locals.iomJ1.latchFull = 0;
+      return locals.iomJ1.latch;
     case 0x180: /* PCS3 bit 0: "receiver ready".  qout_service_pcs1 tests it (D0206) and
                  * gives up for this call when it is clear, so it must report that the Z80
                  * has taken the previous byte */
-      return iomoon_j1.toZ80Full ? 0x00 : 0x01;
+      return locals.iomJ1.toZ80Full ? 0x00 : 0x01;
     case 0x280: /* PCS5: the YM3812 status port, which reads back on the same address as the
                  * index port (A0 = 0) exactly as on any OPL2.
                  *
@@ -1458,7 +1494,7 @@ static WRITE_HANDLER(z80_write_port) {
 
 /* Z80 I/O processor state shadow, shared by the SLEIC1 / SLEIC2 / SLEIC3 port handlers
  * (all three I/O ROMs drive the same latch conventions; Io Moon uses lampRow and keeps
- * its own J1 and switch-column state in iomoon_j1) */
+ * its own J1 and switch-column state in locals.iomJ1) */
 static struct {
   UINT8 swStrobe; /* port 0x82: switch matrix column strobe (0..5 after decode) */
   UINT8 lampCol;  /* lamp matrix column (after decode) */
@@ -1743,14 +1779,14 @@ static READ_HANDLER(iomoon_z80_read) {
   switch (offset) {
     case 0x00: /* J1 inbound data.  Reading is what frees the outbound latch, which is
                 * what PCS3 0xA0180 bit 0 reports back to qout_service_pcs1 */
-      iomoon_j1.toZ80Full = 0;
-      return iomoon_j1.toZ80;
+      locals.iomJ1.toZ80Full = 0;
+      return locals.iomJ1.toZ80;
     case 0x01: /* bit 1 = J1 free (clear while the 80188 has not read the latch yet),
                 * bit 5 = direct input, 1 = open.  The scan that reads bit 5 is gated off
                 * by IOMOON_PORT04_IDLE bit 0 anyway */
-      return (UINT8)((iomoon_j1.latchFull ? 0x00 : 0x02) | 0x20);
+      return (UINT8)((locals.iomJ1.latchFull ? 0x00 : 0x02) | 0x20);
     case 0x02: /* switch matrix: 6 columns -> swMatrix[1..6], active low */
-      return (UINT8)~coreGlobals.swMatrix[1 + iomoon_j1.swCol];
+      return (UINT8)~coreGlobals.swMatrix[1 + locals.iomJ1.swCol];
     case 0x03: /* cabinet inputs -> swMatrix[9], active low */
       return (UINT8)~coreGlobals.swMatrix[9];
     case 0x04: /* cabinet/config byte; swMatrix[10] pulls a bit low when closed */
@@ -1764,32 +1800,32 @@ static READ_HANDLER(iomoon_z80_read) {
 static WRITE_HANDLER(iomoon_z80_write) {
   switch (offset) {
     case 0x00: /* port 0x80: the byte onto the J1 data lines (written before the strobe) */
-      iomoon_j1.to188 = data;
+      locals.iomJ1.to188 = data;
       break;
     case 0x01: /* port 0x81: J1 control.  Bit 2 (event codes) and bit 5 (the C008 state
                 * bitmask) are the two outbound strobes and reach the same latch (F6);
                 * bit 1 is data-valid, bits 4/6 gate the two inbound read paths, bit 3 is
                 * the free-running-ish toggle F3 lists as an INT0 candidate and bit 0 is
                 * unproven -- none of those four need an action here */
-      { const UINT8 rise = (UINT8)(data & ~iomoon_j1.ctrl);
+      { const UINT8 rise = (UINT8)(data & ~locals.iomJ1.ctrl);
         if (rise & 0x24) {
           /* A strobe arriving on a latch the NMI has not read yet would overwrite an
            * undelivered byte -- a lost switch code, silently.  Port-0x01 bit 1 is what
            * stops the firmware getting here, so this is unreachable as the ROM stands;
            * it is a tripwire for any future change to the port-0x81 handling */
-          if (iomoon_j1.latchFull)
+          if (locals.iomJ1.latchFull)
             logerror("iomoon J1: strobe %02x over undelivered byte %02x\n",
-                     iomoon_j1.to188, iomoon_j1.latch);
-          iomoon_j1.latch = iomoon_j1.to188;
-          iomoon_j1.latchFull = 1;
+                     locals.iomJ1.to188, locals.iomJ1.latch);
+          locals.iomJ1.latch = locals.iomJ1.to188;
+          locals.iomJ1.latchFull = 1;
           cpu_set_irq_line(SLEIC_MAIN_CPU, IRQ_LINE_NMI, PULSE_LINE); /* handler D000:016D */
         }
       }
-      iomoon_j1.ctrl = data;
+      locals.iomJ1.ctrl = data;
       break;
     case 0x02: /* port 0x82: switch-matrix column strobe, one-hot 0x01..0x20 = column 0..5 */
       if (data) { const unsigned col = core_BitColToNum(data & -data);
-                  if (col < 6) iomoon_j1.swCol = (UINT8)col; }
+                  if (col < 6) locals.iomJ1.swCol = (UINT8)col; }
       break;
     case 0x03: /* port 0x83: lamp-matrix COLUMN strobe, one-hot 0x01..0x80 = column 0..7.
                 * lamp_colN_out (Z80 3457..34C7, one column per lamp_scan_tick, so the whole
@@ -1886,15 +1922,18 @@ static MACHINE_INIT(SLEIC1) {
  * (bit 3 = NVRAM window closed, bit 5 = OKI /OKCS idle high, page bits clear) */
 static MACHINE_INIT(SLEIC2) {
   machine_init_SLEIC();
-  iomoon_pcs0 = 0x28;
-  iomoon_set_gfx_bank(iomoon_pcs0);
-  /* The OKI latch starts empty rather than at the 0x80 boot_init writes: 0x28 above already
-   * has ST released, so nothing can be triggered before the firmware's own D00C6 write
-   * arrives, and phrase 0 would be a stop in any case */
-  iomoon_oki_latch = 0;
-  iomoon_int0_acc = iomoon_t0_acc = 0.0;
-  iomoon_int0_pend = iomoon_t0_pend = 0;
-  iomoon_panel_acc = 0.0;
+  /* Everything Io Moon keeps in locals has just been zeroed by machine_init_SLEIC's
+   * memset, so only the values that are NOT zero are stated here.  Three that the zero
+   * IS the answer for, because they are easy to mistake for oversights:
+   *   the OKI latch starts empty rather than at the 0x80 boot_init writes -- 0x28 below
+   *     already has ST released, so nothing can be triggered before the firmware's own
+   *     D00C6 write arrives, and phrase 0 would be a stop in any case;
+   *   the interrupt accumulators and their pending latches start at rest;
+   *   the J1 latches start empty, so port-0x01 bit 1 reads free for the Z80's very first
+   *     send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
+   *     that routine spins on the bit before it does anything else */
+  locals.iomPcs0 = 0x28;
+  iomoon_set_gfx_bank(locals.iomPcs0);
 
   /* Panel weighting, from the IC23 dump (asm/pic16c57_annotated.asm) rather than by
    * analogy with the I8039 games: the raster's per-row hold delay is 200 counts for the
@@ -1920,10 +1959,6 @@ static MACHINE_INIT(SLEIC2) {
    *     frames every downstream consumer of a 4-shade DMD reads.  Revisit if the core
    *     ever grows a weighted 2-plane combiner */
   locals.dmdEqualFields = 0;
-  /* J1 idle: both latches empty, so port-0x01 bit 1 reads free for the Z80's very first
-   * send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
-   * that routine spins on the bit before it does anything else */
-  memset(&iomoon_j1, 0, sizeof iomoon_j1);
   /* The ball trough starts EMPTY, and at the default "Balls" = 0 it stays that way: the
    * model is opt-in and the frontend owns those contacts.  It is filled by the first
    * SWITCH_UPDATE only if the operator has asked for it, because the complement comes
@@ -2118,22 +2153,14 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
 #define IOMOON_KICK_FRAMES    8   /* kicker fires -> ball on the exit contact  (~0.13 s) */
 #define IOMOON_LAUNCH_FRAMES 90   /* ball sits at the exit -> into play        (~1.5 s)  */
 
-static struct {
-  int inTrough;   /* balls resting on the trough contacts                              */
-  int atExit;     /* a ball on the ball-exit contact                                    */
-  int inPlay;     /* balls on the playfield                                             */
-  int kick;       /* frames left before the served ball reaches the exit contact        */
-  int dwell;      /* frames the ball has been sitting on the exit contact               */
-  int drainHeld;  /* previous state of the drain input, so one press = one ball         */
-  int seeded;     /* the model is ON and the complement has been taken from the port    */
-} iomoon_balls;
+/* The model's own state is locals.iomBalls, declared with the locals struct */
 
 /* Called from MACHINE_INIT.  Also the whole of the model-off path: zero here means the
  * model owns no contact and no ball, and nothing it presents can survive being switched
  * off.  "seeded" doubles as the on/off flag -- it is set only by iomoon_ball_update with
  * "Balls" > 0, and cleared again the moment that setting goes back to 0 */
 static void iomoon_ball_reset(void) {
-  memset(&iomoon_balls, 0, sizeof iomoon_balls);
+  memset(&locals.iomBalls, 0, sizeof locals.iomBalls);
 }
 
 /* Called from the 80188 -> Z80 strobe with the command byte, i.e. exactly when the Z80's
@@ -2145,9 +2172,9 @@ static void iomoon_ball_reset(void) {
  * "Balls" = 0 the serve command is simply not acted on, and whatever closes the trough
  * contacts -- a table script, or the matrix test keys -- answers it instead */
 static void iomoon_ball_command(UINT8 cmd) {
-  if (cmd == 0xe9 && iomoon_balls.seeded && !iomoon_balls.atExit && !iomoon_balls.kick
-      && iomoon_balls.inTrough > 0)
-    iomoon_balls.kick = IOMOON_KICK_FRAMES;
+  if (cmd == 0xe9 && locals.iomBalls.seeded && !locals.iomBalls.atExit && !locals.iomBalls.kick
+      && locals.iomBalls.inTrough > 0)
+    locals.iomBalls.kick = IOMOON_KICK_FRAMES;
 }
 
 /* Called once a frame from SWITCH_UPDATE(SLEIC2) AFTER the playfield key loop, and it ORs
@@ -2172,29 +2199,29 @@ static void iomoon_ball_update(int balls, int shoot, int drain) {
    * with no give-up path -- which is what a real cabinet missing a ball does, but a UI
    * setting should not brick the emulation.  Clamp up; 0 above is the deliberate way off */
   if (balls < IOMOON_TROUGH_MAX) balls = IOMOON_TROUGH_MAX;
-  if (!iomoon_balls.seeded) {
-    iomoon_balls.seeded   = 1;
-    iomoon_balls.inTrough = balls > IOMOON_TROUGH_MAX ? IOMOON_TROUGH_MAX : balls;
+  if (!locals.iomBalls.seeded) {
+    locals.iomBalls.seeded   = 1;
+    locals.iomBalls.inTrough = balls > IOMOON_TROUGH_MAX ? IOMOON_TROUGH_MAX : balls;
   }
 
-  if (iomoon_balls.kick && --iomoon_balls.kick == 0 && iomoon_balls.inTrough > 0) {
-    iomoon_balls.inTrough--;          /* the kicker has thrown it clear of the trough */
-    iomoon_balls.atExit = 1;
-    iomoon_balls.dwell  = 0;
+  if (locals.iomBalls.kick && --locals.iomBalls.kick == 0 && locals.iomBalls.inTrough > 0) {
+    locals.iomBalls.inTrough--;          /* the kicker has thrown it clear of the trough */
+    locals.iomBalls.atExit = 1;
+    locals.iomBalls.dwell  = 0;
   }
-  if (iomoon_balls.atExit) {
-    iomoon_balls.dwell++;
-    if (shoot || iomoon_balls.dwell >= IOMOON_LAUNCH_FRAMES) {
-      iomoon_balls.atExit = 0;
-      iomoon_balls.inPlay++;
+  if (locals.iomBalls.atExit) {
+    locals.iomBalls.dwell++;
+    if (shoot || locals.iomBalls.dwell >= IOMOON_LAUNCH_FRAMES) {
+      locals.iomBalls.atExit = 0;
+      locals.iomBalls.inPlay++;
     }
   }
   /* One press, one ball: the drain is an event, not a level */
-  if (drain && !iomoon_balls.drainHeld && iomoon_balls.inPlay > 0) {
-    iomoon_balls.inPlay--;
-    if (iomoon_balls.inTrough < IOMOON_TROUGH_MAX) iomoon_balls.inTrough++;
+  if (drain && !locals.iomBalls.drainHeld && locals.iomBalls.inPlay > 0) {
+    locals.iomBalls.inPlay--;
+    if (locals.iomBalls.inTrough < IOMOON_TROUGH_MAX) locals.iomBalls.inTrough++;
   }
-  iomoon_balls.drainHeld = drain ? 1 : 0;
+  locals.iomBalls.drainHeld = drain ? 1 : 0;
 
   /* Balls stack AWAY from the entry, so contact 0 is the last to fill and the first to
    * empty: n balls close the TOP n of the three contacts.  That order is not a choice --
@@ -2203,9 +2230,9 @@ static void iomoon_ball_update(int balls, int shoot, int drain) {
    * therefore the one that is open while a ball is out on the playfield.  Filling from
    * the other end instead reports a drain the instant the game arms the monitor, and the
    * ball ends about a second after it starts -- measured, before this was understood. */
-  bits = (UINT8)(((1u << iomoon_balls.inTrough) - 1u)
-                 << (IOMOON_TROUGH_MAX - iomoon_balls.inTrough)) & IOMOON_TROUGH_BITS;
-  if (iomoon_balls.atExit) bits |= IOMOON_EXIT_BIT;
+  bits = (UINT8)(((1u << locals.iomBalls.inTrough) - 1u)
+                 << (IOMOON_TROUGH_MAX - locals.iomBalls.inTrough)) & IOMOON_TROUGH_BITS;
+  if (locals.iomBalls.atExit) bits |= IOMOON_EXIT_BIT;
   coreGlobals.swMatrix[IOMOON_TROUGH_COL] |= bits;
 }
 
@@ -2278,9 +2305,9 @@ static void iomoon_ball_update(int balls, int shoot, int drain) {
 #define IOMOON_COIN_GAP    3       /* frames it is open again before the next pulse      */
 #define IOMOON_CAB_COIN    0x0200  /* the COIN bit of the cabinet inport (sleic.h)       */
 
-static struct { int pending, phase; UINT16 lastKeys; } iomoon_coin; //!!
+/* The train's own state is locals.iomCoin, declared with the locals struct */
 
-static void iomoon_coin_reset(void) { memset(&iomoon_coin, 0, sizeof iomoon_coin); }
+static void iomoon_coin_reset(void) { memset(&locals.iomCoin, 0, sizeof locals.iomCoin); }
 
 /* Pulses the mechanism emits for the coin the player just put in.  Only the smallest
  * denomination has a key (see SLEIC2_CABPORT in sleic.h): the firmware prices the running
@@ -2298,14 +2325,14 @@ static int iomoon_coin_pulses(void) {
  * again mid-burst adds a second coin, exactly like feeding the mechanism does) */
 static int iomoon_coin_update(UINT16 keys) {
   int closed;
-  if ((keys & IOMOON_CAB_COIN) && !(iomoon_coin.lastKeys & IOMOON_CAB_COIN))
-    iomoon_coin.pending += iomoon_coin_pulses();
-  iomoon_coin.lastKeys = keys;
-  if (iomoon_coin.pending <= 0) { iomoon_coin.phase = 0; return 0; }
-  closed = (iomoon_coin.phase < IOMOON_COIN_HOLD);
-  if (++iomoon_coin.phase >= IOMOON_COIN_HOLD + IOMOON_COIN_GAP) {
-    iomoon_coin.phase = 0;
-    iomoon_coin.pending--;
+  if ((keys & IOMOON_CAB_COIN) && !(locals.iomCoin.lastKeys & IOMOON_CAB_COIN))
+    locals.iomCoin.pending += iomoon_coin_pulses();
+  locals.iomCoin.lastKeys = keys;
+  if (locals.iomCoin.pending <= 0) { locals.iomCoin.phase = 0; return 0; }
+  closed = (locals.iomCoin.phase < IOMOON_COIN_HOLD);
+  if (++locals.iomCoin.phase >= IOMOON_COIN_HOLD + IOMOON_COIN_GAP) {
+    locals.iomCoin.phase = 0;
+    locals.iomCoin.pending--;
   }
   return closed;
 }

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1658,7 +1658,11 @@ MEMORY_END
  *              of F5's open gap, so the honest model is "not fitted" rather than a
  *              guessed wiring.  Turning it on is a one-bit change once that is known.
  *   bit 5 = 0  makes the command-0xED handler 2BEB answer 0x45 at once (IN ($04) / BIT 5 /
- *              JP Z,2C17).  With bit 5 SET the handler instead loops -- strobe column 0,
+ *              JP Z,2C17).  The service manual's SW40 list (section 7.2.2.3) has exactly
+ *              this function on SW5, "servicio: no se dispensan bolas" / no balls
+ *              dispensed, which is documentary confirmation of what the branch is for
+ *              even though the manual gives no bit numbers.
+ *              With bit 5 SET the handler instead loops -- strobe column 0,
  *              check the trough contacts, run the eject coil sequence sub_2CFB, repeat --
  *              and its ONLY exit is those contacts closing.  That is correct hardware
  *              behaviour (a machine waiting for its balls), but it never returns to the
@@ -1667,8 +1671,9 @@ MEMORY_END
  *              honestly hold.  The 80188 side is happy either way: F14's prompt takes
  *              0x45 or 0x46 and moves on.
  *
- * The low nibble is also reported to the 80188 verbatim as 0xF0|nibble by handler 2D9D,
- * i.e. it is a configuration nibble; nothing in either ROM says what the bits mean.
+ * Bits 1-3 have since been taken OUT of this constant: they are the SW40 country switches
+ * and the firmware acts on them, so they come from the DIP bank instead -- see
+ * iomoon_port04() below.  What remains here is bits 0, 4, 5, 6 and 7.
  *
  * Two structural notes, because the read is "IDLE & ~swMatrix[10]" and an AND can only
  * ever CLEAR bits:
@@ -1680,6 +1685,31 @@ MEMORY_END
  *     selftest_wait_reset 2E42.  Nothing writes row 10 today; keep it that way unless
  *     the bit is understood. */
 #define IOMOON_PORT04_IDLE 0xdf
+
+/* Bits 1-3 of port 0x04 are the SW40 country switches SW2-SW4, and they are NOT an idle
+ * constant -- the firmware reads them and acts on them, so they are a DIP the user sets
+ * (sleic.h, DIP bank 0).  The path is a full J1 round trip on every boot: sub_D5A8B
+ * D5A8B pushes Z80 command 0xF9, handler 2D9D answers IN($04) | 0xF0, and the 80188's
+ * reader turns bits 1-3 of that byte into a country number with
+ *
+ *     D5CA3: CMP [0006], 0F0 / JNB          ; a 0xF0-or-above byte is the DIP report
+ *     D5CAC: AND AL, 00E / SUB AX, 2        ; country = (port04 >> 1) & 7
+ *     D5CC2: JMP CS:W[BX + 02DE1]           ; seven-way table at D5D01 -> [4130:0020]
+ *
+ * and then acts on it twice: sub_D69CC applies that country's coin-value preset (one of
+ * eight, D6D36/D6DDF/.../D7204) and saves it to NVRAM 0x1C4-0x1CF, and boot_init compares
+ * the DIP-derived country with the stored NVRAM 0x1BF at D664D -- if they differ the DIP
+ * wins, the NVRAM is rewritten and the preset re-applied.  Country 5 additionally selects
+ * the Spanish string and menu tables (D3277, D8048, DD406); every other value is English.
+ * So this one DIP sets both the coinage and the language, exactly as the service manual's
+ * "country code" row implies.
+ *
+ * The other five bits stay in IOMOON_PORT04_IDLE.  Bit 5 in particular must stay 0 for
+ * the reason above -- the manual's SW5 "servicio: no se dispensan bolas" is the same
+ * behaviour the 0xED handler shows, and with no ball model 0 is the state to hold. */
+static UINT8 iomoon_port04(void) {
+  return (UINT8)((IOMOON_PORT04_IDLE & ~0x0e) | (core_getDip(0) & 0x0e));
+}
 
 static READ_HANDLER(iomoon_z80_read) {
   switch (offset) {
@@ -1696,7 +1726,7 @@ static READ_HANDLER(iomoon_z80_read) {
     case 0x03: /* cabinet inputs -> swMatrix[9], active low */
       return (UINT8)~coreGlobals.swMatrix[9];
     case 0x04: /* cabinet/config byte; swMatrix[10] pulls a bit low when closed */
-      return (UINT8)(IOMOON_PORT04_IDLE & ~coreGlobals.swMatrix[10]);
+      return (UINT8)(iomoon_port04() & ~coreGlobals.swMatrix[10]);
     default:
       logerror("iomoon Z80 read port %02x\n", offset);
   }

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -39,10 +39,9 @@ static struct {
   /* Bike Race (SLEIC3) interrupt-rate accumulators, see sleic3_irq_gen */
   double int0Acc, t0Acc;
 
-  /* DMD: how the two raster fields are weighted, and which submit path is used;
-   * both in MACHINE_INIT (see notes at sleic3_build_dmd_frame and sleic_submit_dmd_frame) */
+  /* DMD: how the two raster fields are weighted; set in MACHINE_INIT
+   * (see the per-machine notes above sleic_build_dmd_frame) */
   int    dmdEqualFields;
-  int    dmdFromPtr;
 
   /* completed-frame latch for the I8039 machines, see SLEIC3_DMD_LATCH_TICKS */
   UINT8  dmdLatch[128 * 32];
@@ -233,6 +232,16 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * 2 kHz = 0.5 ms of granularity against ISRs measured in milliseconds */
 #define IOMOON_IRQ_TICK_HZ 2000.0
 
+/* Panel visible-frame rate -- the third rate on that tick, and the only MEASURED one.
+ * From the Saleae capture of the panel wires (docs/dmd_wire_protocol.md): DOTCLK ~599 kHz
+ * over 128 x 32 dots x 2 bitplanes = 73.1 visible frames/s, and RCLK ~4.7 kHz over the 64
+ * row scans the PIC performs per visible frame (32 rows x 2 planes) = 73.4 -- the same
+ * figure from the other direction.  The capture's own "~145 Hz frame rate" line counts one
+ * BITPLANE scan as a frame; the IC23 listing shows two of those per visible frame.  It is
+ * NOT derived from IOMOON_INT0_HZ and must not be: the panel and the firmware's frame
+ * pipeline are two independent clocks on this machine (F13), which is the whole point */
+#define IOMOON_PANEL_HZ 73.0
+
 /* Fractional tick accumulators, and one held request per source.  The request has to be
  * held because of how this i86 core delivers interrupts.  cpu_set_irq_line_and_vector does
  * not touch the CPU itself: it appends the request to a per-CPU event queue and schedules a
@@ -252,7 +261,19 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
 static double iomoon_int0_acc, iomoon_t0_acc; //!!
 static int    iomoon_int0_pend, iomoon_t0_pend; //!!
 
+/* The panel raster rides on the same tick (F13): IC23 free-runs and sends the 80188 no
+ * frame signal at all, so the DMD is sampled on a clock of its own rather than on
+ * anything the firmware does.  Defined with the Io Moon DMD block further down */
+static double iomoon_panel_acc; //!!
+static void iomoon_submit_dmd_frame(void);
+
 static INTERRUPT_GEN(iomoon_irq_gen) {
+  /* The panel raster is not an interrupt source and is serviced first: IC23 scans segment
+   * 7000 whatever the 80188 is doing, so the display stays live regardless of what the
+   * interrupt model below does */
+  iomoon_panel_acc += IOMOON_PANEL_HZ / IOMOON_IRQ_TICK_HZ;
+  if (iomoon_panel_acc >= 1.0) { iomoon_panel_acc -= 1.0; iomoon_submit_dmd_frame(); }
+
   iomoon_int0_acc += IOMOON_INT0_HZ   / IOMOON_IRQ_TICK_HZ;
   iomoon_t0_acc   += IOMOON_TIMER0_HZ / IOMOON_IRQ_TICK_HZ;
   if (iomoon_int0_acc >= 1.0) { iomoon_int0_acc -= 1.0; iomoon_int0_pend = 1; }
@@ -305,28 +326,43 @@ static INTERRUPT_GEN(sleic3_irq_gen) {
  *     that field 2 does not have at all, so the fields are strongly asymmetric and the
  *     pair really is a weighted 2-bit value.  Keep the 4-level mapping there.
  *
- * Set in MACHINE_INIT (locals.dmdEqualFields); SLEIC1 (Sleic Pin-Ball) overrides it */
+ *   Io Moon (IC23 PIC16C57): a third display program, and the most lopsided of the three
+ *     -- 200 row-hold counts for plane 0 against 30 for plane 1.  4 levels, and see
+ *     MACHINE_INIT(SLEIC2) for what that ratio does and does not settle.
+ *
+ * Set in MACHINE_INIT (locals.dmdEqualFields); SLEIC1 (Sleic Pin-Ball) and SLEIC2 (Io Moon)
+ * each state their own */
+
+/* Decode one 128x32 two-bitplane frame -- 32 rows x 16 bytes per plane, MSB = leftmost
+ * pixel, 1 = lit -- into the brightness grid core_dmd_submit_frame takes.  The two planes
+ * arrive as pointers because the machines stage them differently: the I8039 games
+ * interleave them in the panel buffer at 0x60410 (row stride 0x20, second plane +0x800),
+ * Io Moon writes two flat 512-byte planes at 7000:0000 (row stride 0x10, second plane
+ * +0x200, findings F13).  p0 is the MSB plane on all three -- see the per-machine
+ * weighting note above and the PIC row-hold ratio in MACHINE_INIT(SLEIC2).  No machine
+ * inverts: the firmware ANDs, ORs and copies these bytes and never NOTs or XORs them */
+static void sleic_build_dmd_frame(UINT8 *dst, const UINT8 *p0, const UINT8 *p1, int rowStride) {
+  int ii;
+  for (ii = 0; ii < 32; ii++, p0 += rowStride, p1 += rowStride) {
+    int jj;
+    for (jj = 0; jj < 16; jj++) {
+      const UINT8 f1 = p0[jj]; /* Bike Race / Sleic Pin-Ball: raster field 1 (rows 0x00-0x1F) */
+      const UINT8 f2 = p1[jj]; /*                             raster field 2 (rows 0x20-0x3F) */
+      int kk;
+      for (kk = 7; kk >= 0; kk--) {
+        const int a = (f1 >> kk) & 1, b = (f2 >> kk) & 1;
+        *dst++ = locals.dmdEqualFields ? (a | b ? (a & b ? 3 : 2) : 0)  /* 3 levels  */
+                                       : ((a << 1) | b);                /* 4 levels  */
+      }
+    }
+  }
+}
 
 /* Decode the 2-bitplane frame buffer at 0x60410 into a 128x32 brightness grid.
  * See the plane/weighting notes in SLEIC_irq_i8039 below */
 static void sleic3_build_dmd_frame(UINT8 *dst) {
-  int ii;
   const UINT8 * const buf = memory_region(SLEIC_MEMREG_CPU) + 0x60410;
-  for (ii = 0; ii < 32; ii++) {
-    UINT8 *line = dst + ii * 128;
-    const UINT8 * const src = buf + ii * 32;
-    int jj;
-    for (jj = 0; jj < 16; jj++) {
-      UINT8 f1 = src[jj];         /* plane lit by raster field 1 (rows 0x00-0x1F) */
-      UINT8 f2 = src[jj + 0x800]; /* plane lit by raster field 2 (rows 0x20-0x3F) */
-      int kk;
-      for (kk = 7; kk >= 0; kk--) {
-        int a = (f1 >> kk) & 1, b = (f2 >> kk) & 1;
-        *line++ = locals.dmdEqualFields ? (a | b ? (a & b ? 3 : 2) : 0)  /* 3 levels  */
-                                        : ((a << 1) | b);                /* 4 levels  */
-      }
-    }
-  }
+  sleic_build_dmd_frame(dst, buf, buf + 0x800, 0x20);
 }
 
 /* Bike Race V4.1 rebuilds the panel from scratch every frame: it strobes PCS4 bit 3 to
@@ -396,6 +432,50 @@ static INTERRUPT_GEN(SLEIC_irq_i8039) {
 #ifdef DEBUG_SLEIC
   sleic_dmd_dump(locals.rawDMD);
 #endif
+  core_dmd_submit_frame(core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout, locals.rawDMD, 1);
+}
+
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) DMD frame path -- findings F13.
+/
+/  The firmware runs a four-stage pipeline in work RAM and ends it with a plain copy into
+/  a 1 KB display buffer at segment 7000 (flat 0x70000), which is all the panel ever sees:
+/
+/    4000:0000-05FF   sprite planes 0/1, then a one-plane mask (0xFF = pass-all)
+/    4000:0600-09FF   background planes 0/1 -- where the animation loader lands its frames
+/    4000:0A00-0DFF   composite planes 0/1 = (background AND mask) OR sprite   sub_F08A5
+/    7000:0000-01FF   display plane 0  \ straight copy of 4000:0A00/0C00,      sub_F08EB
+/    7000:0200-03FF   display plane 1  / plane 1 first, then plane 0
+/
+/  Composite and blit are the two alternating branches of the INT0 ISR (F3), so the
+/  display buffer is refreshed at INT0/2.  Four things follow from F13 and are what this
+/  path implements:
+/
+/    * 32 rows x 16 bytes per plane, MSB = leftmost pixel -- the same geometry the
+/      animation pages carry in their header (F2: rows 0x20, bytes/row 0x10, plane stride
+/      0x200), so a full-screen background image reaches the panel byte-for-byte;
+/    * plane 0 is the MSB, because the PIC scans it first and holds each of its rows far
+/      longer (the 200:30 row-hold ratio -- see MACHINE_INIT(SLEIC2));
+/    * NO inversion.  Nothing in the firmware NOTs or XORs these bytes, so an inversion
+/      could only be a property of the panel, and nothing observed says it is one.  (The
+/      old driver applied ^0xFF here; F13 rejects it.);
+/    * NO frame strobe.  PCS4 0xA0200 bit 3 -- the old driver's "swap buffer", which is
+/      what used to trigger the submit -- is pulsed exactly ONCE, from boot_init.  IC23 is
+/      a free-running raster with no command interface (150 words, and the only input it
+/      samples is the external dot clock), so the panel just displays whatever stands in
+/      7000:0000-03FF at the moment it scans it.
+/
+/  So the driver does what the panel does: it samples the buffer at the panel's visible
+/  frame rate and submits what it finds, rather than waiting for a signal the hardware
+/  never sends.  Segment 7000 is not double-buffered, so a sample can catch a blit in
+/  progress and show one plane a frame ahead of the other -- the real panel has exactly
+/  the same race, for exactly the same reason.
+/-----------------------------------------------------------------------------------*/
+#define IOMOON_DMD_STAGE 0x70000 /* 7000:0000 = display plane 0 (MSB); plane 1 at +0x200 */
+
+static void iomoon_submit_dmd_frame(void) {
+  const UINT8 * const stage = memory_region(SLEIC_MEMREG_CPU) + IOMOON_DMD_STAGE;
+  sleic_build_dmd_frame(locals.rawDMD, stage, stage + 0x200, 0x10);
   core_dmd_submit_frame(core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout, locals.rawDMD, 1);
 }
 
@@ -540,53 +620,6 @@ static WRITE_HANDLER(pic_w) {
   logerror("PIC W(%03x->%2x) = %02x\n", offset, offset>>7, data);
 }
 
-/* Io Moon submits its DMD from the display pointer at 4000:1150 when the firmware
- * strobes PCS4 bit 3.  Bike Race and Sleic Pin-Ball instead have an I8039 that rasters
- * the panel out of the 0x60410 frame buffer, and their 4000:1150 is ordinary work RAM,
- * so the pointer-based submit must not run for them -- it would push whatever that RAM
- * happens to hold as a frame.  Set in MACHINE_INIT(SLEIC) from the presence of the
- * display CPU.  (Bike Race V4.1 made this visible: it clears and redraws the panel
- * every frame and strobes PCS4 bit 3 each time -- 114 strobes in a 600-frame run,
- * against a single one from the 1992 sets -- so the bogus frames swamped the real
- * ones and the DMD showed garbage) -> locals.dmdFromPtr */
-
-/* Snapshot the 2-bitplane DMD frame buffer and submit the 128x32 brightness
- * grid to the DMD core. Each plane is 512 bytes (32 rows x 16 bytes,
- * MSB = leftmost pixel); plane 0 weighted x2, plane 1 x1 -> 4 grey levels.
- * cpu_readmem20 routes through the 80188 memory map (per docs/dmd_graphics.md) */
-static void sleic_submit_dmd_frame(void) {
-  int row;
-  UINT8 * __restrict dst = locals.rawDMD;
-  unsigned p1ptr, s1ptr, base;
-  const core_tLCDLayout *layout = core_gameData->lcdLayout->importedLayout
-                                ? core_gameData->lcdLayout->importedLayout
-                                : core_gameData->lcdLayout;
-  /* The 80188 draws the DMD into the buffer addressed by the display pointer at
-   * 4000:1150 (offset p1, segment s1); the PIC rasters from there. seg 7000h is
-   * only a clear/staging area (always zero). Plane 0 = base, plane 1 = base+0x200 */
-  p1ptr = cpu_readmem20(0x41150) | (cpu_readmem20(0x41151) << 8);
-  s1ptr = cpu_readmem20(0x41152) | (cpu_readmem20(0x41153) << 8);
-  base  = (s1ptr << 4) + p1ptr;
-  for (row = 0; row < 32; row++) {
-    int row_offset = row * 16;
-    int byte_idx;
-    for (byte_idx = 0; byte_idx < 16; byte_idx++) {
-      const UINT8 b0 = cpu_readmem20(base + row_offset + byte_idx);
-      const UINT8 b1 = cpu_readmem20(base + 0x200 + row_offset + byte_idx);
-      int bit;
-      for (bit = 7; bit >= 0; bit--) {
-        UINT8 p0 = (b0 >> bit) & 1;
-        UINT8 p1 = (b1 >> bit) & 1;
-        *dst++ = (p0 << 1) | p1;    /* plane 0 = MSB, plane 1 = LSB */
-      }
-    }
-  }
-#ifdef DEBUG_SLEIC
-  sleic_dmd_dump(locals.rawDMD);
-#endif
-  core_dmd_submit_frame(layout, locals.rawDMD, 1);
-}
-
 /* PACS peripheral chip-select block at segment A000h (base 0xA0000,
  * 7 selects PCS0-PCS6 on 0x80 boundaries):
  *   0xA0000 PCS0  DMD control reg 1  AND the OKI /OKCS strobe (bit 5)
@@ -662,13 +695,9 @@ static WRITE_HANDLER(sleic_periph_w) {
       cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE);
       break;
     case 0x200:                        /* PCS4: DMD mode; bit 3 = frame swap */
-      if (data & 0x08) {
-        if (locals.dmdFromPtr)
-          sleic_submit_dmd_frame();    /* Io Moon: buffer-swap ack is emitted by the PIC phase machine */
-        else {                         /* I8039 machines: latch the finished 0x60410 frame */
-          sleic3_build_dmd_frame(locals.dmdLatch);
-          locals.dmdLatchTtl = SLEIC3_DMD_LATCH_TICKS;
-        }
+      if (data & 0x08) {               /* latch the finished 0x60410 frame for the I8039 tick */
+        sleic3_build_dmd_frame(locals.dmdLatch);
+        locals.dmdLatchTtl = SLEIC3_DMD_LATCH_TICKS;
       }
       break;
     default:
@@ -787,7 +816,7 @@ static NVRAM_HANDLER(SLEIC1) {
  *                      0x1B6B), bit3 (0x08) = OKI channel.
  *
  * PCS4 (0xA0200) is the DMD frame strobe (shadow [0x4de]) -- left alone, since the
- * I8039 renders sleicpin's DMD from 0x60410 (calling sleic_submit_dmd_frame would corrupt it) */
+ * I8039 renders sleicpin's DMD from the 0x60410 frame buffer, not from a strobe */
 static WRITE_HANDLER(sleic1_periph_w) {
   switch (offset) {
     case 0x080:                       /* PCS1: 80188 -> Z80 command (reverse path) */
@@ -1485,9 +1514,7 @@ static MACHINE_INIT(SLEIC) {
    * interrupt accumulators all start at zero on every machine start */
   memset(&locals, 0, sizeof locals);
   memset(&sleic_io, 0, sizeof sleic_io);
-  /* Only Io Moon lacks the I8039 display CPU, and only Io Moon uses the 4000:1150 display-pointer submit on the PCS4 bit-3 strobe */
-  locals.dmdFromPtr = (Machine->drv->cpu[SLEIC_DISPLAY_CPU].cpu_type == CPU_DUMMY);
-  /* locals.dmdEqualFields stays 0 here (Bike Race weighting); SLEIC1 overrides it below */
+  /* locals.dmdEqualFields stays 0 here (Bike Race weighting); SLEIC1 and SLEIC2 each state their own below */
   core_dmd_pwm_init(core_gameData->lcdLayout, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, 0);
   /* Ball trough / ball-detect optos live on matrix COL4 (swMatrix[5]). The Z80 cmd-0xD5
    * ball-status query strobes COL4 (out 0x82 = 0x10), reads it into 0xC0DB and replies
@@ -1523,6 +1550,32 @@ static MACHINE_INIT(SLEIC2) {
   iomoon_set_gfx_bank(iomoon_pcs0);
   iomoon_int0_acc = iomoon_t0_acc = 0.0;
   iomoon_int0_pend = iomoon_t0_pend = 0;
+  iomoon_panel_acc = 0.0;
+
+  /* Panel weighting, from the IC23 dump (asm/pic16c57_annotated.asm) rather than by
+   * analogy with the I8039 games: the raster's per-row hold delay is 200 counts for the
+   * plane PORTB walks first (0x00-0x3F = 7000:0000, plane 0) against 30 counts for the
+   * second (0x40-0x7F = 7000:0200, plane 1) -- 6.7:1.  Two consequences, one settled and
+   * one approximated:
+   *
+   *   SETTLED: the planes are strongly asymmetric, so this panel really does show a
+   *     weighted 2-bit value and not Sleic Pin-Ball's "lit / lit brightly" pair, and
+   *     plane 0 is unambiguously the MSB.  That is what locals.dmdEqualFields = 0
+   *     selects, and it is stated here rather than inherited from the base init so the
+   *     PIC is on record as the reason.
+   *
+   *   APPROXIMATED: the DUTY CYCLES the ratio implies are 0, 30/230 = 13%, 200/230 = 87%
+   *     and 100%, whereas MACHINE_INIT(SLEIC)'s CORE_DMD_PWM_PREINTEGRATED_LINEAR_4 maps
+   *     the four levels this driver hands core_dmd_submit_frame onto 0, 1/3, 2/3 and 1.
+   *     The ORDER is right and the ends are exact; the two middle levels are pulled
+   *     toward each other.  The core takes no per-plane weight -- its filter/combiner
+   *     pairs are either fixed FIR patterns for a named board or the two preintegrated
+   *     LUTs -- so LINEAR_4 is the closest available model, and the alternative
+   *     (PREINTEGRATED_SAM's 1/12-step LUT, whose indices 2 and 13 would land within 4%
+   *     of 13% and 87%) is rejected because it would put values outside 0..3 into the raw
+   *     frames every downstream consumer of a 4-shade DMD reads.  Revisit if the core
+   *     ever grows a weighted 2-plane combiner */
+  locals.dmdEqualFields = 0;
   /* J1 idle: both latches empty, so port-0x01 bit 1 reads free for the Z80's very first
    * send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
    * that routine spins on the bit before it does anything else */

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1194,7 +1194,9 @@ static WRITE_HANDLER(z80_write_port) {
   }
 }
 
-/* Z80 I/O processor state shadow (Bike Race port handlers below) */
+/* Z80 I/O processor state shadow, shared by the SLEIC1 / SLEIC2 / SLEIC3 port handlers
+ * (all three I/O ROMs drive the same latch conventions; Io Moon uses lampRow and keeps
+ * its own J1 and switch-column state in iomoon_j1) */
 static struct {
   UINT8 swStrobe; /* port 0x82: switch matrix column strobe (0..5 after decode) */
   UINT8 lampCol;  /* lamp matrix column (after decode) */
@@ -1401,10 +1403,15 @@ MEMORY_END
 /            test mode), 5 -> the auto-repeating 0x32 (0x33 in test mode, 0D3C/0D44)
 /  IN  0x04  cabinet/config byte -- see IOMOON_PORT04_IDLE
 /
-/  OUT 0x80  J1 data lines            OUT 0x83  lamp column strobe   } F7, Task 13
-/  OUT 0x81  J1 control (bit map F6)  OUT 0x84  lamp row data        }
-/  OUT 0x82  switch column strobe     OUT 0x85/0x86  driver latches, active low
+/  OUT 0x80  J1 data lines            OUT 0x83  lamp column strobe, one-hot 0x01..0x80
+/  OUT 0x81  J1 control (bit map F6)  OUT 0x84  lamp row data, active HIGH, latched
+/  OUT 0x82  switch column strobe     OUT 0x85/0x86  driver latches, active LOW
 /                                     OUT 0x87  direct-input index + flag bits
+/
+/  The three output groups are F7: 8 columns x 8 bits = 64 lamps (row byte on 0x84, then
+/  the column strobe on 0x83), and TWO 8-bit driver latches = 16 driver bits -- not the
+/  "7 columns x 16 rows" and "18 solenoids" of the service manual's summary, both of which
+/  the I/O ROM contradicts.
 /-----------------------------------------------------------------------------------*/
 
 /* Port 0x04 with nothing pressed.  Three bits have to be right or the firmware misbehaves,
@@ -1493,10 +1500,52 @@ static WRITE_HANDLER(iomoon_z80_write) {
       if (data) { const unsigned col = core_BitColToNum(data & -data);
                   if (col < 6) iomoon_j1.swCol = (UINT8)col; }
       break;
-    default:   /* 0x83/0x84 lamps, 0x85/0x86 drivers, 0x87 direct-input index: F7, Task 13.
-                * Silently ignored rather than logged -- the lamp refresh writes on every
-                * one of the Z80's ~977 interrupts per second */
+    case 0x03: /* port 0x83: lamp-matrix COLUMN strobe, one-hot 0x01..0x80 = column 0..7.
+                * lamp_colN_out (Z80 3457..34C7, one column per lamp_scan_tick, so the whole
+                * matrix is refreshed every 8 Z80 interrupts) writes the row byte to 0x84
+                * FIRST and pulses the column here second, so the pair commits on this
+                * strobe with the row latched by the preceding 0x84 */
+      if (data) coreGlobals.tmpLampMatrix[core_BitColToNum(data & -data)] = sleic_io.lampRow;
       break;
+    case 0x04: /* port 0x84: lamp-matrix ROW data, ACTIVE HIGH -- no inversion.  The byte is
+                * one of C10F..C116, which sub_353A fills either verbatim from the "lit" bank
+                * C0FF..C106 or as that bank ANDed with the "steady" bank C107..C10E on its
+                * alternate phase (the blink model: lit+steady = on, lit only = blinking),
+                * so a 1 bit is a lamp that is on; boot_port_init 043A starts it at 0x00.
+                * Latched here, committed on the 0x83 strobe */
+      sleic_io.lampRow = data;
+      break;
+    case 0x05: /* port 0x85: driver latch A -> solenoids 1-8.  ACTIVE LOW, so the byte is
+                * inverted here and coreGlobals carries positive logic: boot_port_init 0427
+                * writes 0xFF (everything off) and every driver routine CLEARS its bit to
+                * fire (AND #~bit at 05D7, 05FD, 0623, ...) and SETs it to release (OR #bit).
+                * Writing the driver-local shadow rather than coreGlobals.solenoids is
+                * deliberate: SLEIC_interface_update copies it over once a VBLANK.
+                *
+                * Bits 0/1, 2/3 and 4/5 are three COMPLEMENTARY PAIRS, bits 6 and 7 two
+                * singles (F7).  Each pair is one dual-wound flipper driven one winding at a
+                * time -- the button handlers sub_1292 / sub_12D8 choose between the two on
+                * that flipper's EOS contact (C0DB bit 6 / bit 7), i.e. one winding while it
+                * is travelling and the other to hold it up, and sub_064D / sub_06C2 release
+                * both.  WHICH physical coil sits on each bit is in neither ROM, so the
+                * mapping is the plain one, driver bit b -> solenoid b+1, and no coil is
+                * named here -- unlike Sleic Pin-Ball, whose manual numbering is verified */
+      locals.solenoids = (locals.solenoids & ~(UINT32)0x00ff) | (UINT32)(data ^ 0xff);
+      break;
+    case 0x06: /* port 0x86: driver latch B -> solenoids 9-16.  Same active-low convention
+                * (boot_port_init 042C also writes 0xFF), but all eight bits are independent:
+                * fired at 0706-07D1, released at 081B-0892, plus the timed auto-release path
+                * at 0ADA-0C51 inside the Z80's IRQ handler (F7) */
+      locals.solenoids = (locals.solenoids & ~(UINT32)0xff00) | ((UINT32)(data ^ 0xff) << 8);
+      break;
+    case 0x07: /* port 0x87: NOT a driver output.  Low nibble = direct_input_scan's 16-way
+                * mux index (0DEA-0E01; the selected input comes back on port-0x01 bit 5, and
+                * the scan is gated off entirely by IOMOON_PORT04_IDLE bit 0), bits 4 and 5
+                * are firmware flags (2851/2831 and port87_bit5_set/_clear), and
+                * boot_port_init 0420 starts the port at 0x30.  Nothing to drive */
+      break;
+    default:
+      logerror("iomoon Z80 write port %02x = %02x\n", 0x80 + offset, data);
   }
 }
 

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -274,6 +274,37 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * directly, which makes that listening test a measurement rather than an opinion */
 #define IOMOON_YM3812_CLOCK 4000000
 
+/* Io Moon OKI MSM6376 (IC51) playback rate, in Hz -- the rate the driver hands the core as
+ * the voice stream's sample rate, so it is what sets speech PITCH and duration.
+ *
+ * Unlike the YM3812's clock this one is MEASURED, out of the firmware and the sample ROMs,
+ * and it does not need the OKI's crystal to be traced.  The firmware pairs every phrase
+ * with a playing time: oki_trigger_a/b (F9) load the duration table CS:0C1F+2*(n-1) into
+ * [12FD]/[1300] and the timer-0 ISR counts it down at IOMOON_TIMER0_HZ, freeing the channel
+ * when it hits zero -- i.e. the table is the machine's own statement of how long phrase n
+ * lasts.  The sample ROMs state the same thing in nibbles: phrase n's chained ADPCM blocks
+ * (table entry n*4, see the region note in sleic.h) are 2 nibbles per byte.  Dividing one by
+ * the other over ALL 28 phrases gives the rate the two agree on:
+ *
+ *     phrase 1   292 ticks = 2.944 s   93 496 nibbles  ->  31 757 Hz
+ *     phrase 13  449 ticks = 4.527 s  143 818 nibbles  ->  31 768 Hz
+ *     phrase 28  449 ticks = 4.527 s  143 690 nibbles  ->  31 740 Hz
+ *     ... 28 of 28 inside 31 526 - 32 176 Hz; the long phrases (where a +-0.5 tick rounding
+ *     is negligible) cluster at 31 700 - 31 770 Hz, aggregate 31 747 Hz.
+ *
+ * That is 0.8 % under 32 kHz and 1.6 % over 31.25 kHz, the two rates a 6376 is normally
+ * strapped for (4.096 MHz and 4 MHz divided by 128), and the residual is inside the error
+ * IOMOON_TIMER0_HZ carries from IOMOON_CPU_CLOCK -- a 10.08 MHz part instead of the assumed
+ * 10 MHz makes the fit exactly 32 000.  So 32 kHz is the round value the evidence names,
+ * and it is independently what the reverse-engineering side's sample extractor
+ * (scripts/extract-oki-msm6376.py) defaults to.
+ *
+ * It is stated here rather than reusing SLEIC_okim6376_intf2's 4000000/132: that divisor is
+ * the OKIM6295's (pin 7) and belongs to Bike Race's interface, it is 4.7 % slow against the
+ * measurement above, and sharing the struct would mean any pitch correction from the owner's
+ * sound checkpoint silently retuned Bike Race as well */
+#define IOMOON_OKI_SAMPLE_RATE 32000
+
 /* Fractional tick accumulators, and one held request per source.  The request has to be
  * held because of how this i86 core delivers interrupts.  cpu_set_irq_line_and_vector does
  * not touch the CPU itself: it appends the request to a per-CPU event queue and schedules a
@@ -801,6 +832,22 @@ static struct OKIM6295interface SLEIC_okim6376_intf2 =
 	{ REGION_USER1 },	/* memory region */
 	{ 75 }				/* volume */
 };
+/* Io Moon (SLEIC2) OKI MSM6376 (IC51).  Same shape as the interface above and the same
+ * region -- REGION_USER1 holds V1 3_03.bin at 0x00000 and V1 3_04.bin at 0x80000, which is
+ * where the firmware's own phrase table says the samples are (sleic.h's SLEIC_ROMSTART5
+ * note) -- but the stream rate is Io Moon's measured one rather than Bike Race's assumed
+ * 4 MHz/132.  See IOMOON_OKI_SAMPLE_RATE for the derivation; it is the one knob the owner's
+ * speech pitch/tempo A/B lands on, and having it here keeps that A/B off Bike Race.
+ *
+ * num = 0 is not "no chips": it is how PinMAME's OKIM6295 core is told this is a 6376 --
+ * two voices instead of four, and generate_adpcm_6376's chained-block decoder (adpcm.c) */
+static struct OKIM6295interface SLEIC2_okim6376_intf =
+{
+	0,								/* 6376 marker: 1 chip (IC51), 2 voices        */
+	{ IOMOON_OKI_SAMPLE_RATE },		/* playback rate -- measured, see the constant */
+	{ REGION_USER1 },				/* V1 3_03.bin + V1 3_04.bin, contiguous 1 MB  */
+	{ 75 }							/* volume                                      */
+};
 static struct DACinterface SLEIC_dac_intf = { 1, { 25 }};
 
 static READ_HANDLER(read_0) {
@@ -1045,13 +1092,93 @@ static struct {
   UINT8 swCol;     /* Z80 port 0x82: switch-matrix column strobe, decoded to 0..5      */
 } iomoon_j1; //!!
 
-/* Io Moon 80188 peripheral write.  PCS0's page select (F2), the J1 outbound half (PCS1
- * data + the PCS4 bit-5 strobe, F6) and PCS5's YM3812 pair (F8) are wired; PCS6 OKI (F9)
- * and the PCS0 NVRAM gate (F10) are later tasks and are only logged */
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) OKI MSM6376 speech and effects -- finding F9.
+/
+/  The whole chip is driven by two addresses, and F9 accounts for every write the ROM makes
+/  to either of them (5 writes to PCS6, 8 to PCS0, all enumerated):
+/
+/    PCS6 0xA0300   an 8-bit latch on the OKI's data pins.  Bits 0-6 are the phrase number;
+/                   bit 7 is the CHANNEL, and the driver reads it as the chip's CH2 pin.
+/    PCS0 0xA0000   bit 5 is /OKCS, the chip's start (ST) input: idle HIGH, pulsed low then
+/                   high by okcs_strobe D0CE2.  The other PCS0 bits belong to F2 and F10.
+/
+/  The three sequences, verbatim from F9:
+/
+/    oki_trigger_a D0C57   0xA0300 <- 0x80|n   then strobe            (bit 7 SET)
+/    oki_trigger_b D0C84   0xA0300 <- n&0x7F   then strobe,           (bit 7 CLEAR)
+/                          then 0xA0300 <- 0x80|n with NO second strobe
+/    sub_D0CB8             0xA0300 <- 0        then bit 5 LOW and left low  (silence/reset)
+/
+/  Reading bit 7 as CH2 is what makes those three coherent, and it is the reading the code
+/  argues for rather than an analogy with the sister machines: trigger_b drives bit 7 low
+/  only across its strobe and RESTORES it immediately after, which is a level a pin is held
+/  at for the duration of an event, not a data byte -- a data byte would have no reason to
+/  be rewritten once latched.  Boot leaves the latch at 0x80 (D00C4/D00C6) and the shadow at
+/  0x28, i.e. the idle state is "channel 2 selected, ST released".
+/
+/  PinMAME's core speaks the 6295-style two-byte protocol instead of ST/CH2 (adpcm.c
+/  OKIM6376_data_w: a byte with bit 7 set latches the phrase, the next byte starts the
+/  voices named by its bits 4-5), so a strobe is translated into that pair here.  Three
+/  details of the translation are deliberate:
+/
+/   - WHICH EDGE.  The falling one.  For both trigger routines it makes no difference --
+/     the latch holds the same value at both edges, because trigger_b's rewrite comes after
+/     the pulse -- so the choice is settled by the third sequence: sub_D0CB8 drives ST low
+/     and leaves it there, so only the falling edge sees the silence request at all.
+/     A consequence worth stating: a strobe issued while ST is ALREADY low fires nothing
+/     here.  That is not a hole in the model, it is the pin -- a level that does not move
+/     is an edge the chip does not see either -- and the firmware never does it: after
+/     sub_D0CB8 it sets [1303] = 0xFF, and the timer-0 ISR restores ST high through
+/     pcs0_bit5_set_far (D0284) BEFORE it starts the parked sample.
+/   - PHRASE 0 = STOP BOTH VOICES.  That is sub_D0CB8's whole purpose: it is called when a
+/     priority sample arrives and both channels are busy (D0BBE), and it then parks the
+/     sample for the timer-0 ISR to start a tick later.  Stopping only the CH2-selected
+/     voice would leave the other one playing, and the core would then REFUSE the parked
+/     sample ("requested to play sample on non-stopped voice") -- the priority path would
+/     drop exactly the sound it exists to make room for.
+/   - RETRIGGER STOPS FIRST.  A real ST pulse restarts a channel whatever it was doing; the
+/     core instead refuses a start on a voice still playing.  The firmware's own busy model
+/     is software (F9: the duration counters, no BUSY pin is read anywhere), and those
+/     durations match the sample lengths to about 1 % -- see IOMOON_OKI_SAMPLE_RATE -- so a
+/     re-trigger landing a few milliseconds early is expected, and without the explicit stop
+/     it would be silently dropped instead of restarting.
+/
+/  Not modelled, and stated rather than hidden: WHICH physical channel bit 7 = 1 is.  Both
+/  voices mix to the same output at the same volume and the firmware never reads the chip
+/  back, so swapping them changes nothing audible -- only which voice number a phrase
+/  occupies -- and no dump is needed to settle something with no observable difference.
+/-----------------------------------------------------------------------------------*/
+static UINT8 iomoon_oki_latch; /* PCS6 0xA0300: bit 7 = CH2, bits 0-6 = phrase number */ //!!
+
+static void iomoon_oki_strobe(void) {
+  const UINT8 phrase = iomoon_oki_latch & 0x7f;
+  /* CH2 -> the core's voice bit: bit 4 = voice 0, bit 5 = voice 1 (adpcm.c, data >> 4) */
+  const UINT8 voice  = (iomoon_oki_latch & 0x80) ? 1 : 0;
+
+  if (!phrase) {                      /* sub_D0CB8: latch 0, ST low -- silence both */
+    OKIM6376_data_0_w(0, 0x18);       /* no command pending -> bits 3,4 = stop voices 0,1 */
+    return;
+  }
+  OKIM6376_data_0_w(0, (UINT8)(0x08 << voice));   /* abort this channel first (see above) */
+  OKIM6376_data_0_w(0, (UINT8)(0x80 | phrase));   /* phrase number on D0-D6              */
+  OKIM6376_data_0_w(0, (UINT8)(0x10 << voice));   /* start it on the CH2-selected voice  */
+}
+
+/* Io Moon 80188 peripheral write.  PCS0's page select (F2) and /OKCS strobe (F9), the J1
+ * outbound half (PCS1 data + the PCS4 bit-5 strobe, F6), PCS5's YM3812 pair (F8) and PCS6's
+ * OKI latch (F9) are wired; the PCS0 NVRAM gate bits (F10) need no action -- the window
+ * they open is mapped unconditionally, see IOMOON_NVRAM_BASE */
 static WRITE_HANDLER(sleic2_periph_w) {
   switch (offset) {
     case 0x000: /* PCS0: bits 0-2 graphics page (F2), 3/4 NVRAM window gate (F10), 5 = OKI /OKCS (F9) */
       if ((data ^ iomoon_pcs0) & 0x07) iomoon_set_gfx_bank(data);
+      /* bit 5 = the OKI's ST input, idle high (F9).  Only the three OKI routines ever move
+       * it -- okcs_strobe D0CE2, pcs0_bit5_clear D0CFC and pcs0_bit5_set_far D0D09 -- while
+       * the page select F00A0 and the NVRAM gate D0596/D05B7 write the same shadow byte
+       * with bit 5 untouched, so an edge here is always an OKI event and never a side
+       * effect of the other two fields sharing this register */
+      if ((iomoon_pcs0 & 0x20) && !(data & 0x20)) iomoon_oki_strobe();
       iomoon_pcs0 = data;
       return;
     case 0x080: /* PCS1: the byte on the outbound J1 data lines (qout_service_pcs1 D020F).
@@ -1092,7 +1219,12 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * accepts the pair back to back -- so nothing here waits */
       YM3812_write_port_0_w(0, data);
       return;
-    default:                          /* PCS2, PCS3, PCS6 OKI */
+    case 0x300: /* PCS6: the OKI MSM6376's data/CH2 latch (F9).  Latching alone starts
+                 * nothing -- the PCS0 bit-5 pulse above does -- which is why the boot's
+                 * 0x80 (D00C6) and trigger_b's trailing rewrite (D0CAE) are silent here */
+      iomoon_oki_latch = data;
+      return;
+    default:                          /* PCS2, PCS3 */
 #ifdef DEBUG_SLEIC
       if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
 #endif
@@ -1678,6 +1810,10 @@ static MACHINE_INIT(SLEIC2) {
   machine_init_SLEIC();
   iomoon_pcs0 = 0x28;
   iomoon_set_gfx_bank(iomoon_pcs0);
+  /* The OKI latch starts empty rather than at the 0x80 boot_init writes: 0x28 above already
+   * has ST released, so nothing can be triggered before the firmware's own D00C6 write
+   * arrives, and phrase 0 would be a stop in any case */
+  iomoon_oki_latch = 0;
   iomoon_int0_acc = iomoon_t0_acc = 0.0;
   iomoon_int0_pend = iomoon_t0_pend = 0;
   iomoon_panel_acc = 0.0;
@@ -2020,7 +2156,7 @@ MACHINE_DRIVER_START(SLEIC2)
   // the device only ever added a silent mixer channel.  (SLEIC1 and SLEIC3 keep theirs:
   // their boards were not traced for this and are not this task's to change.)
   MDRV_SOUND_ADD(YM3812, SLEIC2_ym3812_intf)
-  MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf2)
+  MDRV_SOUND_ADD(OKIM6295, SLEIC2_okim6376_intf)
 MACHINE_DRIVER_END
 
 MACHINE_DRIVER_START(SLEIC3)

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1120,6 +1120,9 @@ static struct {
 static void iomoon_ball_command(UINT8 cmd);
 static void iomoon_ball_reset(void);
 
+/* The coin mechanism's pulse train (model further down); the reset is the machine init's */
+static void iomoon_coin_reset(void);
+
 /*-------------------------------------------------------------------------------------
 /  Io Moon (SLEIC2) OKI MSM6376 speech and effects -- finding F9.
 /
@@ -1924,6 +1927,8 @@ static MACHINE_INIT(SLEIC2) {
   /* The ball trough starts EMPTY here and is filled by the first SWITCH_UPDATE, because
    * the ball complement comes from an input port and the ports are not readable yet */
   iomoon_ball_reset();
+  /* No coin part-way through its pulse train, and no key remembered as already down */
+  iomoon_coin_reset();
 }
 
 /*-------------------------------------------------------------------------------------
@@ -2167,6 +2172,107 @@ static void iomoon_ball_update(int balls, int shoot, int drain) {
   coreGlobals.swMatrix[IOMOON_TROUGH_COL] |= bits;
 }
 
+/*-------------------------------------------------------------------------------------
+/  Io Moon (SLEIC2) coin input: ONE line, and one coin is a PULSE TRAIN on it.
+/
+/  The cabinet has a single electronic coin mechanism -- one entry in the manual's board
+/  list, designator N-50, on the door -- and it lands on the direct-input connector J7
+/  (manual 7.2.2.2) as Z80 port 0x03 bit 5.  There is no second or third coin switch
+/  anywhere in the Z80 ROM: a sweep of the whole listing for the code-send pattern finds
+/  73 sites and exactly one of them is a coin (sub_0D15 0D15 -> 0D3C, code 0x32; 0x33 in
+/  test mode), and the 80188 has no other credit source (F5, F11).  So "coin slot 1/2/3"
+/  is NOT a wiring fact here and cannot be put on three keys as three switches.
+/
+/  What the three per-country "coin values" are instead is DENOMINATIONS on that one line,
+/  told apart by HOW MANY pulses the validator emits.  The firmware never sees a coin --
+/  it counts pulses and prices the running total:
+/
+/    D000:0190   the NMI tests the inbound byte for 0x32 and, alone among the codes, does
+/                not queue it: it increments the pulse counter [4000:1144].
+/    sub_D800A   folds that count into the accumulator and calls the per-country pricing
+/                routine (sub_DCD9E for country 5, else sub_DD03D).
+/    sub_DD03D   divides the accumulated pulses by each coin value in turn, LARGEST FIRST
+/                (413C:00AF, then 00AE, then 00AD; the country-5 routine starts one higher
+/                at 00B0), multiplies each whole coin it finds by that coin's credit value
+/                (00AB / 00AA / 00A9, and 00AC), banks it through sub_DD1C1 and keeps the
+/                remainder.
+/
+/  Cross-check the pulse counts against the manual's coin table and the unit is obvious:
+/
+/    country      coin values (pulses)          credits        one pulse =
+/    UK        3 (30p)   5 (50p)  10 (GBP1)      1 / 2 / 5        10p
+/    Germany   1 (1 DM)  2 (2 DM)  5 (5 DM)      1 / 3 / 8        1 DM
+/    Italy     1 (500 L) 2 (1000L) 4 (2000 L)    1 / 3 / 7        500 L
+/    Holland   2 (1 Fl)  5 (2,5Fl) 10 (5 Fl)     1 / 3 / 7        0,50 Fl
+/    Spain     2 (50pta) 4 (100)   8 (200) 20 (500)  1/3/7/18     25 pta
+/
+/  which is an ordinary multi-coin validator with a value-scaled pulse output, and it
+/  settles what the coin KEY has to mean.  A player cannot emit one pulse -- there is no
+/  coin worth one pulse in the UK, Holland or Spain -- so a key that emits a single pulse
+/  models something the cabinet cannot do, and under those countries it takes two or three
+/  presses before the firmware sees a whole coin (owner report, and reproduced: under the
+/  old UK default three presses banked one credit).  The key therefore inserts a COIN: it
+/  starts a burst of as many pulses as that country's coin is worth, and the firmware
+/  prices it exactly as it prices the real mechanism.  One press = one coin = at least one
+/  credit under every one of the eight country settings.
+/
+/  The pulse count is read from the firmware's own live table rather than a copy of the
+/  eight presets, because the table is what the machine is actually pricing against: it is
+/  loaded from NVRAM 0x1C4-0x1CF at boot (sub_D6A36) and rewritten whenever the country
+/  DIP changes or the operator edits the values in the service menu, and a driver-side copy
+/  would go stale on both.  Before the boot load has run it reads zero, and one pulse is
+/  the honest fallback (the machine cannot price anything at that point either -- the
+/  pulses simply pile up in [4000:1144] until it can).
+/
+/  The BURST TIMING is the Z80's, not a guess.  sub_0D15 debounces the contact for 0x32
+/  ticks of the C046 counter before it sends the code, and that counter is stepped from the
+/  Z80's own periodic interrupt (SLEIC2 runs it at 8000000/8192 = 977 Hz), so a pulse must
+/  hold the contact for 50/977 = 51 ms = about 3.1 frames.  Measured on this driver: a
+/  3-frame hold sends NOTHING and a 4-frame hold sends every pulse, so 5 frames closed is
+/  the shortest hold with real margin.  The contact must then open again before the next
+/  pulse, because sub_33FA latches the input into the C0F8 mask on the way out and
+/  input_port03_read only clears it once the contact physically opens (F5: one press, one
+/  code, no auto-repeat); 3 frames open is comfortably enough.  8 frames per pulse is also
+/  about what the mechanism itself does -- a validator of this class pulses at roughly
+/  100 ms -- so the coin sound and the credit ticking up land at a plausible rate. */
+#define IOMOON_COIN_VALUES 0x4146d /* 413C:00AD, the three coin values in PULSES (00AF is
+                                    * the largest; country 5 has a fourth at 00B0)       */
+#define IOMOON_COIN_HOLD   5       /* frames the contact is closed, per pulse            */
+#define IOMOON_COIN_GAP    3       /* frames it is open again before the next pulse      */
+#define IOMOON_CAB_COIN    0x0200  /* the COIN bit of the cabinet inport (sleic.h)       */
+
+static struct { int pending, phase; UINT16 lastKeys; } iomoon_coin; //!!
+
+static void iomoon_coin_reset(void) { memset(&iomoon_coin, 0, sizeof iomoon_coin); }
+
+/* Pulses the mechanism emits for the coin the player just put in.  Only the smallest
+ * denomination has a key (see SLEIC2_CABPORT in sleic.h): the firmware prices the running
+ * pulse total rather than individual coins, so repeated small coins reach the same credit
+ * levels a larger coin does */
+static int iomoon_coin_pulses(void) {
+  const int n = cpu_readmem20(IOMOON_COIN_VALUES);
+  return (n > 0 && n <= 40) ? n : 1; /* 0 = the boot load has not run yet; 20 is the most
+                                      * any preset asks for (Spain's 500 pta)            */
+}
+
+/* Called once a frame with the cabinet inport word.  Returns the state of the coin
+ * contact for this frame: a fresh press queues a whole coin's worth of pulses, and the
+ * queue is emitted one pulse at a time whatever else the player does meanwhile (pressing
+ * again mid-burst adds a second coin, exactly like feeding the mechanism does) */
+static int iomoon_coin_update(UINT16 keys) {
+  int closed;
+  if ((keys & IOMOON_CAB_COIN) && !(iomoon_coin.lastKeys & IOMOON_CAB_COIN))
+    iomoon_coin.pending += iomoon_coin_pulses();
+  iomoon_coin.lastKeys = keys;
+  if (iomoon_coin.pending <= 0) { iomoon_coin.phase = 0; return 0; }
+  closed = (iomoon_coin.phase < IOMOON_COIN_HOLD);
+  if (++iomoon_coin.phase >= IOMOON_COIN_HOLD + IOMOON_COIN_GAP) {
+    iomoon_coin.phase = 0;
+    iomoon_coin.pending--;
+  }
+  return closed;
+}
+
 static SWITCH_UPDATE(SLEIC2) {
   unsigned i;
   int balls = IOMOON_TROUGH_MAX, shoot = 0, drain = 0;
@@ -2196,6 +2302,8 @@ static SWITCH_UPDATE(SLEIC2) {
      *            only path in the ROM that adds credits from a switch.  The award itself
      *            is nvstore_write_triple_83 (F10) with the running total cached in
      *            413C:00D4, and sub_D0B70(0x0A) is the coin sound on the partial.
+     *            This bit is therefore NOT driven from the key directly: one press is one
+     *            COIN, and iomoon_coin_update turns it into that coin's pulse train.
      *   bit 0 -> TILT ("falta").  Its code 0x3E dispatches through the in-game table at
      *            CS:0527 (entry 48) to sub_D9EBB, which counts down the warning counter
      *            [4134:0033] -- loaded at every ball start from NVRAM byte 0x42 minus one
@@ -2221,7 +2329,11 @@ static SWITCH_UPDATE(SLEIC2) {
     CORE_SETKEYSW(in << 1,  0x04, 9); /* R-flip 0x0002 -> bit2 (code 0x42) */
     CORE_SETKEYSW(in << 3,  0x08, 9); /* L-flip 0x0001 -> bit3 (code 0x41) */
     CORE_SETKEYSW(in >> 4,  0x10, 9); /* START  0x0100 -> bit4 (code 0x40) */
-    CORE_SETKEYSW(in >> 4,  0x20, 9); /* COIN   0x0200 -> bit5 (code 0x32) */
+    /* COIN 0x0200 -> bit5 (code 0x32), through the pulse-train generator rather than
+     * straight from the key: one press is one COIN, which is several pulses on this one
+     * line -- see iomoon_coin_update */
+    if (iomoon_coin_update(in)) coreGlobals.swMatrix[9] |=  0x20;
+    else                        coreGlobals.swMatrix[9] &= ~0x20;
   }
   for (i = 0; i < sizeof(iomoon_pf_keys)/sizeof(iomoon_pf_keys[0]); i++) {
     if (keyboard_pressed(iomoon_pf_keys[i].key))

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1924,8 +1924,10 @@ static MACHINE_INIT(SLEIC2) {
    * send -- boot_port_init 041B calls host_send_c008_b with interrupts still off, and
    * that routine spins on the bit before it does anything else */
   memset(&iomoon_j1, 0, sizeof iomoon_j1);
-  /* The ball trough starts EMPTY here and is filled by the first SWITCH_UPDATE, because
-   * the ball complement comes from an input port and the ports are not readable yet */
+  /* The ball trough starts EMPTY, and at the default "Balls" = 0 it stays that way: the
+   * model is opt-in and the frontend owns those contacts.  It is filled by the first
+   * SWITCH_UPDATE only if the operator has asked for it, because the complement comes
+   * from an input port and the ports are not readable this early */
   iomoon_ball_reset();
   /* No coin part-way through its pulse train, and no key remembered as already down */
   iomoon_coin_reset();
@@ -1972,10 +1974,36 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
 };
 
 /*-------------------------------------------------------------------------------------
-/  Io Moon (SLEIC2) ball trough.
+/  Io Moon (SLEIC2) ball trough -- OPT-IN, AND OFF BY DEFAULT.
 /
-/  This is the one piece of playfield state the driver has to keep, because the firmware
-/  BLOCKS on it.  Four of the 48 matrix contacts are ball-handling contacts rather than
+/  READ THIS FIRST.  PinMAME's contract is that switches are switches: the FRONTEND closes
+/  them.  Under VPinMAME a table script owns the trough opto/contact numbers and reports a
+/  ball arriving or leaving; standalone, the matrix test keys do it by hand.  A driver that
+/  seeds balls of its own invents playfield state the frontend then fights, so this model
+/  is not the default and the sister machines have no equivalent -- Bike Race sits on
+/  "FALTA 1 BOLA" until something closes its trough contacts, which is exactly right.
+/
+/  So the four contacts below are ORDINARY SWITCHES unless the operator asks for the
+/  model.  The knob is the standard simulator port's "Balls" setting, which every PinMAME
+/  driver already carries (sim.h, and SLEIC2_INPUT_PORTS_START in sleic.h):
+/
+/    Balls = 0   DEFAULT.  The model is off.  swMatrix[1] bits 0-3 are driven only by the
+/                matrix inputs -- the Q/W/E/R test keys, or a VPinMAME table script.  No
+/                seeding, no kicker, and the "Drain ball in play" and "Shoot Ball" inputs
+/                do nothing at all (iomoon_ball_update returns before it reads them).
+/    Balls = 3   The internal three-ball model below, for standalone desktop play where
+/                nothing else is going to close those contacts.  1 and 2 clamp up to 3
+/                (see the clamp comment); 4..7 also give 3, since the trough only has
+/                three contacts.
+/
+/  Turning it on or off mid-session is safe: the off path drops the whole state, so a
+/  serve caught half-way is not replayed into the first frame after it is switched back on.
+/  Turning it OFF during a game does leave the firmware looking for balls that are now
+/  nobody's job to present, which is the same stall a real cabinet has when the balls are
+/  taken out mid-game -- switch it before you start, not during.
+/
+/  WHAT THE MODEL IS FOR, when it is on.  The firmware BLOCKS on these contacts.  Four of
+/  the 48 matrix contacts are ball-handling contacts rather than
 /  playfield events, and both CPUs stop dead until they read right:
 /
 /    swMatrix[1] bits 0-2   the three trough contacts, codes 0x0A-0x0C
@@ -2055,9 +2083,8 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
 /    at rest            three balls on the trough contacts.  The complement comes from the
 /                       "Balls" setting of the standard simulator input port, which the
 /                       game already carries; the firmware's own number is 3 (DC514 and
-/                       DC14D both store 3).  Setting it to 0 turns the whole model off,
-/                       which is the escape hatch for a frontend that wants to own these
-/                       contacts itself.
+/                       DC14D both store 3).  0 -- the DEFAULT -- turns the whole model
+/                       off and hands these contacts back to the frontend.
 /    serve              on command 0xE9 reaching the Z80, after a short mechanical delay,
 /                       one ball leaves the trough and closes the ball-exit contact.  That
 /                       is what 2B03 is waiting for and it is what makes it answer 0x45.
@@ -2076,7 +2103,8 @@ static const struct { int key; UINT8 col; UINT8 bit; } iomoon_pf_keys[] = {
 /                       lets the Z80's own 161E send the 0x43.
 /
 /  Nothing here writes firmware memory; it only presents contacts, and every contact it
-/  presents is one the real machine has.
+/  presents is one the real machine has -- and with "Balls" at its default 0 it presents
+/  none of them, so the frontend's own trough switches are the only thing driving them.
 /-----------------------------------------------------------------------------------*/
 #define IOMOON_TROUGH_COL   1     /* swMatrix index of Z80 switch column 0              */
 #define IOMOON_TROUGH_BITS  0x07  /* bits 0-2, codes 0x0A-0x0C                          */
@@ -2097,11 +2125,13 @@ static struct {
   int kick;       /* frames left before the served ball reaches the exit contact        */
   int dwell;      /* frames the ball has been sitting on the exit contact               */
   int drainHeld;  /* previous state of the drain input, so one press = one ball         */
-  int seeded;     /* the complement has been taken from the input port                  */
+  int seeded;     /* the model is ON and the complement has been taken from the port    */
 } iomoon_balls;
 
-/* Called from MACHINE_INIT.  The complement is not known here -- the input ports are not
- * readable this early -- so the first SWITCH_UPDATE fills the trough */
+/* Called from MACHINE_INIT.  Also the whole of the model-off path: zero here means the
+ * model owns no contact and no ball, and nothing it presents can survive being switched
+ * off.  "seeded" doubles as the on/off flag -- it is set only by iomoon_ball_update with
+ * "Balls" > 0, and cleared again the moment that setting goes back to 0 */
 static void iomoon_ball_reset(void) {
   memset(&iomoon_balls, 0, sizeof iomoon_balls);
 }
@@ -2109,7 +2139,11 @@ static void iomoon_ball_reset(void) {
 /* Called from the 80188 -> Z80 strobe with the command byte, i.e. exactly when the Z80's
  * NMI takes it.  0xE9 is the only command that moves a ball; 0xEF cannot be served by
  * moving one, since its exit condition is the trough being FULL and the balls it is
- * looking for are the ones already in play */
+ * looking for are the ones already in play.
+ *
+ * The "seeded" test is what keeps the kicker out of the way with the model off: with
+ * "Balls" = 0 the serve command is simply not acted on, and whatever closes the trough
+ * contacts -- a table script, or the matrix test keys -- answers it instead */
 static void iomoon_ball_command(UINT8 cmd) {
   if (cmd == 0xe9 && iomoon_balls.seeded && !iomoon_balls.atExit && !iomoon_balls.kick
       && iomoon_balls.inTrough > 0)
@@ -2122,18 +2156,21 @@ static void iomoon_ball_command(UINT8 cmd) {
  * see, and the model has no business overriding it.
  *
  * shoot = the simulator port's "Shoot Ball", drain = the cabinet port's "Drain ball in
- * play", balls = its "Balls" setting (0 = model off) */
+ * play", balls = its "Balls" setting.  balls = 0 is the DEFAULT and means model off */
 static void iomoon_ball_update(int balls, int shoot, int drain) {
   UINT8 bits;
-  /* "Balls" = 0 turns the model off for a frontend that drives these contacts itself.
-   * Drop the whole state, not just the seeded flag: a half-finished serve left behind
-   * would be applied to the first frame after the setting is turned back on */
+  /* MODEL OFF -- the default, and the only behaviour a frontend ever sees.  Return before
+   * anything is seeded, before the kicker is stepped and before "shoot" or "drain" is
+   * looked at, so those two inputs are inert rather than half-live, and swMatrix[1] bits
+   * 0-3 are left exactly as the matrix inputs set them.  Drop the whole state, not just
+   * the seeded flag: a half-finished serve left behind would otherwise be applied to the
+   * first frame after the setting is turned back on */
   if (balls <= 0) { iomoon_ball_reset(); return; }
-  /* Fewer than three cannot work and is not a machine state a user should be able to
-   * select by accident: the trough test sub_2C1F only ever clears with three adjacent
-   * contacts closed, so a two-ball trough leaves command 0xEF (Z80 2BC7) looping with no
-   * give-up path -- which is what a real cabinet missing a ball does, but a UI setting
-   * should not brick the emulation.  Clamp up; 0 above is the deliberate way off */
+  /* MODEL ON.  Fewer than three cannot work and is not a machine state a user should be
+   * able to select by accident: the trough test sub_2C1F only ever clears with three
+   * adjacent contacts closed, so a two-ball trough leaves command 0xEF (Z80 2BC7) looping
+   * with no give-up path -- which is what a real cabinet missing a ball does, but a UI
+   * setting should not brick the emulation.  Clamp up; 0 above is the deliberate way off */
   if (balls < IOMOON_TROUGH_MAX) balls = IOMOON_TROUGH_MAX;
   if (!iomoon_balls.seeded) {
     iomoon_balls.seeded   = 1;
@@ -2275,13 +2312,18 @@ static int iomoon_coin_update(UINT16 keys) {
 
 static SWITCH_UPDATE(SLEIC2) {
   unsigned i;
-  int balls = IOMOON_TROUGH_MAX, shoot = 0, drain = 0;
+  /* Model OFF unless the ports say otherwise, and inports == NULL is exactly the case
+   * that must stay off: core.c passes NULL when the host owns the keyboard (VPinMAME),
+   * i.e. when a table script is driving the trough switches itself */
+  int balls = 0, shoot = 0, drain = 0;
   if (inports) {
     const UINT16 in = inports[CORE_COREINPORT];
     /* The ball trough's three inputs, acted on after the key loop below.  "Balls" and
      * "Shoot Ball" are the standard simulator port the game already carries (sim.h,
      * SLEIC2_INPUT_PORTS_START); "Drain ball in play" is Io Moon's own cabinet bit
-     * 0x1000 (sleic.h), which is how a run gets through a whole ball */
+     * 0x1000 (sleic.h), which is how a run gets through a whole ball.  "Balls" is the
+     * opt-in: 0 (the DEFAULT) leaves the trough contacts to the frontend and makes the
+     * other two inert */
     balls = SIM_BALLS(inports[CORE_SIMINPORT]);
     shoot = (inports[CORE_SIMINPORT] & SIM_SHOOTERKEY) ? 1 : 0;
     drain = (in & 0x1000) ? 1 : 0;

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1664,8 +1664,8 @@ MEMORY_END
 /  the I/O ROM contradicts.
 /-----------------------------------------------------------------------------------*/
 
-/* Port 0x04 with nothing pressed.  Three bits have to be right or the firmware misbehaves,
- * and all three readings come from the ROM:
+/* Port 0x04 with nothing pressed.  Two bits have to be right or the firmware misbehaves,
+ * and both readings come from the ROM:
  *
  *   bit 7 = 1  selftest_wait_reset 2E42 spins on it (IN ($04) / BIT 7 / JP Z,self), so a 0
  *              here is a hang the moment the self-test path is taken.
@@ -1674,24 +1674,10 @@ MEMORY_END
  *              bit 5, sending codes 0x50-0x79; which physical contacts sit on it is part
  *              of F5's open gap, so the honest model is "not fitted" rather than a
  *              guessed wiring.  Turning it on is a one-bit change once that is known.
- *   bit 5 = 0  makes the command-0xED handler 2BEB answer 0x45 at once (IN ($04) / BIT 5 /
- *              JP Z,2C17).  The service manual's SW40 list (section 7.2.2.3) has a switch
- *              with exactly this function, SW5 "servicio: no se dispensan bolas" / no
- *              balls dispensed.  That the FUNCTION matches is a good sign the branch is
- *              understood; it is NOT proof that SW5 is this bit, because the manual gives
- *              no bit numbers and only SW2-SW4's positions have been established.
- *              With bit 5 SET the handler instead loops -- strobe column 0,
- *              check the trough contacts, run the eject coil sequence sub_2CFB, repeat --
- *              and its ONLY exit is those contacts closing.  That is correct hardware
- *              behaviour (a machine waiting for its balls), but it never returns to the
- *              command dispatcher, so the Z80 stops scanning switches entirely; with no
- *              ball model and F5's physical map open, 0 is the state this driver can
- *              honestly hold.  The 80188 side is happy either way: F14's prompt takes
- *              0x45 or 0x46 and moves on.
  *
- * Bits 1-3 have since been taken OUT of this constant: they are the SW40 country switches
- * and the firmware acts on them, so they come from the DIP bank instead -- see
- * iomoon_port04() below.  What remains here is bits 0, 4, 5, 6 and 7.
+ * Bits 1-3 and bit 5 are NOT in this constant: they are SW40 switches the firmware acts
+ * on, so they come from the DIP bank -- see iomoon_port04() below.  What remains here is
+ * bits 0, 4, 6 and 7, all high.
  *
  * Two structural notes, because the read is "IDLE & ~swMatrix[10]" and an AND can only
  * ever CLEAR bits:
@@ -1702,7 +1688,7 @@ MEMORY_END
  *   - anything mapped into swMatrix[10] bit 7 would pull that bit low and hang
  *     selftest_wait_reset 2E42.  Nothing writes row 10 today; keep it that way unless
  *     the bit is understood. */
-#define IOMOON_PORT04_IDLE 0xdf
+#define IOMOON_PORT04_IDLE 0xff
 
 /* Bits 1-3 of port 0x04 are the SW40 country switches SW2-SW4, and they are NOT an idle
  * constant -- the firmware reads them and acts on them, so they are a DIP the user sets
@@ -1724,11 +1710,21 @@ MEMORY_END
  * themselves, not by the UK and Spain rows (both are palindromes and survive a reversal);
  * sleic.h carries the eight-row comparison and the three rows a reversal would break.
  *
- * The other five bits stay in IOMOON_PORT04_IDLE.  Bit 5 in particular must stay 0 for
- * the reason above -- the manual's SW5 "servicio: no se dispensan bolas" is the same
- * behaviour the 0xED handler shows, and with no ball model 0 is the state to hold. */
+ * Bit 5 is SW40-5, the manual's "servicio: no se dispensan bolas".  The 0xED handler
+ * 2BEB reads it (IN ($04) / BIT 5 / JP Z,2C17) and with the bit LOW answers 0x45 without
+ * looking at a contact -- which is exactly "do not dispense balls", i.e. the SERVICE
+ * position.  Normal play is the bit HIGH, where 2BEB runs the real check: strobe column
+ * 0, test the trough (sub_2C1F), and answer 0x45 through sub_2851 when the balls are
+ * home or 0x46 and the eject sequence when they are not.  That branch used to be a hang,
+ * which is why this bit was held low; with the trough modelled it is not, and the DIP
+ * now selects it.  Measured both ways: bit high answers 0x45 in ONE frame at boot and
+ * the whole coin/credit/START/serve chain runs identically to bit low. */
 static UINT8 iomoon_port04(void) {
-  return (UINT8)((IOMOON_PORT04_IDLE & ~0x0e) | (core_getDip(0) & 0x0e));
+  /* DIP 0x10 is SW40-5 and its two settings are named for the switch, not for the bit:
+   * "On" (DIP 0) = the service position = port-04 bit 5 LOW, "Off" (DIP 0x10) = normal
+   * play = bit 5 HIGH.  Default is Off */
+  return (UINT8)((IOMOON_PORT04_IDLE & ~0x2e) | (core_getDip(0) & 0x0e)
+                 | ((core_getDip(0) & 0x10) ? 0x20 : 0x00));
 }
 
 static READ_HANDLER(iomoon_z80_read) {
@@ -2109,7 +2105,16 @@ static void iomoon_ball_command(UINT8 cmd) {
  * play", balls = its "Balls" setting (0 = model off) */
 static void iomoon_ball_update(int balls, int shoot, int drain) {
   UINT8 bits;
-  if (balls <= 0) { iomoon_balls.seeded = 0; return; }   /* frontend owns the trough */
+  /* "Balls" = 0 turns the model off for a frontend that drives these contacts itself.
+   * Drop the whole state, not just the seeded flag: a half-finished serve left behind
+   * would be applied to the first frame after the setting is turned back on */
+  if (balls <= 0) { iomoon_ball_reset(); return; }
+  /* Fewer than three cannot work and is not a machine state a user should be able to
+   * select by accident: the trough test sub_2C1F only ever clears with three adjacent
+   * contacts closed, so a two-ball trough leaves command 0xEF (Z80 2BC7) looping with no
+   * give-up path -- which is what a real cabinet missing a ball does, but a UI setting
+   * should not brick the emulation.  Clamp up; 0 above is the deliberate way off */
+  if (balls < IOMOON_TROUGH_MAX) balls = IOMOON_TROUGH_MAX;
   if (!iomoon_balls.seeded) {
     iomoon_balls.seeded   = 1;
     iomoon_balls.inTrough = balls > IOMOON_TROUGH_MAX ? IOMOON_TROUGH_MAX : balls;

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1213,7 +1213,17 @@ static WRITE_HANDLER(sleic2_periph_w) {
                  * (D022A/D0243) -- the inbound NMI handler asserts bits 7/6/4 but never
                  * bit 5 -- so its rising edge is the outbound strobe, and it arrives
                  * after the PCS1 write above.  Bit 3 (the old branch's "frame strobe")
-                 * is F13/Task 11's, not this one's */
+                 * is F13/Task 11's, not this one's.
+                 *
+                 * Bits 0-2 are deliberately ignored: sub_D03C0 / sub_D0401 bit-bang them
+                 * as a three-wire serial port (CS, U/D, INC) for the X9C503P digital
+                 * potentiometer IC63, which is the service menu's VOLUME page.  That part
+                 * is an ANALOGUE attenuator on the YM3014B's output, not a register the
+                 * sound core has: PinMAME has no device for it, and the mixer level here
+                 * is the driver's own MDRV volume.  The page still works -- it draws its
+                 * bar and stores the setting in NVRAM 0x1BC-0x1BE (sub_D098C) -- it just
+                 * does not change what comes out, and modelling it would mean scaling the
+                 * YM3812 channel by a wiper position the schematic has not been read for */
       if ((data & 0x20) && !(iomoon_j1.pcs4 & 0x20)) {
         iomoon_j1.toZ80Full = 1;
         cpu_set_irq_line(SLEIC_IO_CPU, IRQ_LINE_NMI, PULSE_LINE); /* Z80 handler 0x0066 */

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -299,6 +299,19 @@ static INTERRUPT_GEN(sleic1_irq_gen) {
  * and it is independently what the reverse-engineering side's sample extractor
  * (scripts/extract-oki-msm6376.py) defaults to.
  *
+ * That ~1 % clock question is NOT the whole error budget, and the other branch is a factor
+ * of two rather than a trim.  This rate is measured in timer-0 TICKS, so it inherits
+ * IOMOON_T0_MAXCOUNT's open ALT-mode assumption as well: if the part interrupts only on max
+ * count B, IOMOON_TIMER0_HZ halves to 49.59 Hz, every duration above doubles in seconds and
+ * the derived rate lands at ~15.9 kHz -- i.e. 16 000, itself a standard 6376 strapping and
+ * the neighbourhood Sleic Pin-Ball's interface already sits in (15 151).  The two branches
+ * are audibly distinct and the owner's sound checkpoint separates them by ear:
+ *     speech roughly right but slightly sharp   -> the clock branch; trim 32000 -> 31250
+ *     speech an OCTAVE high (and half as long)  -> the ALT-mode branch; set ~16000 here AND
+ *                                                  revisit IOMOON_TIMER0_HZ, which is then
+ *                                                  wrong by the same factor everywhere else
+ * That second outcome would be a finding about the timer, not about the OKI.
+ *
  * It is stated here rather than reusing SLEIC_okim6376_intf2's 4000000/132: that divisor is
  * the OKIM6295's (pin 7) and belongs to Bike Race's interface, it is 4.7 % slow against the
  * measurement above, and sharing the struct would mean any pitch correction from the owner's
@@ -1156,6 +1169,13 @@ static void iomoon_oki_strobe(void) {
   /* CH2 -> the core's voice bit: bit 4 = voice 0, bit 5 = voice 1 (adpcm.c, data >> 4) */
   const UINT8 voice  = (iomoon_oki_latch & 0x80) ? 1 : 0;
 
+  /* The test is on the PHRASE, not on the whole latch, and the two are the same test here:
+   * the only latch value with phrase 0 that sub_D0CB8 can leave is 0x00 itself, because the
+   * one other way phrase 0 could reach a trigger routine -- sound command 0 -- is intercepted
+   * by the dispatcher at D0B92, which substitutes a random sample from CS:0C19 instead of
+   * passing 0 through.  Testing the phrase is kept because it is also the right answer for
+   * the value that cannot occur: a phrase-0 start is silence on the chip too, its table
+   * entry being null */
   if (!phrase) {                      /* sub_D0CB8: latch 0, ST low -- silence both */
     OKIM6376_data_0_w(0, 0x18);       /* no command pending -> bits 3,4 = stop voices 0,1 */
     return;

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1668,10 +1668,11 @@ MEMORY_END
  *              of F5's open gap, so the honest model is "not fitted" rather than a
  *              guessed wiring.  Turning it on is a one-bit change once that is known.
  *   bit 5 = 0  makes the command-0xED handler 2BEB answer 0x45 at once (IN ($04) / BIT 5 /
- *              JP Z,2C17).  The service manual's SW40 list (section 7.2.2.3) has exactly
- *              this function on SW5, "servicio: no se dispensan bolas" / no balls
- *              dispensed, which is documentary confirmation of what the branch is for
- *              even though the manual gives no bit numbers.
+ *              JP Z,2C17).  The service manual's SW40 list (section 7.2.2.3) has a switch
+ *              with exactly this function, SW5 "servicio: no se dispensan bolas" / no
+ *              balls dispensed.  That the FUNCTION matches is a good sign the branch is
+ *              understood; it is NOT proof that SW5 is this bit, because the manual gives
+ *              no bit numbers and only SW2-SW4's positions have been established.
  *              With bit 5 SET the handler instead loops -- strobe column 0,
  *              check the trough contacts, run the eject coil sequence sub_2CFB, repeat --
  *              and its ONLY exit is those contacts closing.  That is correct hardware
@@ -1712,7 +1713,9 @@ MEMORY_END
  * wins, the NVRAM is rewritten and the preset re-applied.  Country 5 additionally selects
  * the Spanish string and menu tables (D3277, D8048, DD406); every other value is English.
  * So this one DIP sets both the coinage and the language, exactly as the service manual's
- * "country code" row implies.
+ * "country code" row implies.  Which of SW2/SW4 is the low bit is settled by the presets
+ * themselves, not by the UK and Spain rows (both are palindromes and survive a reversal);
+ * sleic.h carries the eight-row comparison and the three rows a reversal would break.
  *
  * The other five bits stay in IOMOON_PORT04_IDLE.  Bit 5 in particular must stay 0 for
  * the reason above -- the manual's SW5 "servicio: no se dispensan bolas" is the same

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -62,7 +62,21 @@
       COREPORT_DIPSET(0x0000, "0" ) \
       COREPORT_DIPSET(0x0080, "1" )
 
-/*-- Io Moon (SLEIC2) inports.  Same cabinet block, but its DIP block is the real SW40. \
+/*-- Io Moon adds one cabinet input the other machines have no use for: the ball drain.
+ * Its ball trough is modelled in the driver (SWITCH_UPDATE(SLEIC2)) because the firmware
+ * BLOCKS on it -- 80188 commands 0xE9/0xEF and the Z80 handlers 2B03/2BC7 wait on the
+ * column-0 trough contacts, and with no ball anywhere the Z80 never returns to its main
+ * loop.  The model does everything a ball does on its own except the one thing that is
+ * the player's (or a frontend's): when the ball in play drains.  This is that input.
+ * It is a NEW bit, 0x1000, appended after the shared block's 0x0800, so every existing
+ * binding keeps the bit it already had and a saved cfg stays valid.  Backspace because
+ * the MAME UI does not claim it and the keys a player uses are all taken. */
+#define SLEIC2_CABPORT \
+  SLEIC_CABPORT \
+    COREPORT_BIT(     0x1000, "Drain ball in play", KEYCODE_BACKSPACE)
+
+/*-- Io Moon (SLEIC2) inports.  Same cabinet block plus the drain, but its DIP block is \
+ * the real SW40. \
  * \
  * Read as PinMAME DIP bank 0 (core_getDip(0)); only SLEIC2 reads it, which is why it is \
  * a separate macro -- the sister machines' Z80 ROMs were never traced for SW40 and keep \
@@ -125,7 +139,7 @@
  * Io Moon was built for and the path the ROM exercises most (its own pricing routine \
  * sub_DCD9E and the only fourth coin value). */ \
 #define SLEIC2_COMPORTS \
-  SLEIC_CABPORT \
+  SLEIC2_CABPORT \
   PORT_START /* 1 */ \
     COREPORT_DIPNAME( 0x0001, 0x0001, "SW40-1 VDB watchdog (not modelled)") \
       COREPORT_DIPSET(0x0000, "On (watchdog disabled)" ) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -32,31 +32,51 @@
     COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 */ \
     COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 */ \
     COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14). F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
+  /* DIP block SW40 on the Z80 I/O board, read as PinMAME DIP bank 0 (core_getDip(0)). \
+   * The FUNCTIONS are the Io Moon service manual's, section 7.2.2.3: SW1 VDB solenoid \
+   * watchdog, SW2-SW4 country code, SW5 "no balls dispensed", SW6 solenoid test, SW7 \
+   * lamp test, SW8 board self-test.  The switch -> BIT assignment is only established \
+   * for SW2-SW4, and it is established from the ROM rather than the manual, which gives \
+   * no bit numbers: Z80 command 0xF9 -> handler 2D9D reads port 0x04 and sends the low \
+   * nibble back as 0xF0|nibble, and the 80188 turns bits 1-3 of it into a country number \
+   * 0..7 (D5CA3-D5CC2, seven-way table at D5D01).  Only SLEIC2 reads any of this; the \
+   * sister machines' Z80 ROMs were not traced for it, so the rest stay plain switches. \
+   * \
+   * COUNTRY is what the manual calls the coin-value setting, and it is more than that: \
+   * it picks the pricing preset (sub_D69CC -> one of eight, saved to NVRAM 0x1C4-0x1CF) \
+   * AND the display LANGUAGE, because value 5 selects the Spanish string and menu-record \
+   * tables at three sites (D3277 attract, D8048 pricing, DD406 menu records) while every \
+   * other value gets the English ones.  Two independent checks anchor the manual's row \
+   * order to the value: value 0 (all three ON) loads exactly the manual's UK column \
+   * (30p/1, 50p/2, GBP1/5 -> divisors 3/5/10, credits 1/2/5 at D6D36), and the manual's \
+   * Spain row is SW2 OFF / SW3 ON / SW4 OFF, which with ON = 0 and SW2 as the low bit is \
+   * value 5 -- the one value the ROM special-cases.  ON = 0 is the ordinary closed-switch \
+   * convention and the Z80 reads port 0x04 without inverting it. */ \
   PORT_START /* 1 */ \
-    COREPORT_DIPNAME( 0x0001, 0x0000, "S1") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0001, "1" ) \
-    COREPORT_DIPNAME( 0x0002, 0x0000, "S2") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0002, "1" ) \
-    COREPORT_DIPNAME( 0x0004, 0x0000, "S3") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0004, "1" ) \
-    COREPORT_DIPNAME( 0x0008, 0x0000, "S4") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0008, "1" ) \
-    COREPORT_DIPNAME( 0x0010, 0x0000, "S5") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0010, "1" ) \
-    COREPORT_DIPNAME( 0x0020, 0x0000, "S6") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0020, "1" ) \
-    COREPORT_DIPNAME( 0x0040, 0x0000, "S7") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0040, "1" ) \
-    COREPORT_DIPNAME( 0x0080, 0x0000, "S8") \
-      COREPORT_DIPSET(0x0000, "0" ) \
-      COREPORT_DIPSET(0x0080, "1" )
+    COREPORT_DIPNAME( 0x0001, 0x0001, "SW40-1 (VDB watchdog)") \
+      COREPORT_DIPSET(0x0000, "On" ) \
+      COREPORT_DIPSET(0x0001, "Off" ) \
+    COREPORT_DIPNAME( 0x000e, 0x000e, "SW40-2/3/4 Country") \
+      COREPORT_DIPSET(0x0000, "United Kingdom" ) \
+      COREPORT_DIPSET(0x0002, "France" ) \
+      COREPORT_DIPSET(0x0004, "Germany" ) \
+      COREPORT_DIPSET(0x0006, "Italy" ) \
+      COREPORT_DIPSET(0x0008, "Netherlands" ) \
+      COREPORT_DIPSET(0x000a, "Spain (Spanish text)" ) \
+      COREPORT_DIPSET(0x000c, "Belgium" ) \
+      COREPORT_DIPSET(0x000e, "Portugal" ) \
+    COREPORT_DIPNAME( 0x0010, 0x0000, "SW40-5") \
+      COREPORT_DIPSET(0x0000, "On" ) \
+      COREPORT_DIPSET(0x0010, "Off" ) \
+    COREPORT_DIPNAME( 0x0020, 0x0000, "SW40-6") \
+      COREPORT_DIPSET(0x0000, "On" ) \
+      COREPORT_DIPSET(0x0020, "Off" ) \
+    COREPORT_DIPNAME( 0x0040, 0x0000, "SW40-7") \
+      COREPORT_DIPSET(0x0000, "On" ) \
+      COREPORT_DIPSET(0x0040, "Off" ) \
+    COREPORT_DIPNAME( 0x0080, 0x0000, "SW40-8") \
+      COREPORT_DIPSET(0x0000, "On" ) \
+      COREPORT_DIPSET(0x0080, "Off" )
 
 /*-- Standard input ports --*/
 #define SLEIC_INPUT_PORTS_START(name,balls) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -9,8 +9,8 @@
 /--------------------------*/
 #define SLEIC_ROMEND    ROM_END
 
-/*-- Common Inports for SLEIC Games --*/
-#define SLEIC_COMPORTS \
+/*-- Playfield keys and cabinet buttons, shared by every SLEIC machine --*/
+#define SLEIC_CABPORT \
   PORT_START /* 0 */ \
     /* Switch Column 1 / direct switches port 0x00 on Io Moon */ \
     COREPORT_BIT(     0x0001, "Key 1 / L Flipper", KEYCODE_LSHIFT) \
@@ -32,49 +32,121 @@
     COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 */ \
     COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 */ \
     COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14). F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
-  /* DIP block SW40 on the Z80 I/O board, read as PinMAME DIP bank 0 (core_getDip(0)). \
-   * The FUNCTIONS are the Io Moon service manual's, section 7.2.2.3: SW1 VDB solenoid \
-   * watchdog, SW2-SW4 country code, SW5 "no balls dispensed", SW6 solenoid test, SW7 \
-   * lamp test, SW8 board self-test.  The switch -> BIT assignment is only established \
-   * for SW2-SW4, and it is established from the ROM rather than the manual, which gives \
-   * no bit numbers: Z80 command 0xF9 -> handler 2D9D reads port 0x04 and sends the low \
-   * nibble back as 0xF0|nibble, and the 80188 turns bits 1-3 of it into a country number \
-   * 0..7 (D5CA3-D5CC2, seven-way table at D5D01).  Only SLEIC2 reads any of this; the \
-   * sister machines' Z80 ROMs were not traced for it, so the rest stay plain switches. \
-   * \
-   * COUNTRY is what the manual calls the coin-value setting, and it is more than that: \
-   * it picks the pricing preset (sub_D69CC -> one of eight, saved to NVRAM 0x1C4-0x1CF) \
-   * AND the display LANGUAGE, because value 5 selects the Spanish string and menu-record \
-   * tables at three sites (D3277 attract, D8048 pricing, DD406 menu records) while every \
-   * other value gets the English ones.  Two independent checks anchor the manual's row \
-   * order to the value: value 0 (all three ON) loads exactly the manual's UK column \
-   * (30p/1, 50p/2, GBP1/5 -> divisors 3/5/10, credits 1/2/5 at D6D36), and the manual's \
-   * Spain row is SW2 OFF / SW3 ON / SW4 OFF, which with ON = 0 and SW2 as the low bit is \
-   * value 5 -- the one value the ROM special-cases.  ON = 0 is the ordinary closed-switch \
-   * convention and the Z80 reads port 0x04 without inverting it. */ \
+
+/*-- Common Inports for SLEIC games whose DIP block has not been traced --*/
+#define SLEIC_COMPORTS \
+  SLEIC_CABPORT \
   PORT_START /* 1 */ \
-    COREPORT_DIPNAME( 0x0001, 0x0001, "SW40-1 (VDB watchdog)") \
-      COREPORT_DIPSET(0x0000, "On" ) \
-      COREPORT_DIPSET(0x0001, "Off" ) \
-    COREPORT_DIPNAME( 0x000e, 0x000e, "SW40-2/3/4 Country") \
+    COREPORT_DIPNAME( 0x0001, 0x0000, "S1") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0001, "1" ) \
+    COREPORT_DIPNAME( 0x0002, 0x0000, "S2") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0002, "1" ) \
+    COREPORT_DIPNAME( 0x0004, 0x0000, "S3") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0004, "1" ) \
+    COREPORT_DIPNAME( 0x0008, 0x0000, "S4") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0008, "1" ) \
+    COREPORT_DIPNAME( 0x0010, 0x0000, "S5") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0010, "1" ) \
+    COREPORT_DIPNAME( 0x0020, 0x0000, "S6") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0020, "1" ) \
+    COREPORT_DIPNAME( 0x0040, 0x0000, "S7") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0040, "1" ) \
+    COREPORT_DIPNAME( 0x0080, 0x0000, "S8") \
+      COREPORT_DIPSET(0x0000, "0" ) \
+      COREPORT_DIPSET(0x0080, "1" )
+
+/*-- Io Moon (SLEIC2) inports.  Same cabinet block, but its DIP block is the real SW40. \
+ * \
+ * Read as PinMAME DIP bank 0 (core_getDip(0)); only SLEIC2 reads it, which is why it is \
+ * a separate macro -- the sister machines' Z80 ROMs were never traced for SW40 and keep \
+ * the plain S1..S8 above rather than showing labels they do not honour. \
+ * \
+ * The FUNCTIONS are the Io Moon service manual's, section 7.2.2.3: SW1 VDB solenoid \
+ * watchdog, SW2-SW4 country code, SW5 "no balls dispensed", SW6 solenoid test, SW7 lamp \
+ * test, SW8 board self-test.  Only SW2-SW4 is wired here, and only it is established \
+ * from the ROM -- the manual gives no bit numbers.  Z80 command 0xF9 -> handler 2D9D \
+ * reads port 0x04 and sends the low nibble back as 0xF0|nibble; the 80188 turns bits 1-3 \
+ * of it into a country number 0..7 (D5CA3-D5CC2, seven-way table at D5D01). \
+ * \
+ * COUNTRY is what the manual calls the coin-value setting, and it is more than that: it \
+ * picks the pricing preset (sub_D69CC -> one of eight, saved to NVRAM 0x1C4-0x1CF) AND \
+ * the display LANGUAGE, because value 5 selects the Spanish string and menu-record \
+ * tables at three sites (D3277 attract, D8048 pricing, DD406 menu records) while every \
+ * other value gets the English ones. \
+ * \
+ * WHICH SWITCH IS THE LOW BIT is decided by the presets, not by the two obvious \
+ * anchors.  Country 0 = the manual's UK row and country 5 = its Spain row are both \
+ * INVARIANT under reversing SW2 and SW4 (000 and 101 are palindromes), so neither \
+ * discriminates; so is Germany (010).  The rows that do are Italy, Netherlands, France \
+ * and Belgium, and with SW2 as the LOW bit the presets read out of the emulator match \
+ * the manual on six of the eight rows: \
+ * \
+ *   value  divisors (pulses)  credits      manual row     verdict \
+ *     0        3 / 5 / 10      1 / 2 / 5   United Kingdom exact \
+ *     1        2 / 5 / 10      1 / 3 / 7   France         DOES NOT MATCH (manual 3/5/10, 1/2/5) \
+ *     2        1 / 2 / 5       1 / 3 / 8   Germany        exact \
+ *     3        1 / 2 / 4       1 / 3 / 7   Italy          exact \
+ *     4        2 / 5 / 10      1 / 3 / 7   Netherlands    exact \
+ *     5      2 / 4 / 8 / 20  1 / 3 / 7 / 18 Spain         coins exact, 3rd credit 7 vs 8 \
+ *     6        2 / 4 / 10      1 / 3 / 8   Belgium        DOES NOT MATCH (manual 2/5/10, 1/3/7) \
+ *     7        1 / 2 / 4       1 / 3 / 6   Portugal       coins exact, 3rd credit 6 vs 7 \
+ * \
+ * Reverse SW2 and SW4 and three of those four discriminating rows break: value 3 would \
+ * be Belgium (2/5/10 against the ROM's 1/2/4), value 4 France (3/5/10 against 2/5/10) \
+ * and value 6 Italy (1/2/4 against 2/4/10), buying only Netherlands at value 1.  Six \
+ * matching rows against three broken ones settles it: SW2 is the low bit, ON = 0, which \
+ * is also the ordinary closed-switch convention and how the Z80 reads port 0x04 (no \
+ * inversion).  Values 1 and 6 are labelled for their manual ROW; the coin values the \
+ * ROM actually loads there are not the manual's, and value 1 is a duplicate of value 4. \
+ * \
+ * DEFAULT is United Kingdom -- country 0, SW2/SW3/SW4 all ON, DIP value 0x0000 -- by \
+ * OWNER PREFERENCE: English text.  Country 5 is the only value that selects the Spanish \
+ * tables, so any other value gives English; 0 is picked because it is the only English \
+ * one whose preset matches the manual exactly, 30p/1, 50p/2, GBP1/5 = divisors 3/5/10 \
+ * and credits 1/2/5, with none of the France/Belgium coin-value discrepancies and no \
+ * off-by-one credit like Portugal's.  So the English default also comes with correct \
+ * documented pricing, at the cost of three coin pulses per credit rather than one. \
+ * Verified end to end at this setting: country byte 0, preset 3/5/10 and 1/2/5, menu \
+ * record table 0x0100, and the DMD drawing ADJUSTMENT / SOUND-VIDEO / GAME / TECHNICAL. \
+ * Note country 0 reaches its preset through two fall-through paths -- the country table \
+ * at D5D01 is indexed from 2 so a nibble of 0 lands on D5CF8's "country 0", and \
+ * sub_D69CC's bounds check sends 0 to the default preset sub_D6D36 -- which is by \
+ * design, not an accident: D6D36 IS the UK column. \
+ * Set Spain if the machine being compared against is a Spanish one; that is the market \
+ * Io Moon was built for and the path the ROM exercises most (its own pricing routine \
+ * sub_DCD9E and the only fourth coin value). */ \
+#define SLEIC2_COMPORTS \
+  SLEIC_CABPORT \
+  PORT_START /* 1 */ \
+    COREPORT_DIPNAME( 0x0001, 0x0001, "SW40-1 VDB watchdog (not modelled)") \
+      COREPORT_DIPSET(0x0000, "On (watchdog disabled)" ) \
+      COREPORT_DIPSET(0x0001, "Off (watchdog enabled)" ) \
+    COREPORT_DIPNAME( 0x000e, 0x0000, "SW40-2/3/4 Country") \
       COREPORT_DIPSET(0x0000, "United Kingdom" ) \
-      COREPORT_DIPSET(0x0002, "France" ) \
+      COREPORT_DIPSET(0x0002, "France (ROM coins differ)" ) \
       COREPORT_DIPSET(0x0004, "Germany" ) \
       COREPORT_DIPSET(0x0006, "Italy" ) \
       COREPORT_DIPSET(0x0008, "Netherlands" ) \
       COREPORT_DIPSET(0x000a, "Spain (Spanish text)" ) \
-      COREPORT_DIPSET(0x000c, "Belgium" ) \
+      COREPORT_DIPSET(0x000c, "Belgium (ROM coins differ)" ) \
       COREPORT_DIPSET(0x000e, "Portugal" ) \
-    COREPORT_DIPNAME( 0x0010, 0x0000, "SW40-5") \
+    COREPORT_DIPNAME( 0x0010, 0x0000, "SW40-5 no balls dispensed (not modelled)") \
       COREPORT_DIPSET(0x0000, "On" ) \
       COREPORT_DIPSET(0x0010, "Off" ) \
-    COREPORT_DIPNAME( 0x0020, 0x0000, "SW40-6") \
+    COREPORT_DIPNAME( 0x0020, 0x0000, "SW40-6 solenoid test (not modelled)") \
       COREPORT_DIPSET(0x0000, "On" ) \
       COREPORT_DIPSET(0x0020, "Off" ) \
-    COREPORT_DIPNAME( 0x0040, 0x0000, "SW40-7") \
+    COREPORT_DIPNAME( 0x0040, 0x0000, "SW40-7 lamp test (not modelled)") \
       COREPORT_DIPSET(0x0000, "On" ) \
       COREPORT_DIPSET(0x0040, "Off" ) \
-    COREPORT_DIPNAME( 0x0080, 0x0000, "SW40-8") \
+    COREPORT_DIPNAME( 0x0080, 0x0000, "SW40-8 board self-test (not modelled)") \
       COREPORT_DIPSET(0x0000, "On" ) \
       COREPORT_DIPSET(0x0080, "Off" )
 
@@ -84,6 +156,12 @@
     CORE_PORTS \
     SIM_PORTS(balls) \
     SLEIC_COMPORTS
+
+#define SLEIC2_INPUT_PORTS_START(name,balls) \
+  INPUT_PORTS_START(name) \
+    CORE_PORTS \
+    SIM_PORTS(balls) \
+    SLEIC2_COMPORTS
 
 #define SLEIC_INPUT_PORTS_END INPUT_PORTS_END
 

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -113,8 +113,10 @@
  * and credits 1/2/5, with none of the France/Belgium coin-value discrepancies and no \
  * off-by-one credit like Portugal's.  So the English default also comes with correct \
  * documented pricing, at the cost of three coin pulses per credit rather than one. \
- * Verified end to end at this setting: country byte 0, preset 3/5/10 and 1/2/5, menu \
- * record table 0x0100, and the DMD drawing ADJUSTMENT / SOUND-VIDEO / GAME / TECHNICAL. \
+ * Verified end to end at this setting, from the DIP rather than a probe override: country \
+ * byte 0, preset 3/5/10 and 1/2/5, menu record table 0x0100, the DMD drawing ADJUSTMENT / \
+ * SOUND-VIDEO / GAME / TECHNICAL, and coin -> credit -> START -> mode 3 -> song 1 \
+ * (scratchpad logs t16/dip-uk-default.log, t16/uk-full.log and t16/fixround-final.log). \
  * Note country 0 reaches its preset through two fall-through paths -- the country table \
  * at D5D01 is indexed from 2 so a nibble of 0 lands on D5CF8's "country 0", and \
  * sub_D69CC's bounds check sends 0 to the default preset sub_D6D36 -- which is by \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -230,14 +230,14 @@
       COREPORT_DIPSET(0x0000, "On (0xED answers at once, no ball check)" ) \
       COREPORT_DIPSET(0x0010, "Off (normal play)" ) \
     COREPORT_DIPNAME( 0x0020, 0x0000, "SW40-6 solenoid test (not modelled)") \
-      COREPORT_DIPSET(0x0000, "On" ) \
-      COREPORT_DIPSET(0x0020, "Off" ) \
+      COREPORT_DIPSET(0x0020, DEF_STR( Off ) ) \
+      COREPORT_DIPSET(0x0000, DEF_STR( On ) ) \
     COREPORT_DIPNAME( 0x0040, 0x0000, "SW40-7 lamp test (not modelled)") \
-      COREPORT_DIPSET(0x0000, "On" ) \
-      COREPORT_DIPSET(0x0040, "Off" ) \
+      COREPORT_DIPSET(0x0040, DEF_STR( Off ) ) \
+      COREPORT_DIPSET(0x0000, DEF_STR( On ) ) \
     COREPORT_DIPNAME( 0x0080, 0x0000, "SW40-8 board self-test (not modelled)") \
-      COREPORT_DIPSET(0x0000, "On" ) \
-      COREPORT_DIPSET(0x0080, "Off" )
+      COREPORT_DIPSET(0x0080, DEF_STR( Off ) ) \
+      COREPORT_DIPSET(0x0000, DEF_STR( On ) )
 
 /*-- Standard input ports --*/
 #define SLEIC_INPUT_PORTS_START(name,balls) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -9,20 +9,46 @@
 /--------------------------*/
 #define SLEIC_ROMEND    ROM_END
 
-/*-- Playfield keys and cabinet buttons, shared by every SLEIC machine --*/
+/*-- Cabinet buttons, shared by every SLEIC machine.
+ *
+ * KEY MAP (all three machines; Io Moon adds one more, see SLEIC2_CABPORT):
+ *
+ *   Left Shift   left flipper        Right Shift  right flipper
+ *   1            start               5            coin
+ *   T            tilt                7            test / service menu
+ *
+ * That is the PinMAME convention throughout: Left/Right Shift are the flippers in
+ * CORE_PORTS itself, 1/5/T are MAME's own IPT_START1 / IPT_COIN1 / IPT_TILT defaults
+ * (inptport.c), and 7 is the test/self-test/diagnostic button in by35, by6803, gts1,
+ * gts3, atari, alvg, ltd, zac and spinb.  These machines used to put test on End
+ * instead; across PinMAME End is a coin-door-class TOGGLE (Coin Door in wpc/gts3,
+ * Memory Protect in se, Ticket in alvg), not a momentary test button, so it moved to 7.
+ * A saved .cfg keeps whatever binding it was saved with, so delete the game's file in
+ * cfg/ to pick the new default up.
+ *
+ * There is no separate 8/9/0 service cluster because these machines have no separate
+ * service buttons: the service menu is walked with the flipper buttons, which is what
+ * the cabinet does.  Io Moon sends codes 0x41/0x42 for them and sub_DD480's dispatch at
+ * DD501 uses those as scroll and select (F14); Bike Race and Sleic Pin-Ball do the same
+ * with their own codes.
+ *
+ * Six further entries used to sit here -- "Key 3".."Key 8" on keys 3..8, feeding
+ * swMatrix[0] through the base SWITCH_UPDATE(SLEIC).  Every machine replaces that
+ * handler (SLEIC1/SLEIC2/SLEIC3 each map their own cabinet block into swMatrix[9]), so
+ * nothing ever read them, and two of them clashed with keys that have a job: key 5 is
+ * MAME's coin key, and keys 7/8 are the service keys.  They are gone; the bits they had
+ * (0x0004-0x0080) are simply unused, so every other binding keeps the mask it had and a
+ * saved cfg stays valid.  The playfield contacts are NOT here either -- each machine
+ * maps its own matrix with its own key table (iomoon_pf_keys, sleic1_pf_keys,
+ * sleic3_pf_keys), which is what lets the contact self-test exercise every position.
+ *
+ * Bits 0/1 are the flipper BUTTONS, read as cabinet inputs (Io Moon swMatrix[9] bits
+ * 3/2); on Io Moon port 0x00 IN is the J1 inbound byte, not a switch-matrix read.
+ --*/
 #define SLEIC_CABPORT \
   PORT_START /* 0 */ \
-    /* Switch Column 1 direct switches on Bike Race / Sleic Pin-Ball; on Io Moon, Keys 1/2 \
-     * are the cabinet flipper inputs (swMatrix[9] bits 3/2) -- port 0x00 IN there is the \
-     * J1 inbound byte, not a switch-matrix read */ \
-    COREPORT_BIT(     0x0001, "Key 1 / L Flipper", KEYCODE_LSHIFT) \
-    COREPORT_BIT(     0x0002, "Key 2 / R Flipper", KEYCODE_RSHIFT) \
-    COREPORT_BIT(     0x0004, "Key 3",     KEYCODE_3) \
-    COREPORT_BIT(     0x0008, "Key 4",     KEYCODE_4) \
-    COREPORT_BIT(     0x0010, "Key 5",     KEYCODE_5) \
-    COREPORT_BIT(     0x0020, "Key 6",     KEYCODE_6) \
-    COREPORT_BIT(     0x0040, "Key 7",     KEYCODE_7) \
-    COREPORT_BIT(     0x0080, "Key 8",     KEYCODE_8) \
+    COREPORT_BIT(     0x0001, "L Flipper", KEYCODE_LSHIFT) \
+    COREPORT_BIT(     0x0002, "R Flipper", KEYCODE_RSHIFT) \
     /* Cabinet buttons.  Every SLEIC machine here reads them on Z80 port 0x03 and every \
      * SWITCH_UPDATE handler below maps them into swMatrix[9], one bit per button, in the \
      * same bit order: 0 = TILT, 1 = TEST, 2 = right flipper, 3 = left flipper, 4 = START, \
@@ -30,10 +56,10 @@
      * 0x3E/0x3F/0x42/0x41/0x40/0x32), so the per-driver handler is the place that names \
      * them; see SWITCH_UPDATE(SLEIC2) for what the Io Moon firmware does with each. \
      * Nothing is mapped into swMatrix[10] (Io Moon's port-0x04 config byte). */ \
-    COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].4 */ \
-    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 */ \
-    COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 */ \
-    COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14). F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
+    COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].4 (key 1) */ \
+    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 (key 5) */ \
+    COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 (key T) */ \
+    COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_7) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14) */ \
 
 /*-- Common Inports for SLEIC games whose DIP block has not been traced --*/
 #define SLEIC_COMPORTS \
@@ -72,7 +98,10 @@
  * the player's (or a frontend's): when the ball in play drains.  This is that input.
  * It is a NEW bit, 0x1000, appended after the shared block's 0x0800, so every existing
  * binding keeps the bit it already had and a saved cfg stays valid.  Backspace because
- * the MAME UI does not claim it and the keys a player uses are all taken. */
+ * the MAME UI does not claim it and it is not a key the cabinet map or the PinMAME
+ * service convention wants: the digits the retired "Key 3".."Key 8" entries freed are
+ * left unbound on purpose, since 8/9/0 are where PinMAME puts service buttons and this
+ * machine has none. */
 #define SLEIC2_CABPORT \
   SLEIC_CABPORT \
     COREPORT_BIT(     0x1000, "Drain ball in play", KEYCODE_BACKSPACE)

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -100,20 +100,29 @@
       COREPORT_DIPSET(0x0080, "1" )
 
 /*-- Io Moon adds one cabinet input the other machines have no use for: the ball drain.
- * Its ball trough is modelled in the driver (SWITCH_UPDATE(SLEIC2)) because the firmware
- * BLOCKS on it -- 80188 commands 0xE9/0xEF and the Z80 handlers 2B03/2BC7 wait on the
- * column-0 trough contacts, and with no ball anywhere the Z80 never returns to its main
- * loop.  The model does everything a ball does on its own except the one thing that is
- * the player's (or a frontend's): when the ball in play drains.  This is that input.
- * It is a NEW bit, 0x1000, appended after the shared block's 0x0800, so every existing
- * binding keeps the bit it already had and a saved cfg stays valid.  Backspace because
- * the MAME UI does not claim it and it is not a key the cabinet map or the PinMAME
- * service convention wants: the digits the retired "Key 3".."Key 8" entries freed are
- * left unbound on purpose, since 8/9/0 are where PinMAME puts service buttons and this
- * machine has none. */
+ * It belongs to the driver's OPTIONAL internal trough model (SWITCH_UPDATE(SLEIC2)), and
+ * that model is OFF BY DEFAULT -- so by default this key does nothing at all.
+ *
+ * Why the model exists: the firmware BLOCKS on the trough contacts -- 80188 commands
+ * 0xE9/0xEF and the Z80 handlers 2B03/2BC7 wait on the column-0 contacts, and with no
+ * ball anywhere the Z80 never returns to its main loop.  Why it is not the default:
+ * PinMAME's convention is that the FRONTEND closes switches, and swMatrix[1] bits 0-3
+ * are ordinary switches a VPinMAME table script (or, standalone, the Q/W/E/R matrix test
+ * keys) drives.  A driver that seeds balls invents state the frontend then fights.
+ *
+ * The opt-in knob is the standard simulator port's "Balls" setting, in SIM_PORTS below:
+ * 0 (the default) = model off, frontend-driven; 3 = the internal three-ball model, for
+ * standalone desktop play.  With it at 0 this input and "Shoot Ball" are both INERT --
+ * iomoon_ball_update returns before it reads either -- so nothing is half-live.
+ *
+ * The bit is 0x1000, appended after the shared block's 0x0800, so every existing binding
+ * keeps the bit it already had.  Backspace because the MAME UI does not claim it and it
+ * is not a key the cabinet map or the PinMAME service convention wants: the digits the
+ * retired "Key 3".."Key 8" entries freed are left unbound on purpose, since 8/9/0 are
+ * where PinMAME puts service buttons and this machine has none. */
 #define SLEIC2_CABPORT \
   SLEIC_CABPORT \
-    COREPORT_BIT(     0x1000, "Drain ball in play", KEYCODE_BACKSPACE)
+    COREPORT_BIT(     0x1000, "Drain ball (needs Balls=3)", KEYCODE_BACKSPACE)
 
 /*-- Io Moon (SLEIC2) inports.  Same cabinet block plus the drain, but its DIP block is \
  * the real SW40. \
@@ -237,6 +246,11 @@
     SIM_PORTS(balls) \
     SLEIC_COMPORTS
 
+/* Io Moon.  <balls> is SIM_PORTS' "Balls" default and, for this machine only, it doubles
+ * as the on/off switch for the driver's internal ball-trough model: sleicgames.c passes
+ * 0 for every Io Moon set, so the trough contacts are plain frontend-driven switches
+ * unless the operator sets "Balls" to 3.  See SLEIC2_CABPORT above and the trough
+ * comment in sleic.c */
 #define SLEIC2_INPUT_PORTS_START(name,balls) \
   INPUT_PORTS_START(name) \
     CORE_PORTS \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -21,13 +21,17 @@
     COREPORT_BIT(     0x0020, "Key 6",     KEYCODE_6) \
     COREPORT_BIT(     0x0040, "Key 7",     KEYCODE_7) \
     COREPORT_BIT(     0x0080, "Key 8",     KEYCODE_8) \
-    /* Io Moon direct switches port 0x03 IN (bit 3 = START, bit 2 = TEST / COIN) \
-     * and port 0x04 IN (bit 0 = TILT). Mapped into swMatrix[9] / swMatrix[10] \
-     * by the SLEIC2 driver's SWITCH_UPDATE handler. */ \
-    COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].3 */ \
-    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN/TEST -> swMatrix[9].2 */ \
-    COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT -> swMatrix[10].0 */ \
-    COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* Bike Race C4 Test = service-menu enter (code 0x33); F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
+    /* Cabinet buttons.  Every SLEIC machine here reads them on Z80 port 0x03 and every \
+     * SWITCH_UPDATE handler below maps them into swMatrix[9], one bit per button, in the \
+     * same bit order: 0 = TILT, 1 = TEST, 2 = right flipper, 3 = left flipper, 4 = START, \
+     * 5 = COIN.  The port-0x03 CODE each bit produces differs per machine (Io Moon F5: \
+     * 0x3E/0x3F/0x42/0x41/0x40/0x32), so the per-driver handler is the place that names \
+     * them; see SWITCH_UPDATE(SLEIC2) for what the Io Moon firmware does with each. \
+     * Nothing is mapped into swMatrix[10] (Io Moon's port-0x04 config byte). */ \
+    COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].4 */ \
+    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 */ \
+    COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 */ \
+    COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_END) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14). F2 is grabbed by MAME UI, End avoids stale-cfg unbinding */ \
   PORT_START /* 1 */ \
     COREPORT_DIPNAME( 0x0001, 0x0000, "S1") \
       COREPORT_DIPSET(0x0000, "0" ) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -73,6 +73,9 @@
 #define SLEIC_MEMREG_CPU     REGION_CPU1
 #define SLEIC_MEMREG_IO      REGION_CPU2
 #define SLEIC_MEMREG_DISPLAY REGION_CPU3
+/* Io Moon's graphics ROM: not CPU-addressable at a fixed address, it is paged into
+ * segment 6000 a 64 KB page at a time (findings F2), so it lives in its own region */
+#define SLEIC_MEMREG_GFX     REGION_USER2
 
 /* CPUs */
 #define SLEIC_MAIN_CPU    0
@@ -90,16 +93,27 @@ ROM_START(name) \
   NORMALREGION(0x100000, REGION_USER1) \
     ROM_LOAD(n2, 0x00000, 0x80000, chk2)
 
+/* Io Moon (SLEIC2).  The 80188 sees ROM1 (n1) through two chip selects that are not
+ * adjacent in its address space, so the image is placed twice in the CPU region:
+ *   LMCS 0x00000-0x3FFFF <- ROM1 file 0x00000-0x3FFFF (resident IVT + animation data)
+ *   UMCS 0xC0000-0xFFFFF <- ROM1 file 0x40000-0x7FFFF (all code, reset vector at FFFF0)
+ * The full image is loaded at 0x80000 (so file 0x40000 lands on 0xC0000) and its low
+ * 256 KB is reloaded at 0, which leaves 0x40000-0x7FFFF empty for the mid-range RAM
+ * windows to alias into.  The graphics ROM (n2) is NOT flat in the address space: it
+ * is paged one 64 KB page at a time into segment 6000 by PCS0 bits 0-2, so it stays
+ * in its own region and the driver banks it.  n3/n4 are the OKI sample ROMs, n5 the
+ * Z80 I/O ROM.  See findings F1/F2 */
 #define SLEIC_ROMSTART5(name, n1, chk1, n2, chk2, n3, chk3, n4, chk4, n5, chk5) \
 ROM_START(name) \
   NORMALREGION(0x100000, SLEIC_MEMREG_CPU) \
     ROM_LOAD(n1, 0x80000, 0x80000, chk1) \
+    ROM_RELOAD(  0x00000, 0x40000) \
   NORMALREGION(0x10000, SLEIC_MEMREG_IO) \
     ROM_LOAD(n5, 0x0000, 0x8000, chk5) \
   NORMALREGION(0x100000, REGION_USER1) \
     ROM_LOAD(n3, 0x00000, 0x80000, chk3) \
     ROM_LOAD(n4, 0x80000, 0x80000, chk4) \
-  NORMALREGION(0x100000, REGION_USER2) \
+  NORMALREGION(0x100000, SLEIC_MEMREG_GFX) \
     ROM_LOAD(n2, 0x00000, 0x80000, chk2)
 
 #define SLEIC_ROMSTART7(name, n1, chk1, n2, chk2, n3, chk3, n4, chk4, n5, chk5, n6, chk6, n7, chk7) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -153,9 +153,9 @@
       COREPORT_DIPSET(0x000a, "Spain (Spanish text)" ) \
       COREPORT_DIPSET(0x000c, "Belgium (ROM coins differ)" ) \
       COREPORT_DIPSET(0x000e, "Portugal" ) \
-    COREPORT_DIPNAME( 0x0010, 0x0000, "SW40-5 no balls dispensed (not modelled)") \
-      COREPORT_DIPSET(0x0000, "On" ) \
-      COREPORT_DIPSET(0x0010, "Off" ) \
+    COREPORT_DIPNAME( 0x0010, 0x0010, "SW40-5 Service: no balls dispensed") \
+      COREPORT_DIPSET(0x0000, "On (0xED answers at once, no ball check)" ) \
+      COREPORT_DIPSET(0x0010, "Off (normal play)" ) \
     COREPORT_DIPNAME( 0x0020, 0x0000, "SW40-6 solenoid test (not modelled)") \
       COREPORT_DIPSET(0x0000, "On" ) \
       COREPORT_DIPSET(0x0020, "Off" ) \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -12,7 +12,9 @@
 /*-- Playfield keys and cabinet buttons, shared by every SLEIC machine --*/
 #define SLEIC_CABPORT \
   PORT_START /* 0 */ \
-    /* Switch Column 1 / direct switches port 0x00 on Io Moon */ \
+    /* Switch Column 1 direct switches on Bike Race / Sleic Pin-Ball; on Io Moon, Keys 1/2 \
+     * are the cabinet flipper inputs (swMatrix[9] bits 3/2) -- port 0x00 IN there is the \
+     * J1 inbound byte, not a switch-matrix read */ \
     COREPORT_BIT(     0x0001, "Key 1 / L Flipper", KEYCODE_LSHIFT) \
     COREPORT_BIT(     0x0002, "Key 2 / R Flipper", KEYCODE_RSHIFT) \
     COREPORT_BIT(     0x0004, "Key 3",     KEYCODE_3) \
@@ -127,10 +129,9 @@
  * and credits 1/2/5, with none of the France/Belgium coin-value discrepancies and no \
  * off-by-one credit like Portugal's.  So the English default also comes with correct \
  * documented pricing, at the cost of three coin pulses per credit rather than one. \
- * Verified end to end at this setting, from the DIP rather than a probe override: country \
+ * Verified end to end at this setting, from the DIP default, not an override: country \
  * byte 0, preset 3/5/10 and 1/2/5, menu record table 0x0100, the DMD drawing ADJUSTMENT / \
- * SOUND-VIDEO / GAME / TECHNICAL, and coin -> credit -> START -> mode 3 -> song 1 \
- * (scratchpad logs t16/dip-uk-default.log, t16/uk-full.log and t16/fixround-final.log). \
+ * SOUND-VIDEO / GAME / TECHNICAL, and coin -> credit -> START -> mode 3 -> song 1. \
  * Note country 0 reaches its preset through two fall-through paths -- the country table \
  * at D5D01 is indexed from 2 so a nibble of 0 lands on D5CF8's "country 0", and \
  * sub_D69CC's bounds check sends 0 to the default preset sub_D6D36 -- which is by \

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -26,6 +26,15 @@
  * A saved .cfg keeps whatever binding it was saved with, so delete the game's file in
  * cfg/ to pick the new default up.
  *
+ * There is ONE coin key because the cabinet has ONE coin line: a single electronic
+ * mechanism on the door, wired to Z80 port 0x03 bit 5, and the only credit source in
+ * either ROM.  On Io Moon a press of it is a COIN, not a contact closure -- the mechanism
+ * answers a coin with a pulse train whose length is the coin's value, and the firmware
+ * prices pulses, so the driver emits that train (iomoon_coin_update in sleic.c).  One
+ * press therefore buys at least one credit under every country setting; the three coin
+ * VALUES the country switch selects are denominations on that same line, not three
+ * switches, so there is no coin 2 / coin 3 key to bind.
+ *
  * There is no separate 8/9/0 service cluster because these machines have no separate
  * service buttons: the service menu is walked with the flipper buttons, which is what
  * the cabinet does.  Io Moon sends codes 0x41/0x42 for them and sub_DD480's dispatch at
@@ -57,7 +66,7 @@
      * them; see SWITCH_UPDATE(SLEIC2) for what the Io Moon firmware does with each. \
      * Nothing is mapped into swMatrix[10] (Io Moon's port-0x04 config byte). */ \
     COREPORT_BITDEF(  0x0100, IPT_START1, IP_KEY_DEFAULT) /* START -> swMatrix[9].4 (key 1) */ \
-    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 (key 5) */ \
+    COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 (key 5); on Io Moon one press = one coin = a pulse train */ \
     COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 (key T) */ \
     COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_7) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14) */ \
 
@@ -151,16 +160,41 @@
  * inversion).  Values 1 and 6 are labelled for their manual ROW; the coin values the \
  * ROM actually loads there are not the manual's, and value 1 is a duplicate of value 4. \
  * \
- * DEFAULT is United Kingdom -- country 0, SW2/SW3/SW4 all ON, DIP value 0x0000 -- by \
- * OWNER PREFERENCE: English text.  Country 5 is the only value that selects the Spanish \
- * tables, so any other value gives English; 0 is picked because it is the only English \
- * one whose preset matches the manual exactly, 30p/1, 50p/2, GBP1/5 = divisors 3/5/10 \
- * and credits 1/2/5, with none of the France/Belgium coin-value discrepancies and no \
- * off-by-one credit like Portugal's.  So the English default also comes with correct \
- * documented pricing, at the cost of three coin pulses per credit rather than one. \
- * Verified end to end at this setting, from the DIP default, not an override: country \
- * byte 0, preset 3/5/10 and 1/2/5, menu record table 0x0100, the DMD drawing ADJUSTMENT / \
- * SOUND-VIDEO / GAME / TECHNICAL, and coin -> credit -> START -> mode 3 -> song 1. \
+ * WHAT ONE COIN BUYS, per setting, because that is what the country switch is FOR.  The \
+ * coin key inserts one coin of the smallest denomination the country accepts (SLEIC_CABPORT \
+ * above, and iomoon_coin_update in sleic.c for why a key is a coin and not a pulse), so \
+ * this column is what one press gives you on a fresh machine: \
+ * \
+ *   value  country          smallest coin    one press   two presses  three presses \
+ *     0    United Kingdom   30p  (3 pulses)     1 credit    2           3 \
+ *     1    France(ROM=NL)   2 pulses            1           2           3 \
+ *     2    Germany          1 DM (1 pulse)      1           3           4 \
+ *     3    Italy            500 L (1 pulse)     1           3           4 \
+ *     4    Netherlands      1 Fl (2 pulses)     1           2           3 \
+ *     5    Spain            50 pta (2 pulses)   1           3           4 \
+ *     6    Belgium          2 pulses            1           3           4 \
+ *     7    Portugal         50 Esc (1 pulse)    1           3           4 \
+ * \
+ * (No setting needs more than one press for the first credit, and none can: every preset's \
+ * smallest coin is worth at least one credit -- that is what a smallest coin IS.  The \
+ * later columns do not simply add up because the firmware prices the RUNNING PULSE TOTAL \
+ * greedily, largest coin first, so two 1 DM coins are priced as one 2 DM coin and pay the \
+ * 2 DM bonus -- that is the machine's own arithmetic (sub_DD03D), not a driver artefact. \
+ * The larger denominations are not separate keys because they are not separate switches; \
+ * see the coin comment in sleic.c.) \
+ * \
+ * DEFAULT is Netherlands -- country 4, SW2/SW3 ON and SW4 OFF, DIP value 0x0008 -- by \
+ * OWNER PREFERENCE, and it is the setting the owner's own cabinet ran: guilders, one coin \
+ * per game.  It is English text (country 5 is the only value that selects the Spanish \
+ * tables, so every other value is English) and its preset is one of the six that match \
+ * the service manual exactly -- 1 Fl/1, 2,5 Fl/3, 5 Fl/7 = 2/5/10 pulses for 1/3/7 \
+ * credits -- with none of the France/Belgium coin-value discrepancies and no off-by-one \
+ * credit like Spain's or Portugal's.  United Kingdom (0x0000) is equally exact and stays \
+ * one click away; it is not the default only because the machine this driver is compared \
+ * against is a Dutch one.  Verified end to end at the Netherlands default, from the DIP \
+ * rather than an override: country byte 4, preset 2/5/10 and 1/3/7, one coin key \
+ * press -> 1 credit, and START -> mode 3 -> song 1, with the DMD drawing the English \
+ * ADJUSTMENT / SOUND-VIDEO / GAME / TECHNICAL menu. \
  * Note country 0 reaches its preset through two fall-through paths -- the country table \
  * at D5D01 is indexed from 2 so a nibble of 0 lands on D5CF8's "country 0", and \
  * sub_D69CC's bounds check sends 0 to the default preset sub_D6D36 -- which is by \
@@ -174,7 +208,7 @@
     COREPORT_DIPNAME( 0x0001, 0x0001, "SW40-1 VDB watchdog (not modelled)") \
       COREPORT_DIPSET(0x0000, "On (watchdog disabled)" ) \
       COREPORT_DIPSET(0x0001, "Off (watchdog enabled)" ) \
-    COREPORT_DIPNAME( 0x000e, 0x0000, "SW40-2/3/4 Country") \
+    COREPORT_DIPNAME( 0x000e, 0x0008, "SW40-2/3/4 Country") \
       COREPORT_DIPSET(0x0000, "United Kingdom" ) \
       COREPORT_DIPSET(0x0002, "France (ROM coins differ)" ) \
       COREPORT_DIPSET(0x0004, "Germany" ) \

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -107,4 +107,5 @@ SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925
 						"v1_3_04.bin", CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
 						"v1_3_05.bin", CRC(6bb5e101) SHA1(125412953bbee7ee171c0bd34f7848fde37ace67))
 SLEIC_ROMEND
-CORE_GAMEDEFNV(iomoon,"Io Moon",1994,"Sleic (Spain)",gl_mSLEIC2,GAME_NOT_WORKING)
+CORE_GAMEDEFNV(iomoon,"Io Moon",1994,"Sleic (Spain)",gl_mSLEIC2,0)
+

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -93,14 +93,21 @@ CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,0)
 /*-------------------------------------------------------------------
 / Io Moon (1994)
 /-------------------------------------------------------------------*/
-/* THREE balls, and that is the firmware's own number rather than a guess: the 80188's
-   ball-start path stores 3 into its trough counter [413C:00F9] after a successful ball
-   search (DC514, DC587) and its 0xEA reply table does the same for the "trough full"
-   answer 0x3A (DC14D), and the Z80's trough test 2C1F only ever clears with three
-   adjacent contacts closed.  The driver's trough model (SWITCH_UPDATE(SLEIC2)) takes the
-   complement from this setting, and 0 turns the model off for a frontend that would
-   rather drive the trough contacts itself. */
-INITGAME2(iomoon, sleic_dispDMD, 3)
+/* "Balls" defaults to 0, and for Io Moon that is not a ball count -- it is the OFF
+   position of the driver's optional internal ball-trough model (SWITCH_UPDATE(SLEIC2) in
+   sleic.c).  Off is the PinMAME convention: swMatrix[1] bits 0-3 (switch codes 0x0A-0x0D)
+   are ordinary switches, and closing them is the frontend's job -- a VPinMAME table
+   script's, or standalone the Q/W/E/R matrix test keys'.  Bike Race does the same and
+   sits on "FALTA 1 BOLA" until its trough contacts close.
+
+   Set "Balls" to 3 to turn the model on for standalone desktop play, where nothing else
+   is going to close those contacts.  THREE is the firmware's own number rather than a
+   guess: the 80188's ball-start path stores 3 into its trough counter [413C:00F9] after a
+   successful ball search (DC514, DC587) and its 0xEA reply table does the same for the
+   "trough full" answer 0x3A (DC14D), and the Z80's trough test 2C1F only ever clears with
+   three adjacent contacts closed.  1 and 2 clamp up to 3; 4-7 also give 3, since the
+   trough has only three contacts. */
+INITGAME2(iomoon, sleic_dispDMD, 0)
 SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925d6b3112f584df37250),
 						"v1_3_02.bin", CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
 						"v1_3_03.bin", CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),
@@ -122,8 +129,10 @@ CORE_GAMEDEFNV(iomoon,"Io Moon",1994,"Sleic (Spain)",gl_mSLEIC2,0)
    reach the sound, non-volatile-store or country/pricing code, which is byte-identical
    to the parent's.  What is NOT tested is where the two revisions actually diverge --
    the service-menu dispatch around DD480 in chip 01, and the Z80 trough and port-0x04
-   handlers 2BC7/2C1F/2D9D in chip 05.  Those want an interactive play-test. */
-INITGAME2(iomoona, sleic_dispDMD, 3)
+   handlers 2BC7/2C1F/2D9D in chip 05.  Those want an interactive play-test -- and the
+   trough half of it needs either a frontend driving the trough switches or "Balls" set
+   to 3, since the internal model is off by default here as it is on the parent. */
+INITGAME2(iomoona, sleic_dispDMD, 0)
 SLEIC_ROMSTART5(iomoona,"v1_3_01e.bin", CRC(00a75790) SHA1(3af7a5c10a8c1687a212a01393cc9195a04a73c9),
 						"v1_3_02.bin",  CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
 						"v1_3_03.bin",  CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),
@@ -136,8 +145,10 @@ CORE_CLONEDEFNV(iomoona,iomoon,"Io Moon (earlier ROM revision)",1994,"Sleic (Spa
    START instead of dropping straight back to attract, which is what a tournament wants
    between players.  Only chip 01 changes; 02-05 are the parent's.  The patch is 186
    bytes in four regions -- a 168-byte and an 11-byte block of new code at C0010-C00B7
-   and C00D0-C00DA, reached by two four-byte hooks planted at D5077 and D5123. */
-INITGAME2(iomoont, sleic_dispDMD, 3)
+   and C00D0-C00DA, reached by two four-byte hooks planted at D5077 and D5123.  Seeing
+   the patch fire means playing a game to its end, so standalone it needs "Balls" = 3;
+   the internal trough model is off by default here as it is on the parent. */
+INITGAME2(iomoont, sleic_dispDMD, 0)
 SLEIC_ROMSTART5(iomoont,"v1_3_01t.bin", CRC(42cafcda) SHA1(0ac3dd882748bc86a3b66aff2d286eecd8d24a4b),
 						"v1_3_02.bin",  CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
 						"v1_3_03.bin",  CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -109,3 +109,39 @@ SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925
 SLEIC_ROMEND
 CORE_GAMEDEFNV(iomoon,"Io Moon",1994,"Sleic (Spain)",gl_mSLEIC2,0)
 
+/* An earlier dump of the same 1.3 set.  The stickers on both sets read V1.3 -- the number
+   after the dash is the chip position, not a sub-revision -- so the two are told apart by
+   content: chip 01 (80188 code + upper graphics) and chip 05 (Z80 I/O code) differ, and
+   the graphics and OKI sample ROMs 02/03/04 are byte-identical to the parent set and are
+   listed here under the parent's names.  The suffixed file names are this driver's, for
+   the same reason bikerac2 renames the two chips it changes: the chips themselves carry
+   no label that separates them.
+
+   TESTED to the same depth as the parent and no further: it boots, runs, seeds a blank
+   non-volatile store and renders the DMD, and the parts of chip 01 that differ do not
+   reach the sound, non-volatile-store or country/pricing code, which is byte-identical
+   to the parent's.  What is NOT tested is where the two revisions actually diverge --
+   the service-menu dispatch around DD480 in chip 01, and the Z80 trough and port-0x04
+   handlers 2BC7/2C1F/2D9D in chip 05.  Those want an interactive play-test. */
+INITGAME2(iomoona, sleic_dispDMD, 3)
+SLEIC_ROMSTART5(iomoona,"v1_3_01e.bin", CRC(00a75790) SHA1(3af7a5c10a8c1687a212a01393cc9195a04a73c9),
+						"v1_3_02.bin",  CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
+						"v1_3_03.bin",  CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),
+						"v1_3_04.bin",  CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
+						"v1_3_05e.bin", CRC(dd5145f5) SHA1(7de0b9582e5130cd1eafb1c0038ee7c9ce7b3ec2))
+SLEIC_ROMEND
+CORE_CLONEDEFNV(iomoona,iomoon,"Io Moon (earlier ROM revision)",1994,"Sleic (Spain)",gl_mSLEIC2,0)
+
+/* Tournament MOD of the parent set: chip 01 patched so the end of a game asks for PRESS
+   START instead of dropping straight back to attract, which is what a tournament wants
+   between players.  Only chip 01 changes; 02-05 are the parent's.  The patch is 186
+   bytes in four regions -- a 168-byte and an 11-byte block of new code at C0010-C00B7
+   and C00D0-C00DA, reached by two four-byte hooks planted at D5077 and D5123. */
+INITGAME2(iomoont, sleic_dispDMD, 3)
+SLEIC_ROMSTART5(iomoont,"v1_3_01t.bin", CRC(42cafcda) SHA1(0ac3dd882748bc86a3b66aff2d286eecd8d24a4b),
+						"v1_3_02.bin",  CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
+						"v1_3_03.bin",  CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),
+						"v1_3_04.bin",  CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
+						"v1_3_05.bin",  CRC(6bb5e101) SHA1(125412953bbee7ee171c0bd34f7848fde37ace67))
+SLEIC_ROMEND
+CORE_CLONEDEFNV(iomoont,iomoon,"Io Moon (PRESS START tournament MOD)",1994,"Sleic (Spain)",gl_mSLEIC2,0)

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -93,7 +93,14 @@ CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,0)
 /*-------------------------------------------------------------------
 / Io Moon (1994)
 /-------------------------------------------------------------------*/
-INITGAME2(iomoon, sleic_dispDMD, 1)
+/* THREE balls, and that is the firmware's own number rather than a guess: the 80188's
+   ball-start path stores 3 into its trough counter [413C:00F9] after a successful ball
+   search (DC514, DC587) and its 0xEA reply table does the same for the "trough full"
+   answer 0x3A (DC14D), and the Z80's trough test 2C1F only ever clears with three
+   adjacent contacts closed.  The driver's trough model (SWITCH_UPDATE(SLEIC2)) takes the
+   complement from this setting, and 0 turns the model off for a frontend that would
+   rather drive the trough contacts itself. */
+INITGAME2(iomoon, sleic_dispDMD, 3)
 SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925d6b3112f584df37250),
 						"v1_3_02.bin", CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
 						"v1_3_03.bin", CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -91,7 +91,7 @@ SLEIC_ROMEND
 CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,0)
 
 /*-------------------------------------------------------------------
-/ Io Moon (1994)
+/ Io Moon (1996)
 /-------------------------------------------------------------------*/
 /* "Balls" defaults to 0, and for Io Moon that is not a ball count -- it is the OFF
    position of the driver's optional internal ball-trough model (SWITCH_UPDATE(SLEIC2) in
@@ -114,7 +114,7 @@ SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925
 						"v1_3_04.bin", CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
 						"v1_3_05.bin", CRC(6bb5e101) SHA1(125412953bbee7ee171c0bd34f7848fde37ace67))
 SLEIC_ROMEND
-CORE_GAMEDEFNV(iomoon,"Io Moon",1994,"Sleic (Spain)",gl_mSLEIC2,0)
+CORE_GAMEDEFNV(iomoon,"Io Moon",1996,"Sleic (Spain)",gl_mSLEIC2,0)
 
 /* An earlier dump of the same 1.3 set.  The stickers on both sets read V1.3 -- the number
    after the dash is the chip position, not a sub-revision -- so the two are told apart by
@@ -139,7 +139,7 @@ SLEIC_ROMSTART5(iomoona,"v1_3_01e.bin", CRC(00a75790) SHA1(3af7a5c10a8c1687a212a
 						"v1_3_04.bin",  CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
 						"v1_3_05e.bin", CRC(dd5145f5) SHA1(7de0b9582e5130cd1eafb1c0038ee7c9ce7b3ec2))
 SLEIC_ROMEND
-CORE_CLONEDEFNV(iomoona,iomoon,"Io Moon (earlier ROM revision)",1994,"Sleic (Spain)",gl_mSLEIC2,0)
+CORE_CLONEDEFNV(iomoona,iomoon,"Io Moon (earlier ROM revision)",1996,"Sleic (Spain)",gl_mSLEIC2,0)
 
 /* Tournament MOD of the parent set: chip 01 patched so the end of a game asks for PRESS
    START instead of dropping straight back to attract, which is what a tournament wants
@@ -155,4 +155,4 @@ SLEIC_ROMSTART5(iomoont,"v1_3_01t.bin", CRC(42cafcda) SHA1(0ac3dd882748bc86a3b66
 						"v1_3_04.bin",  CRC(f3a950bf) SHA1(e0410f8fe9b4efe7d21052c0a19894a563f90a27),
 						"v1_3_05.bin",  CRC(6bb5e101) SHA1(125412953bbee7ee171c0bd34f7848fde37ace67))
 SLEIC_ROMEND
-CORE_CLONEDEFNV(iomoont,iomoon,"Io Moon (PRESS START tournament MOD)",1994,"Sleic (Spain)",gl_mSLEIC2,0)
+CORE_CLONEDEFNV(iomoont,iomoon,"Io Moon (PRESS START tournament MOD)",1996,"Sleic (Spain)",gl_mSLEIC2,0)

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -12,6 +12,15 @@
 		core_gameData = &name##GameData; \
 	}
 
+/* Io Moon only: same cabinet block, but the real SW40 DIP block instead of S1..S8,
+   because it is the one machine here whose Z80 ROM was traced for it (sleic.h) */
+#define INITGAME2(name, disptype, balls) \
+	SLEIC2_INPUT_PORTS_START(name, balls) SLEIC_INPUT_PORTS_END \
+	static core_tGameData name##GameData = {GEN_SLEIC,disptype,{FLIP_SW(FLIP_L)}}; \
+	static void init_##name(void) { \
+		core_gameData = &name##GameData; \
+	}
+
 /* Dot-Matrix display (128 x 32) */
 static core_tLCDLayout sleic_dispDMD[] = {
   {0,0,32,128,CORE_DMD,NULL,NULL}, {0}
@@ -84,7 +93,7 @@ CORE_GAMEDEFNV(sleicpin,"Sleic Pin-Ball",1993,"Sleic (Spain)",gl_mSLEIC1,0)
 /*-------------------------------------------------------------------
 / Io Moon (1994)
 /-------------------------------------------------------------------*/
-INITGAME(iomoon, sleic_dispDMD, 1)
+INITGAME2(iomoon, sleic_dispDMD, 1)
 SLEIC_ROMSTART5(iomoon, "v1_3_01.bin", CRC(df80bf4f) SHA1(29547b444cad116c9dc925d6b3112f584df37250),
 						"v1_3_02.bin", CRC(2bd589cd) SHA1(87354c76cbef8185d563266230c72a618ce6fcd7),
 						"v1_3_03.bin", CRC(334d0e20) SHA1(06b38cc7fcee633c45a9000187fcde8d7e03a51f),


### PR DESCRIPTION
This makes Sleic's Io Moon (1996) fully playable and drops GAME_NOT_WORKING.
It builds on the merged Bike Race / Sleic Pin-Ball work (#625/#627) and on a
fresh, cross-verified disassembly of both Io Moon CPU ROMs, documented in the
reverse-engineering repository: https://github.com/gerwout/sleic-iomoon

What works: boot, attract, DMD (two frames verified byte-identical against the
graphics ROM), coin -> credit -> start, gameplay with flippers/scoring/drains
and the firmware's short-ball replay, full 3-ball games ending back in attract,
the complete 38-record service menu in both languages, YM3812 FM music and
OKI MSM6376 speech/FX.

Hardware model highlights (each constant in sleic.c cites its evidence):
- The IC23 PIC16C57 DMD coprocessor was recovered from the code-protected
  original chip and disassembled - it is a free-running raster sequencer with
  no command interface. Dump + analysis:
  https://github.com/gerwout/sleic-iomoon/tree/main/roms/PIC16C57
- Resident-ROM IVT; interrupts are timer 0 (99.18 Hz, derived from the boot
  table) and INT0 (rate still open, shipped as a documented serviceability
  constant).
- PCS0 bits 0-2 bank the graphics ROM's seven 64 KB pages into segment 6000h;
  PCS5 = YM3812 (two-address), PCS6 + PCS0 bit 5 = OKI phrase latch + /ST.
- The 80188<->Z80 link is an 8-bit byte-port (J1); the Z80 firmware supplies
  all traffic (switch codes, language replies) - nothing is synthesized.
- Country/coinage DIP (SW40-2/3/4) is modelled and also selects the language;
  coin insertion emits the per-country mech pulse train. Default: Netherlands, 
  so the default language is English and a single coin adds a single credit.
- Ball trough switches are frontend-driven by default (VPinMAME convention);
  a built-in 3-ball simulation for standalone use is enabled via the "Balls"
  setting.

Three sets are registered: iomoon (v1.3), iomoona (v1.3, earlier revision),
iomoont (PRESS START tournament MOD). All ROM zips can be downloaded from
https://github.com/gerwout/sleic-iomoon/tree/main/roms/pinmame
