### PR TITLE
sleic: get Bike Race V4.1 (bikerac3) working, and an opt-in ball model for Bike Race

### DIFF
--- a/src/sound/3812intf.c
+++ b/src/sound/3812intf.c
@@ -107,6 +107,18 @@ static void YM3812Write_ymfm(int n, int a, int v)
 {
 	if (a & 1) /* data port */
 	{
+		/* Render the stream up to this write's CPU time before applying it, exactly as the
+		 * legacy fmopl path always did (fmopl.c OPLWrite calls its UpdateHandler, i.e.
+		 * stream_update, before every data write) and as the YM2151 ymfm wrapper does
+		 * (2151intf.c YM2151_data_port_0_w -> YM2151UpdateRequest).  Without it every
+		 * write of a video frame lands on the chip at one instant.  ymfm detects a
+		 * key-on/key-off EDGE only per generated sample (ymfm_fm.ipp clock_keystate),
+		 * so a key-off immediately followed by a key-on inside the same frame -- how
+		 * sequencers re-strike a repeated note and retrigger 0xBD drums -- collapses to
+		 * key 1->1: no attack, the old note just sustains.  fmopl re-attacks at write
+		 * time and never showed this.  Address writes only set the register latch and
+		 * are left unflushed, matching fmopl. */
+		stream_update(stream_3812[n], 0);
 		vgm_write(vgm_idx_3812[n], 0x00, lastreg_3812[n], v);
 		ymfm_opl_write(chip_3812[n], 1, v);
 	}

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1376,8 +1376,8 @@ MEMORY_END
  *   MCS0 0x00000-0x1FFFF : work RAM (boot stack 012F:0203; the boot copies its IVT
  *                          image from CS:00C4 to physical 0 before STI, so the
  *                          driver must NOT overwrite the IVT)
- *   MCS1 0x20000-0x3FFFF : graphics ROM bkcpu05
- *   MCS2 0x40000-0x5FFFF : graphics ROM bkcpu06 (read via ES=0x5000)
+ *   MCS1 0x20000-0x3FFFF : graphics ROM bkcpu06 (sprite table in its first 0x1104)
+ *   MCS2 0x40000-0x5FFFF : graphics ROM bkcpu05 (read via ES=0x5000)
  *   MCS3 0x60000-0x7FFFF : DMD / video frame buffer RAM (panel staging at 0x60410)
  * PACS=0xA03C -> peripheral block at 0xA0000, so sleic_periph_r/w are used.
  * UMCS -> bkcpu04 code at 0xE0000-0xFFFFF (reset EA F000:0000). */

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -650,6 +650,7 @@ static void sleic_debug_switches(int troughCol, UINT8 troughDefault) {
   static int frame = 0;
   const char *e, *col, *bit;
   frame++;
+  if (getenv("SLEIC_TRACE_SND") && (frame % 60) == 0) fprintf(stderr, "[frame %d]\n", frame);
 
   if ((e = getenv("SLEIC_INJECT_CAB")))
     coreGlobals.swMatrix[9] |= (UINT8)strtol(e, NULL, 0);
@@ -743,20 +744,19 @@ static WRITE_HANDLER(pic_w) {
   logerror("PIC W(%03x->%2x) = %02x\n", offset, offset>>7, data);
 }
 
-/* PACS peripheral chip-select block at segment A000h (base 0xA0000,
- * 7 selects PCS0-PCS6 on 0x80 boundaries):
- *   0xA0000 PCS0  DMD control reg 1  AND the OKI /OKCS strobe (bit 5)
- *   0xA0080 PCS1  DMD control reg 2
- *   0xA0200 PCS4  DMD mode; bit 3 rising edge = swap-buffer / frame strobe
- *   0xA0280 PCS5  YM3812 register/index port (A0=0)
- *   0xA0281 PCS5  YM3812 data port          (A0=1)
- *   0xA0300 PCS6  DMD enable (init 0x80)  AND the OKI control latch
- *                 (phrase number in bits 0-6, channel select in bit 7)
+/* Bike Race (SLEIC3) PACS peripheral chip-select block at segment A000h (base 0xA0000,
+ * PCS0-PCS6 on 0x80 boundaries), read off schematic REF 011-026 sheets 3 and 4:
+ *   0xA0000 PCS0  IC32 74LS273 control latch: bit 1 YA0 (YM3812 A0), bit 2 /RCS,
+ *                 bit 3 2CH (OKI channel), bit 4 /ST (OKI start), bits 5-7 X9103 pot
+ *   0xA0080 PCS1  command byte to the I/O side (J1 link)
+ *   0xA0280 PCS5  YM3812 -- ONE address; index vs data is PCS0 bit 1 (net YA0)
+ *   0xA0300 PCS6  IC45 74LS273 OKI phrase latch, I0-I6 (bit 7 unconnected)
  *
- * YM3812 (IC60) = in-game FM music; OKI MSM6376 (IC51) = speech/FX. OKI trigger
- * model (exact latch bits await the IC7 PAL dump): a non-zero phrase written to
- * 0xA0300 ARMS a phrase, the next /OKCS rising edge (0xA0000 bit 5) STARTS it
- * -> locals.okiLatch / locals.okiPrevStrobe / locals.okiPending */
+ * YM3812 (IC41) = in-game FM music; OKI MSM6376 (IC46) = speech/FX, run as two
+ * channels selected by 2CH at the /ST edge -> sleic3_oki_strobe.  A phrase written to
+ * 0xA0300 ARMS the next /ST rising edge (0xA0000 bit 4), which STARTS it
+ * -> locals.okiLatch / locals.okiPrevStrobe / locals.okiPending.  sleic_oki_trigger
+ * just below is Pin-Ball's (SLEIC1) single-voice model and is left exactly as it was. */
 
 /* J1 inbound byte latch (IC43 at 80188 PCS2 = 0xA0100): the last byte the Z80 strobed
  * across the J1 port. The Z80's port-0x81 bit-2 strobe latches the byte AND raises the
@@ -776,33 +776,81 @@ static void sleic_oki_trigger(void) {
   OKIM6376_data_0_w(0, voice << 4);    /* trigger playback on the voice */
 }
 
+/* Bike Race (SLEIC3) OKI MSM6376 strobe.  Separate from sleic_oki_trigger above, which
+ * Pin-Ball (SLEIC1) shares and which must keep its byte-for-byte behaviour.
+ *
+ * The firmware runs the 6376 as TWO concurrent channels.  The channel is NOT a bit of
+ * the phrase byte -- every 0xA0300 write is masked with AND AL,07F first (E0CCE / E0CF9),
+ * and on the board bit 7 of the IC45 phrase latch is unconnected -- it is PCS0 bit 3,
+ * IC32 4Q = 2CH (schematic sheet 3 p122, OKI pin 63 on sheet 4).  The channel-1 trigger
+ * sub_E0CBF leaves 2CH high; the channel-2 trigger sub_E0CEA clears it (E0D0C-E0D14)
+ * around the /ST pulse (bit 4, IC32 5Q) and restores it after (E0D1B-E0D23), so the
+ * channel is the state of bit 3 at the /ST rising edge -- which is what this is given.
+ * Both channels reach the core's two 6376 voices (adpcm.c: bit 4 = voice 0, bit 5 =
+ * voice 1 on data >> 4); collapsing them onto one voice, as the old model did, made
+ * adpcm.c refuse the second of every overlapping pair (its start on a still-playing
+ * voice is dropped at OKIM6376_data_w) -- exactly how START issues phrase 19, the 4.7 s
+ * motor sample in BK03, on channel 2 while phrase 1 is still running on channel 1.
+ *
+ * The abort-before-start is the same as iomoon_oki_strobe: the firmware's only busy
+ * model is its own software counter per channel ([01BE] / [01C1]), which can expire a
+ * little before the emulated sample ends (the interface rate is ~2 % under the
+ * firmware-implied ~30.9 kHz), so a re-issue on a channel the firmware considers free
+ * must restart, not be refused.  Phrase 0 is the stop-all sub_E0D2D (latch 0, /ST held
+ * low, released two timer ticks later by sub_E0D7E): silence both voices. */
+static void sleic3_oki_strobe(UINT8 pcs0) {
+  const UINT8 phrase = locals.okiLatch & 0x7f;
+  const UINT8 voice  = (pcs0 & 0x08) ? 0 : 1;   /* 2CH high = channel 1 = voice 0 */
+  locals.okiPending = 0;
+#ifdef DEBUG_SLEIC
+  if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[oki] phrase %02x ch%d\n", phrase, voice + 1);
+#endif
+  if (!phrase) {                                  /* sub_E0D2D stop-all                 */
+    OKIM6376_data_0_w(0, 0x18);                   /* no phrase pending: bits 3,4 = stop voices 0,1 */
+    return;
+  }
+  OKIM6376_data_0_w(0, (UINT8)(0x08 << voice));   /* abort this channel first            */
+  OKIM6376_data_0_w(0, (UINT8)(0x80 | phrase));   /* phrase number on D0-D6              */
+  OKIM6376_data_0_w(0, (UINT8)(0x10 << voice));   /* start it on the 2CH-selected voice  */
+}
+
 static WRITE_HANDLER(sleic_periph_w) {
 #ifdef DEBUG_SLEIC
   if (getenv("SLEIC_TRACE_PW")) fprintf(stderr, "[188->periph] PCS%d off=%03x data=%02x\n", offset>>7, offset, data);
 #endif
   switch (offset) {
-    case 0x280:                        /* PCS5: YM3812 port */
-      /* Bike Race wires the YM3812 to the single address 0xA0280 and toggles A0 in hardware
-       * per write, so it streams (register,value) pairs all to 0xA0280 */
+    case 0x280:                        /* PCS5: YM3812, single address */
+      /* Bike Race puts the YM3812 on the one address 0xA0280 and drives its A0 from a
+       * LATCHED control bit, PCS0 bit 1 (IC32 2Q = net YA0 -> IC81 pin 4, schematic
+       * sheets 3/4) -- the Pin-Ball scheme, not a per-write hardware toggle.  The only
+       * writer, sub_E0E0E, clears the bit (E0E12) before the index byte and sets it
+       * (E0E2A) before the data byte, so locals.ymA0 is set in case 0x000 below and
+       * simply read here.  (The old per-write toggle happened to agree with the latch
+       * on every reachable write of this ROM, but modelled an invariant of the ROM
+       * rather than the wiring.) */
       {
 #ifdef DEBUG_SLEIC
-        if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[ym] %s %02x\n", locals.ymA0 ? "data":"reg ", data);
+        if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[ym] %llu %s %02x\n", (unsigned long long)activecpu_gettotalcycles64(), locals.ymA0 ? "data":"reg ", data);
 #endif
         if (locals.ymA0) YM3812_write_port_0_w(0, data); else YM3812_control_port_0_w(0, data);
-        locals.ymA0 ^= 1;
       }
       return;
-    case 0x300:                        /* PCS6: DMD enable + OKI ctrl latch */
+    case 0x300:                        /* PCS6: IC45 74LS273 OKI phrase latch, I0-I6 */
       locals.okiLatch = data;
-      if (data & 0x7f) locals.okiPending = 1; /* real phrase (not 0x80 DMD-enable) */
+      /* Every value arms the next /ST edge, INCLUDING zero: latch 0 is the firmware's
+       * stop-all (sub_E0D2D writes 0 at E0D32, then pulses /ST), so gating this on a
+       * non-zero phrase silently discarded every stop and let a following priority
+       * phrase be refused by the core as "still playing". */
+      locals.okiPending = 1;
       break;
-    case 0x000:                        /* PCS0: OKI /OKCS strobe (bit 4) */
-      {
-        /* /OKCS strobe: Bike Race pulses PCS0 bit 4 (0x10). (Exact decode awaits the IC7 PAL20L10 dump) */
-        const UINT8 okcs = 0x10;
-        if (locals.okiPending && (data & okcs) && !(locals.okiPrevStrobe & okcs))
-          sleic_oki_trigger();
-      }
+    case 0x000:                        /* PCS0: IC32 control latch */
+      /* IC32 74LS273 (sheet 3 p122): bit 1 YA0 (YM3812 A0), bit 2 /RCS (driven low once
+       * at boot, never raised), bit 3 2CH (OKI channel), bit 4 /ST (OKI start strobe),
+       * bits 5-7 the X9103 volume pot.  A0 is latched here for case 0x280; the OKI
+       * channel is read from bit 3 at the /ST rising edge. */
+      locals.ymA0 = (data >> 1) & 1;
+      if (locals.okiPending && (data & 0x10) && !(locals.okiPrevStrobe & 0x10))
+        sleic3_oki_strobe(data);
       locals.okiPrevStrobe = data;
       break;
     case 0x080:                        /* PCS1: command byte the 80188 sends to the I/O side */

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -2441,9 +2441,55 @@ static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
   {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_MINUS,5,0x40},{KEYCODE_9,5,0x80}, /* COL4 0x2E; trough optos: 0x2F=C7(key8) 0x31=C8(key9) both versions, 0x30=key'-' bikerac2-only (+0x2C=key3); 0x30 is on '-' rather than 7 because 7 is the test/service key (sleic.h); see trough notes above */
 };
 
+/*-------------------------------------------------------------------------------------
+/  Bike Race (SLEIC3) ball-present model -- OPT-IN, AND OFF BY DEFAULT.
+/
+/  Same bargain as Io Moon's trough model: under a frontend a table script owns the ball
+/  optos and reports them, so the driver must not fabricate them, and with "Balls" at its
+/  default 0 it does not.  Standalone there is nothing to close them, and the machine sits
+/  on "FALTA n BOLAS" until something does -- which is correct, but means holding two
+/  matrix keys down for the whole session before a game can be started.  Setting "Balls"
+/  to any non-zero value hands that job to the driver.
+/
+/  This is a SIMPLER model than Io Moon's, deliberately.  Io Moon's trough is three
+/  contacts in a line with a kicker command (0xE9) and a drain sensor, so the state a ball
+/  is in can be tracked and each contact driven from it.  What Bike Race exposes on COL4
+/  is a ball-PRESENT check answered by the Z80's cmd-0xD5 handler, and no serve command
+/  has been identified in either Z80 ROM.  So nothing here tracks a ball count or a
+/  kicker: it presents the complement the firmware wants to see, and the cabinet port's
+/  "Ball out of trough" key lifts it.  Inventing a serve would be inventing mechanics the
+/  disassembly does not show.
+/
+/  THE MASK.  0xE0 closes all three of COL4's monitored optos at once, which satisfies
+/  every version's rule without the driver having to know which set is running:
+/    bikerace  wants a ball at 0x20 OR 0x80                         -> 0xE0 satisfies it
+/    bikerac2  wants two optos INCLUDING 0x40 (0x20+0x40 or 0x40+0x80) -> 0xE0 satisfies it
+/    bikerac3  shares bikerac2's Z80 code revision, so the same rule
+/  Measured over 2000 headless frames with two coins and START, distinct DMD frames:
+/  104 / 107 / 111 with the mask against 5-6 for the sets that need 0x40 without it.
+/  See the per-version breakdown in the MACHINE_INIT trough comment above.
+/-----------------------------------------------------------------------------------*/
+#define SLEIC3_TROUGH_COL   5     /* swMatrix index of Z80 switch column 4 (COL4)       */
+#define SLEIC3_TROUGH_BITS  0xE0  /* the three monitored optos, see the mask note above  */
+
+/* Called from SWITCH_UPDATE(SLEIC3) AFTER the playfield key loop, and it ORs its bits in
+ * rather than assigning them, for the same reason Io Moon's does: a matrix test key held
+ * on one of these positions is a contact stuck closed, which is what the service menu's
+ * contact test wants to see, and the model has no business overriding it.
+ *
+ * balls = the simulator port's "Balls" setting, 0 (the default) meaning model off.
+ * out   = the cabinet port's "Ball out of trough", held while the ball is away. */
+static void sleic3_ball_update(int balls, int out) {
+  if (balls <= 0 || out) return;
+  coreGlobals.swMatrix[SLEIC3_TROUGH_COL] |= SLEIC3_TROUGH_BITS;
+}
+
 static SWITCH_UPDATE(SLEIC3) {
   unsigned i;
+  int balls = 0, out = 0;
   if (inports) {
+    balls = SIM_BALLS(inports[CORE_SIMINPORT]);
+    out   = (inports[CORE_COREINPORT] & 0x1000) ? 1 : 0;
     /* Cabinet/direct buttons are all on Z80 port 0x03 (swMatrix[9]), bit -> contact:
      *   bit0 = C17 Tilt        (code 0x32, also menu ENTER)
      *   bit1 = C4  Test        (code 0x33 = menu ENTER)
@@ -2465,8 +2511,10 @@ static SWITCH_UPDATE(SLEIC3) {
     else
       coreGlobals.swMatrix[sleic3_pf_keys[i].col] &= ~sleic3_pf_keys[i].bit;
   }
+  /* After the key loop, because it ORs its optos in on top -- see the comment on it */
+  sleic3_ball_update(balls, out);
 #ifdef DEBUG_SLEIC
-  sleic_debug_switches(5, 0xE0); /* COL4: C7 0x20 | '-' sensor 0x40 (bikerac2) | C8 0x80 */
+  sleic_debug_switches(5, SLEIC3_TROUGH_BITS); /* COL4 optos, same mask the model uses */
 #endif
 }
 

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -1896,15 +1896,23 @@ static MACHINE_INIT(SLEIC) {
    * ball-status query strobes COL4 (out 0x82 = 0x10), reads it into 0xC0DB and replies
    * over J1. The set of monitored optos and reply codes DIFFERS BY VERSION -- the Z80 I/O
    * ROM (bkio07.bin vs 07.bin) is one of the two ROMs that differ between the games:
+   * The contact names below are the firmware's own, decoded from its code->C-number->name
+   * table at linear 0xF373D (5-byte records Cnum|name_off16|name_seg, indexed
+   * [F000:0x370B + code*5]); the name pool is length-prefixed DMD glyph indices, 0x0A =
+   * space and 0x0B.. = A..Z with N-tilde inserted after N:
+   *     code 0x2C bit 0x04 = C22 "EXPULSOR 1"
+   *     code 0x2F bit 0x20 = C6  "SALIDA BOLAS"
+   *     code 0x30 bit 0x40 = C7  "BOLA EN ESPERA"
+   *     code 0x31 bit 0x80 = C8  "BOLA FUERA"
    *   bikerace (bkio07, handler 0x0B1D -> sub 0x0B31, replies 0x0B7C/0x0B9D): monitors
-   *     COL4 bits 0x04 (code 0x2C, key 3), 0x20 (C7 "Bola Retenida", key 8) and
-   *     0x80 (C8 "Bola fuera", key 9). Reply 0x5D "BOLAS OK" / 0x5B "FALTA 1 BOLA";
-   *     a ball at C7 OR C8 -> BOLAS OK, so standalone-test by holding key 8 (or 9).
+   *     COL4 bits 0x04 (C22, key 3), 0x20 (C6 "Salida Bolas", key 8) and
+   *     0x80 (C8 "Bola Fuera", key 9). Reply 0x5D "BOLAS OK" / 0x5B "FALTA 1 BOLA";
+   *     a ball at C6 OR C8 -> BOLAS OK, so standalone-test by holding key 8 (or 9).
    *   bikerac2 (07.bin, sub 0x0B72, replies 0x0C0B/0x0C16/0x0C37): monitors the same three
-   *     PLUS bit 0x40 (code 0x30, key '-') and counts missing balls -- reply adds
-   *     0x5C "FALTA 2 BOLAS". "BOLAS OK" needs two optos INCLUDING the '-' sensor
+   *     PLUS bit 0x40 (C7 "Bola en Espera", key '-') and counts missing balls -- reply adds
+   *     0x5C "FALTA 2 BOLAS". "BOLAS OK" needs two optos INCLUDING C7
    *     (combos 0x20+0x40 or 0x40+0x80), so standalone-test by holding '-' with 8 or 9;
-   *     holding only 8+9 (no '-') never reports OK. (Verified against the disassembly of both
+   *     holding only 8+9 (no C7) never reports OK. (Verified against the disassembly of both
    *     Z80 ROMs; the key bindings already exist in sleic3_pf_keys below.)
    * The driver does not fabricate the ball complement -- the frontend (e.g. VPX)
    * supplies trough state; the keys above are only for standalone testing */
@@ -2420,9 +2428,10 @@ static SWITCH_UPDATE(SLEIC2) {
  * the port-0x82 one-hot column strobe); code = 0x0A + 8*(col-1) + row. Mapping every
  * position to a key lets the CONTACTOS self-test verify each contact. COL4 (swMatrix[5])
  * is the trough column. The Z80 cmd-0xD5 ball-status handler monitors COL4 bits 0x04
- * (code 0x2C, key 3), 0x20 = C7 (key 8) and 0x80 = C8 (key 9) on all three sets, plus
- * bit 0x40 (code 0x30, key '-') on bikerac2 AND bikerac3, which share the same F000
- * code revision; see the per-version breakdown in the MACHINE_INIT trough comment above.
+ * (C22, key 3), 0x20 = C6 "Salida Bolas" (key 8) and 0x80 = C8 "Bola Fuera" (key 9) on
+ * all three sets, plus bit 0x40 = C7 "Bola en Espera" (key '-') on bikerac2 AND
+ * bikerac3, which share the same F000 code revision; see the per-version breakdown and
+ * the source of those names in the MACHINE_INIT trough comment above.
  *
  * What that means for filling the trough by hand: bikerace clears with either 8+9 or
  * 8+'-', but bikerac2 and bikerac3 need 8+'-' -- 8+9 alone leaves them sitting on
@@ -2438,7 +2447,7 @@ static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
   {KEYCODE_0_PAD,4,0x01},{KEYCODE_1_PAD,4,0x02},{KEYCODE_2_PAD,4,0x04},{KEYCODE_3_PAD,4,0x08}, /* COL3 0x22-0x25 */
   {KEYCODE_4_PAD,4,0x10},{KEYCODE_5_PAD,4,0x20},{KEYCODE_6_PAD,4,0x40},{KEYCODE_7_PAD,4,0x80}, /* COL3 0x26-0x29 */
   {KEYCODE_0,5,0x01},{KEYCODE_2,5,0x02},{KEYCODE_3,5,0x04},{KEYCODE_4,5,0x08}, /* COL4 0x2A-0x2D */
-  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_MINUS,5,0x40},{KEYCODE_9,5,0x80}, /* COL4 0x2E; trough optos: 0x2F=C7(key8) 0x31=C8(key9) both versions, 0x30=key'-' bikerac2-only (+0x2C=key3); 0x30 is on '-' rather than 7 because 7 is the test/service key (sleic.h); see trough notes above */
+  {KEYCODE_6,5,0x10},{KEYCODE_8,5,0x20},{KEYCODE_MINUS,5,0x40},{KEYCODE_9,5,0x80}, /* COL4 0x2E; trough optos: 0x2F=C6 "Salida Bolas"(key8), 0x30=C7 "Bola en Espera"(key'-'), 0x31=C8 "Bola Fuera"(key9), +0x2C=C22(key3); C7 is on '-' rather than 7 because 7 is the test/service key (sleic.h); see trough notes above */
 };
 
 /*-------------------------------------------------------------------------------------
@@ -2462,15 +2471,15 @@ static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
 /
 /  THE MASK.  0xE0 closes all three of COL4's monitored optos at once, which satisfies
 /  every version's rule without the driver having to know which set is running:
-/    bikerace  wants a ball at 0x20 OR 0x80                         -> 0xE0 satisfies it
-/    bikerac2  wants two optos INCLUDING 0x40 (0x20+0x40 or 0x40+0x80) -> 0xE0 satisfies it
+/    bikerace  wants a ball at C6 0x20 OR C8 0x80                     -> 0xE0 satisfies it
+/    bikerac2  wants two INCLUDING C7 0x40 (0x20+0x40 or 0x40+0x80)   -> 0xE0 satisfies it
 /    bikerac3  shares bikerac2's Z80 code revision, so the same rule
 /  Measured over 2000 headless frames with two coins and START, distinct DMD frames:
 /  104 / 107 / 111 with the mask against 5-6 for the sets that need 0x40 without it.
 /  See the per-version breakdown in the MACHINE_INIT trough comment above.
 /-----------------------------------------------------------------------------------*/
 #define SLEIC3_TROUGH_COL   5     /* swMatrix index of Z80 switch column 4 (COL4)       */
-#define SLEIC3_TROUGH_BITS  0xE0  /* the three monitored optos, see the mask note above  */
+#define SLEIC3_TROUGH_BITS  0xE0  /* C6 | C7 | C8, the three monitored optos; see above  */
 
 /* Called from SWITCH_UPDATE(SLEIC3) AFTER the playfield key loop, and it ORs its bits in
  * rather than assigning them, for the same reason Io Moon's does: a matrix test key held

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -2420,9 +2420,14 @@ static SWITCH_UPDATE(SLEIC2) {
  * the port-0x82 one-hot column strobe); code = 0x0A + 8*(col-1) + row. Mapping every
  * position to a key lets the CONTACTOS self-test verify each contact. COL4 (swMatrix[5])
  * is the trough column. The Z80 cmd-0xD5 ball-status handler monitors COL4 bits 0x04
- * (code 0x2C, key 3), 0x20 = C7 (key 8) and 0x80 = C8 (key 9) on BOTH versions, plus
- * bit 0x40 (code 0x30, key '-') on bikerac2 only; see the per-version breakdown in the
- * MACHINE_INIT trough comment above */
+ * (code 0x2C, key 3), 0x20 = C7 (key 8) and 0x80 = C8 (key 9) on all three sets, plus
+ * bit 0x40 (code 0x30, key '-') on bikerac2 AND bikerac3, which share the same F000
+ * code revision; see the per-version breakdown in the MACHINE_INIT trough comment above.
+ *
+ * What that means for filling the trough by hand: bikerace clears with either 8+9 or
+ * 8+'-', but bikerac2 and bikerac3 need 8+'-' -- 8+9 alone leaves them sitting on
+ * "FALTAN n BOLAS" (measured: 5 and 6 distinct DMD frames against 110 and 111). The
+ * SLEIC_TROUGH default mask 0xE0 closes 8, '-' and 9 together and serves all three */
 static const struct { int key; UINT8 col; UINT8 bit; } sleic3_pf_keys[] = {
   {KEYCODE_Q,1,0x01},{KEYCODE_W,1,0x02},{KEYCODE_E,1,0x04},{KEYCODE_R,1,0x08}, /* COL0 0x0A-0x0D */
   {KEYCODE_Y,1,0x10},{KEYCODE_U,1,0x20},{KEYCODE_I,1,0x40},{KEYCODE_O,1,0x80}, /* COL0 0x0E-0x11 */

--- a/src/wpc/sleic.h
+++ b/src/wpc/sleic.h
@@ -69,6 +69,13 @@
     COREPORT_BITDEF(  0x0200, IPT_COIN1,  IP_KEY_DEFAULT) /* COIN  -> swMatrix[9].5 (key 5); on Io Moon one press = one coin = a pulse train */ \
     COREPORT_BITDEF(  0x0400, IPT_TILT,   IP_KEY_DEFAULT) /* TILT  -> swMatrix[9].0 (key T) */ \
     COREPORT_BIT(     0x0800, "Test / Service Menu", KEYCODE_7) /* -> swMatrix[9].1; service-menu enter: Bike Race C4 Test code 0x33, Io Moon code 0x3F (F14) */ \
+    /* Lifts the ball off the trough optos while held, so the ball-missing path can be \
+     * exercised without letting go of the matrix test keys.  Inert unless "Balls" > 0, \
+     * and inert on Sleic Pin-Ball, which has no trough model yet (see SWITCH_UPDATE(SLEIC1)). \
+     * Same key as Io Moon's drain, which is the opposite polarity on that machine: there \
+     * the trough contacts mean "ball home" and the key RETURNS one, here they gate the \
+     * ball-present check and the key TAKES one away */ \
+    COREPORT_BIT(     0x1000, "Ball out of trough (needs Balls>0)", KEYCODE_BACKSPACE) \
 
 /*-- Common Inports for SLEIC games whose DIP block has not been traced --*/
 #define SLEIC_COMPORTS \

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -69,8 +69,9 @@ CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)"
 /
 /  For 02 and 05 that inheritance is verified rather than assumed, against a
 /  complete six-chip pull off a V4.1 machine.  01 was never dumped.  06 IS
-/  INHERITED ON THE EVIDENCE BELOW rather than on a dump: the V4.1 ROM 06 in
-/  circulation, CRC ad48a30a, is a BAD DUMP, and no good one exists yet.
+/  INHERITED because a re-dump confirmed it is the parent's: the first V4.1 read
+/  of ROM 06, CRC ad48a30a, was a BAD DUMP, and a re-read came back CRC 9db436d4,
+/  byte-identical to bkcpu06 (see "Confirmed by a second dump" below).
 /
 /  Why ROM 06 is inherited
 /  -----------------------
@@ -111,10 +112,12 @@ CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)"
 /  captured DMD frames identical to substituting the whole chip, seven distinct
 /  screens instead of two.
 /
-/  IF A GOOD V4.1 ROM 06 IS EVER DUMPED and turns out not to be bkcpu06, this
-/  block is what has to change: replace the bkcpu06.bin line with it.  The
-/  evidence above says to expect CRC 9db436d4, but that is a prediction, not a
-/  dump.  The bad image is archived and documented at
+/  CONFIRMED BY A SECOND DUMP.  ROM 06 was re-read from the same V4.1 machine and
+/  came back as CRC 9db436d4 -- byte-identical to bkcpu06 -- passing the checks the
+/  bad read failed (offset 0x1E = 08 00 01 00 08 00, no duplicated 0x200 pages, 12
+/  well-formed sprite records from 0x0000).  So V4.1 is a genuine three-chip clone,
+/  03/04/07 over the parent, and inheriting bkcpu06 is correct rather than inferred.
+/  The bad image (ad48a30a) and this analysis are archived at
 /  sleic-iomoon/roms/related-machines/bike-race/v4.1/. */
 INITGAME(bikerac3, sleic_dispDMD, 0)
 SLEIC_ROMSTART7(bikerac3,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -51,112 +51,69 @@ SLEIC_ROMSTART7(bikerac2,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b
 SLEIC_ROMEND
 CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
-/* V4.1 -- the newest of the three known Bike Race sets (dumped by Joerg Amann).
-/  ROM 01 was not dumped; 02 and 05 are byte-identical to the parent set and are
-/  inherited from it, so only 03/04/06/07 are listed here.  That inheritance is
-/  verified for 02 and 05 against a complete six-chip pull off a V4.1 machine,
-/  not merely assumed; 01 is still assumed.  Relative to bikerace, this set
-/  carries the same F000 code revision as bikerac2 (including the 4-opto trough
-/  handler that can report "FALTA 2 BOLAS"), and adds changes of its own to the
-/  OKI sample ROM (03), the character/graphics ROM (06) and the game data (04).
+/* V4.1 -- the newest of the three known Bike Race sets.  Three chips differ from
+/  the parent: the OKI sample ROM 03 (by 229 bytes), the game code 04 and the Z80
+/  I/O code 07, both full rebuilds.  Chips 01, 02, 05 and 06 are the parent's.
 /
-/  NOT WORKING: it boots and runs, but the artwork comes out as garbage.  The
-/  cause is in the ROM set, not in this driver: ROM 06 does not match ROM 04.
+/  For 02 and 05 that inheritance is verified rather than assumed, against a
+/  complete six-chip pull off a V4.1 machine.  01 was never dumped.  06 IS
+/  INHERITED ON THE EVIDENCE BELOW rather than on a dump: the V4.1 ROM 06 in
+/  circulation, CRC ad48a30a, is a BAD DUMP, and no good one exists yet.
 /
-/  ROM 06 holds the sprite/character table in its first 0x1104 bytes -- the only
-/  part of that chip V4.1 changes -- as records of a 6-byte header W,1,H followed
-/  by ceil(W/8)*H*3 bytes of plane 0, plane 1 and mask.  ROM 04 reaches them
-/  through far pointers held in its own code segment, and those pointers are
-/  BYTE-IDENTICAL to the 1992 set's: every one of the 24 seg-0x2000 pointer slots
-/  in bk04 holds the same offset as the matching slot in bkcpu04, 0x0000, 0x012C,
-/  0x014A, 0x03A2 and 0x05FA among them.  bkcpu06 carries a well-formed record at
-/  each of those offsets (eleven 8x8 sprites on a 0x1E stride, then an 18x18 at
-/  0x014A).  bk06 carries none: it has 19 well-formed headers where bkcpu06 has
-/  32, at different offsets, and the very first record of the chain at 0x0000 is
-/  already malformed.  The same code reading the same addresses therefore finds
-/  no sprite, and draws the garbage.
+/  Why ROM 06 is inherited
+/  -----------------------
+/  ROM 06 holds the sprite/character table in its first 0x1104 bytes, as records
+/  of a 6-byte header W,1,H followed by ceil(W/8)*H*3 bytes of plane 0, plane 1
+/  and mask.  ROM 04 reaches them through far pointers in its own code segment,
+/  and those pointers are byte-identical to bkcpu04's -- all 24 segment-0x2000
+/  slots, and likewise every slot for ROM 05 and the DMD buffer.  Logging every
+/  80188 read of that window, bikerace and the bad V4.1 set are identical for 120
+/  accesses -- both fetch the 18x18 record at 0x20366 -- and then split on one
+/  byte at flat 0x2001E, the table's second record: the parent reads
+/  08 00 01 00 08 00 and draws an 8x8 sprite, the bad set reads 18 06 26 26 3C 3C,
+/  a width of 1560 pixels, and runs away.
 /
-/  Substituting bkcpu06 for bk06 -- or just its first 0x1104 bytes, leaving the
-/  other 124 KB of V4.1's own graphics in place -- makes this set render exactly
-/  like the parent: 5131 of 5131 captured DMD frames identical between the two
-/  substitutions, seven distinct screens instead of two, the "SLEIC PRESENTA" and
-/  "FALTAN n BOLAS" screens clean.  So ROM 03, 04 and 07 of this set are sound
-/  and the fault is confined to bk06[0x0000:0x1104].
+/  The machine that dump came from displays text correctly, per its owner.  For
+/  that to be true the byte at 0x2001E must be 0x08, so the file is not what the
+/  chip holds -- the read is at fault and the chip is fine.  Four things agree:
 /
-/  bk06 CONTAINS NO NEW ARTWORK, which is what says it is not a genuine V4.1
-/  revision of the table.  Classify each byte of bk06[0x0000:0x1200] as either
-/  bkcpu06's byte at the same address or its byte 0x200 further on, and all but
-/  two are accounted for -- 2099 displaced by +0x200, 2507 correct, 2 left over:
+/    * The bad file duplicates pages.  bk06[0x0400:0x0600] == bk06[0x0600:0x0800],
+/      likewise 0x0800/0x0A00 and 0x0C00/0x0E00.  No sprite table on a 0x1E record
+/      stride looks like that, and bkcpu06 does not.
+/    * Every differing byte is recycled.  Classify bk06[0x0000:0x1200] as either
+/      bkcpu06's byte at the same address or its byte 0x200 on, and all but two
+/      are accounted for: 2099 displaced, 2507 correct, 2 left over.  A revised
+/      table would hold revised sprites; this one holds two new bytes.
+/    * No Bike Race revision has ever changed a graphics ROM.  There are two, 05
+/      at MCS2 0x40000 and 06 at MCS1 0x20000, and 05 -- the larger bank, 133
+/      records against 06's 32 -- is byte-identical in bikerace, bikerac2 and
+/      V4.1.  bikerac2 rebuilds 04 and 07 and still leaves both alone.  The same
+/      dump session read 05 perfectly, with none of the page duplication, so the
+/      fault is one chip's read rather than the reader.
+/    * The surviving records line up with the intact bytes exactly.  Of bkcpu06's
+/      32 records, the 15 that survive into the bad dump all sit in correctly-read
+/      windows and the 17 that are lost all sit in mis-read ones, zero anomalies.
+/      It is bkcpu06's table with the damaged pages knocked out, not another one.
 /
-/      0x0000-0x002D  +0x200      0x0600-0x07FF  same
-/      0x002E-0x002F  NEITHER     0x0800-0x09FF  +0x200
-/      0x0030-0x00FF  same        0x0A00-0x0BFF  same
-/      0x0100-0x01FF  +0x200      0x0C00-0x0DFF  +0x200
-/      0x0200-0x03FF  same        0x0E00-0x0FFF  same
-/      0x0400-0x05FF  +0x200      0x1000-0x1104  +0x200
-/                                 0x1105-0x11FF  same
+/  With bkcpu06 in place the set renders exactly like the parent -- 5131 of 5131
+/  captured DMD frames identical to substituting the whole chip, seven distinct
+/  screens instead of two.
 /
-/  Every run is exact.  A revised sprite table would hold revised sprites; this
-/  one holds two bytes that are not already in the 1992 chip, recycled at a
-/  0x200 page granularity no build tool produces.  It is NOT a stuck address
-/  line -- 0x0030-0x00FF and 0x1105-0x11FF have bit 9 clear and are correct, and
-/  the 0x1104 boundary falls mid-block where no address line can change.
-/
-/  Traced at runtime the divergence is one byte.  Logging every 80188 read of the
-/  ROM 06 window, the two sets are identical for 120 accesses -- both fetch the
-/  18x18 record at 0x20366 -- and then split at flat 0x2001E, the table's second
-/  record: bikerace reads 08 00 01 00 08 00 and draws an 8x8 sprite, bikerac3
-/  reads 18 06 26 26 3C 3C, a width of 0x0618 = 1560 pixels, and runs away (3514
-/  reads reaching 0x20D5F against 180 reaching 0x203A1).
-/
-/  THE MACHINE THIS SET CAME FROM RUNS CORRECTLY, per its owner, and that settles
-/  what the bytes could not: for it to work, the byte at 0x2001E must be 0x08, and
-/  the file says 0x18, so the file is not what the chip holds.  The read is at
-/  fault and the physical ROM 06 is fine.  That also fits the damage stopping
-/  after 4 KB rather than following an address line -- a marginal contact, or a
-/  reader that fetched the opening pages twice, corrupts the start of a read and
-/  then settles.
-/
-/  Nothing on the driver side compensates, which was tested rather than assumed:
-/  loading bkcpu05 in the 06 slot, and rotating bk06 0x200 each way, all still
-/  fail (2, 8 and 2 distinct DMD frames over 600, against 7 for a working set).
-/  The emulation is faithfully reading the byte the file contains.
-/
-/  Three further things say the chip is simply the 1992 one.  Bike Race has two
-/  graphics ROMs, 05 at MCS2 0x40000 and 06 at MCS1 0x20000; 05 is the larger
-/  sprite bank, 133 well-formed records against 06's 32, and is byte-identical
-/  across every known set (CRC 072ce879 in bikerace, bikerac2 and V4.1).  First,
-/  no Bike Race revision has ever changed a graphics ROM -- bikerac2 rebuilds 04
-/  and 07 and leaves both alone -- so a V4.1 that revised 06 would be the only
-/  exception in the family.  Second, the same dump session read 05 perfectly,
-/  128 KB correct with none of the page duplication bk06 shows, so the fault is
-/  one chip's read and not the setup.  Third, of the 32 records in bkcpu06, the
-/  15 that survive into bk06 all sit in correctly-read windows and the 17 that
-/  are lost all sit in mis-read ones, with zero anomalies: bk06's table is not a
-/  different 19-record table but the 1992 table with the damaged pages knocked
-/  out.
-/
-/  So the set needs a re-read of ROM 06, checking offset 0x001E first: it must be
-/  08 00 01 00 08 00.  The expected outcome is bkcpu06, CRC 9db436d4, which would
-/  make V4.1 a three-chip clone -- bk03, bk04 and bk07 over the parent set.
-/
-/  Either way this is not a driver change.  It is not a missing chip: the V4.1
-/  16-bit board carries exactly three 27C010 positions and all three are
-/  populated, so the seven-chip complement this driver expects is the whole
-/  machine.  Nor is it a mapping question: bk04's chip-select table (MMCS 0x01FF,
-/  PACS 0xA03C, MPCS 0xC0FC, at file offset 0x50) is byte-identical to bkcpu04's,
-/  so V4.1 decodes ROM 06 at MCS1 0x20000 and ROM 05 at MCS2 0x40000 exactly as
-/  the 1992 sets do. */
+/  IF A GOOD V4.1 ROM 06 IS EVER DUMPED and turns out not to be bkcpu06, this
+/  block is what has to change: replace the bkcpu06.bin line with it.  The
+/  evidence above says to expect CRC 9db436d4, but that is a prediction, not a
+/  dump.  The bad image is archived and documented at
+/  sleic-iomoon/roms/related-machines/bike-race/v4.1/. */
 INITGAME(bikerac3, sleic_dispDMD, 2)
 SLEIC_ROMSTART7(bikerac3,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bk03.bin",    CRC(74c10536) SHA1(43a2a63494b044fe2326ee09831ef90f37d3b432),
 						 "bk04.bin",    CRC(33fd212e) SHA1(9471e34fc4280741816d65f88590febc9e8629a7),
 						 "bkcpu05.bin", CRC(072ce879) SHA1(4f6fb044592feb4c72bbdcbe5f19e063c0e49d0d),
-						 "bk06.bin",    CRC(ad48a30a) SHA1(183b04699b038811de950bba6b8a067689bdb883),
+						 "bkcpu06.bin", CRC(9db436d4) SHA1(3869524c0490e0a019d2f8ab46546ff42727665e),
 						 "bk07.bin",    CRC(200ff3fc) SHA1(96fc8561b078c5306b15e260436e3d3ba562c51d))
 SLEIC_ROMEND
-CORE_CLONEDEFNV(bikerac3,bikerace,"Bike Race (V4.1)",1992,"Sleic (Spain)",gl_mSLEIC3,GAME_NOT_WORKING)
+CORE_CLONEDEFNV(bikerac3,bikerace,"Bike Race (V4.1)",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
 /*-------------------------------------------------------------------
 / Sleic Pin-Ball (1993)

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -122,11 +122,23 @@ CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)"
 /  fail (2, 8 and 2 distinct DMD frames over 600, against 7 for a working set).
 /  The emulation is faithfully reading the byte the file contains.
 /
-/  What the set needs is a re-read of ROM 06, checking offset 0x001E first: it
-/  must be 08 00 01 00 08 00.  Whether the corrected chip then matches bkcpu06
-/  (CRC 9db436d4), which would make V4.1 a three-chip clone, is open -- the
-/  substitution only shows that A valid table at those offsets works, not that
-/  V4.1's table is the 1992 one.
+/  Three further things say the chip is simply the 1992 one.  Bike Race has two
+/  graphics ROMs, 05 at MCS2 0x40000 and 06 at MCS1 0x20000; 05 is the larger
+/  sprite bank, 133 well-formed records against 06's 32, and is byte-identical
+/  across every known set (CRC 072ce879 in bikerace, bikerac2 and V4.1).  First,
+/  no Bike Race revision has ever changed a graphics ROM -- bikerac2 rebuilds 04
+/  and 07 and leaves both alone -- so a V4.1 that revised 06 would be the only
+/  exception in the family.  Second, the same dump session read 05 perfectly,
+/  128 KB correct with none of the page duplication bk06 shows, so the fault is
+/  one chip's read and not the setup.  Third, of the 32 records in bkcpu06, the
+/  15 that survive into bk06 all sit in correctly-read windows and the 17 that
+/  are lost all sit in mis-read ones, with zero anomalies: bk06's table is not a
+/  different 19-record table but the 1992 table with the damaged pages knocked
+/  out.
+/
+/  So the set needs a re-read of ROM 06, checking offset 0x001E first: it must be
+/  08 00 01 00 08 00.  The expected outcome is bkcpu06, CRC 9db436d4, which would
+/  make V4.1 a three-chip clone -- bk03, bk04 and bk07 over the parent set.
 /
 /  Either way this is not a driver change.  It is not a missing chip: the V4.1
 /  16-bit board carries exactly three 27C010 positions and all three are

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -53,21 +53,88 @@ CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)"
 
 /* V4.1 -- the newest of the three known Bike Race sets (dumped by Joerg Amann).
 /  ROM 01 was not dumped; 02 and 05 are byte-identical to the parent set and are
-/  inherited from it, so only 03/04/06/07 are listed here.  Relative to bikerace,
-/  this set carries the same F000 code revision as bikerac2 (including the 4-opto
-/  trough handler that can report "FALTA 2 BOLAS"), and adds changes of its own to
-/  the OKI sample ROM (03), the character/graphics ROM (06) and the game data (04).
+/  inherited from it, so only 03/04/06/07 are listed here.  That inheritance is
+/  verified for 02 and 05 against a complete six-chip pull off a V4.1 machine,
+/  not merely assumed; 01 is still assumed.  Relative to bikerace, this set
+/  carries the same F000 code revision as bikerac2 (including the 4-opto trough
+/  handler that can report "FALTA 2 BOLAS"), and adds changes of its own to the
+/  OKI sample ROM (03), the character/graphics ROM (06) and the game data (04).
 /
-/  NOT WORKING: it boots and runs, but the artwork comes out as garbage, and the
-/  reason looks like a missing or differently-mapped graphics ROM rather than a
-/  driver bug.  The graphics descriptor table lives in the first 4KB of ROM 06 --
-/  the only part of that chip this revision changed -- and where the 1992 sets
-/  fetch their artwork from 0x40000 (ROM 05), V4.1's table sends the fetch to
-/  0x24000, i.e. into ROM 06 itself, whose contents from 0x1104 on are byte-for-byte
-/  the 1992 data.  Drawing from there produces the garbage.  Swapping the 05/06 bank
-/  order, and relocating ROM 05's artwork to 0x24000, both fail, so the set as dumped
-/  does not contain what its own table points at.  Resolving this needs the V4.1
-/  board's ROM complement confirmed (ROM 01 was never dumped) or its PAL. */
+/  NOT WORKING: it boots and runs, but the artwork comes out as garbage.  The
+/  cause is in the ROM set, not in this driver: ROM 06 does not match ROM 04.
+/
+/  ROM 06 holds the sprite/character table in its first 0x1104 bytes -- the only
+/  part of that chip V4.1 changes -- as records of a 6-byte header W,1,H followed
+/  by ceil(W/8)*H*3 bytes of plane 0, plane 1 and mask.  ROM 04 reaches them
+/  through far pointers held in its own code segment, and those pointers are
+/  BYTE-IDENTICAL to the 1992 set's: every one of the 24 seg-0x2000 pointer slots
+/  in bk04 holds the same offset as the matching slot in bkcpu04, 0x0000, 0x012C,
+/  0x014A, 0x03A2 and 0x05FA among them.  bkcpu06 carries a well-formed record at
+/  each of those offsets (eleven 8x8 sprites on a 0x1E stride, then an 18x18 at
+/  0x014A).  bk06 carries none: it has 19 well-formed headers where bkcpu06 has
+/  32, at different offsets, and the very first record of the chain at 0x0000 is
+/  already malformed.  The same code reading the same addresses therefore finds
+/  no sprite, and draws the garbage.
+/
+/  Substituting bkcpu06 for bk06 -- or just its first 0x1104 bytes, leaving the
+/  other 124 KB of V4.1's own graphics in place -- makes this set render exactly
+/  like the parent: 5131 of 5131 captured DMD frames identical between the two
+/  substitutions, seven distinct screens instead of two, the "SLEIC PRESENTA" and
+/  "FALTAN n BOLAS" screens clean.  So ROM 03, 04 and 07 of this set are sound
+/  and the fault is confined to bk06[0x0000:0x1104].
+/
+/  bk06 CONTAINS NO NEW ARTWORK, which is what says it is not a genuine V4.1
+/  revision of the table.  Classify each byte of bk06[0x0000:0x1200] as either
+/  bkcpu06's byte at the same address or its byte 0x200 further on, and all but
+/  two are accounted for -- 2099 displaced by +0x200, 2507 correct, 2 left over:
+/
+/      0x0000-0x002D  +0x200      0x0600-0x07FF  same
+/      0x002E-0x002F  NEITHER     0x0800-0x09FF  +0x200
+/      0x0030-0x00FF  same        0x0A00-0x0BFF  same
+/      0x0100-0x01FF  +0x200      0x0C00-0x0DFF  +0x200
+/      0x0200-0x03FF  same        0x0E00-0x0FFF  same
+/      0x0400-0x05FF  +0x200      0x1000-0x1104  +0x200
+/                                 0x1105-0x11FF  same
+/
+/  Every run is exact.  A revised sprite table would hold revised sprites; this
+/  one holds two bytes that are not already in the 1992 chip, recycled at a
+/  0x200 page granularity no build tool produces.  It is NOT a stuck address
+/  line -- 0x0030-0x00FF and 0x1105-0x11FF have bit 9 clear and are correct, and
+/  the 0x1104 boundary falls mid-block where no address line can change.
+/
+/  Traced at runtime the divergence is one byte.  Logging every 80188 read of the
+/  ROM 06 window, the two sets are identical for 120 accesses -- both fetch the
+/  18x18 record at 0x20366 -- and then split at flat 0x2001E, the table's second
+/  record: bikerace reads 08 00 01 00 08 00 and draws an 8x8 sprite, bikerac3
+/  reads 18 06 26 26 3C 3C, a width of 0x0618 = 1560 pixels, and runs away (3514
+/  reads reaching 0x20D5F against 180 reaching 0x203A1).
+/
+/  THE MACHINE THIS SET CAME FROM RUNS CORRECTLY, per its owner, and that settles
+/  what the bytes could not: for it to work, the byte at 0x2001E must be 0x08, and
+/  the file says 0x18, so the file is not what the chip holds.  The read is at
+/  fault and the physical ROM 06 is fine.  That also fits the damage stopping
+/  after 4 KB rather than following an address line -- a marginal contact, or a
+/  reader that fetched the opening pages twice, corrupts the start of a read and
+/  then settles.
+/
+/  Nothing on the driver side compensates, which was tested rather than assumed:
+/  loading bkcpu05 in the 06 slot, and rotating bk06 0x200 each way, all still
+/  fail (2, 8 and 2 distinct DMD frames over 600, against 7 for a working set).
+/  The emulation is faithfully reading the byte the file contains.
+/
+/  What the set needs is a re-read of ROM 06, checking offset 0x001E first: it
+/  must be 08 00 01 00 08 00.  Whether the corrected chip then matches bkcpu06
+/  (CRC 9db436d4), which would make V4.1 a three-chip clone, is open -- the
+/  substitution only shows that A valid table at those offsets works, not that
+/  V4.1's table is the 1992 one.
+/
+/  Either way this is not a driver change.  It is not a missing chip: the V4.1
+/  16-bit board carries exactly three 27C010 positions and all three are
+/  populated, so the seven-chip complement this driver expects is the whole
+/  machine.  Nor is it a mapping question: bk04's chip-select table (MMCS 0x01FF,
+/  PACS 0xA03C, MPCS 0xC0FC, at file offset 0x50) is byte-identical to bkcpu04's,
+/  so V4.1 decodes ROM 06 at MCS1 0x20000 and ROM 05 at MCS2 0x40000 exactly as
+/  the 1992 sets do. */
 INITGAME(bikerac3, sleic_dispDMD, 2)
 SLEIC_ROMSTART7(bikerac3,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),

--- a/src/wpc/sleicgames.c
+++ b/src/wpc/sleicgames.c
@@ -29,7 +29,19 @@ static core_tLCDLayout sleic_dispDMD[] = {
 /*-------------------------------------------------------------------
 / Bike Race (1992)
 /-------------------------------------------------------------------*/
-INITGAME(bikerace, sleic_dispDMD, 2)
+/* "Balls" is 0 on all three Bike Race sets, and for this family that is not a ball count
+   -- it is the OFF position of the driver's optional ball-present model
+   (sleic3_ball_update in sleic.c).  Off is the PinMAME convention: swMatrix[5]'s COL4
+   optos are ordinary switches, and closing them is the frontend's job -- a VPinMAME table
+   script's, or standalone the matrix test keys 8 and '-'.  Io Moon does the same and sits
+   on "FALTA 1 BOLA" until its trough contacts close.
+
+   Set "Balls" to any non-zero value to turn the model on for standalone desktop play,
+   where nothing else is going to close them.  Unlike Io Moon there is no meaningful
+   number here: the firmware answers a ball-PRESENT query rather than counting a trough,
+   so the model presents the whole complement or none of it, and the cabinet port's "Ball
+   out of trough" key (Backspace) lifts it while held. */
+INITGAME(bikerace, sleic_dispDMD, 0)
 SLEIC_ROMSTART7(bikerace,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bksnd03.bin", CRC(b6d00245) SHA1(f7da6f2ca681fbe62ea9cab7f92d3e501b7e867d),
@@ -40,7 +52,7 @@ SLEIC_ROMSTART7(bikerace,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b
 SLEIC_ROMEND
 CORE_GAMEDEFNV(bikerace,"Bike Race",1992,"Sleic (Spain)",gl_mSLEIC3,0)
 
-INITGAME(bikerac2, sleic_dispDMD, 2)
+INITGAME(bikerac2, sleic_dispDMD, 0)
 SLEIC_ROMSTART7(bikerac2,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bksnd03.bin", CRC(b6d00245) SHA1(f7da6f2ca681fbe62ea9cab7f92d3e501b7e867d),
@@ -104,7 +116,7 @@ CORE_CLONEDEFNV(bikerac2,bikerace,"Bike Race (2-ball play)",1992,"Sleic (Spain)"
 /  evidence above says to expect CRC 9db436d4, but that is a prediction, not a
 /  dump.  The bad image is archived and documented at
 /  sleic-iomoon/roms/related-machines/bike-race/v4.1/. */
-INITGAME(bikerac3, sleic_dispDMD, 2)
+INITGAME(bikerac3, sleic_dispDMD, 0)
 SLEIC_ROMSTART7(bikerac3,"bkdsp01.bin", CRC(9b220fcb) SHA1(54e82705d8ce8a26d9e1b5f0fe382ded1f2070c3),
 						 "bksnd02.bin", CRC(d67b3883) SHA1(712022b9b24c6ab559d020ab8e2106f68b4d7896),
 						 "bk03.bin",    CRC(74c10536) SHA1(43a2a63494b044fe2326ee09831ef90f37d3b432),


### PR DESCRIPTION
Makes the Bike Race V4.1 set (`bikerac3`) work — it was registered
`GAME_NOT_WORKING` because it rendered garbage artwork — and adds an opt-in ball
model so all three Bike Race sets can be started standalone without holding
matrix keys.

## Bike Race V4.1 renders correctly now

The garbage was a **bad ROM 06 dump**, not a driver problem. `bikerac3`'s ROM 06,
CRC `ad48a30a`, is a defective read (confirmed with Joerg): its first `0x1104` bytes (the sprite/character
table) are the parent chip's own data with several `0x200`-byte pages duplicated,
so the 80188 reads a malformed record at the first sprite and runs off into the
blit loop.

Evidence, and how it was confirmed:

- ROM 04's far pointers into the sprite table are **byte-identical** to the 1992
  set's, and they point at addresses the good chip has records at and the bad dump
  does not.
- A logging read handler shows both sets fetching the same 120 bytes and then
  splitting on one: at flat `0x2001E` the parent reads `08 00 01 00 08 00` (a valid
  8×8 record) and the bad set reads `18 06 26 26 3C 3C`, a width of 1560 px.
- No Bike Race revision has ever changed a graphics ROM — ROM 05 is byte-identical
  across `bikerace`, `bikerac2` and V4.1, and it read perfectly in the same dump.
- **A re-dump of ROM 06 from the same V4.1 machine came back CRC `9db436d4`,
  byte-identical to the parent's `bkcpu06`,** passing every check the bad read
  failed.

So V4.1 is a genuine three-chip clone (`03`/`04`/`07` over the 1992 set), and this
PR inherits `bkcpu06` for ROM 06 and clears `GAME_NOT_WORKING`. The driver requires
CRC `9db436d4` and rejects the bad `ad48a30a` image (`bkcpu06.bin WRONG CHECKSUMS`).

Full write-up, disassembly and captures:
https://github.com/gerwout/sleic-iomoon/tree/main/asm/bikerace-2026-09

## Opt-in ball model for Bike Race

Standalone, Bike Race sits on "FALTA n BOLAS" until its trough optos are closed,
which otherwise means holding two matrix keys for the whole session. This mirrors
Io Moon's existing opt-in trough model: the `Balls` setting is the switch,
**default 0 = off** so a frontend/table still owns the optos and nothing is
fabricated; any non-zero value turns it on, and a new "Ball out of trough" cabinet
key lifts it. One `0xE0` opto mask satisfies all three sets' ball-status handlers.

Also in here (comment-only): the SLEIC3 memory-map comment had MCS1/MCS2 labelled
with each other's chip, and the COL4 trough optos are now named from the firmware's
own contact table (C6 "Salida Bolas", C7 "Bola en Espera", C8 "Bola Fuera").

## Testing (Linux, SDL3 build)

- All seven SLEIC sets pass `validitychecks` under the `MAME_DEBUG` build.
- `bikerace`, `bikerac2`, `bikerac3` boot, attract, take coins and play; V4.1's
  DMD output matches the parent frame-for-frame.
- `bikerac3` loads with no ROM warnings and starts without `-skip_gamewarnings`.

## Note: a pre-existing sound regression on Linux (not addressed here)
 
@toxieainc Unrelated to this PR, but worth flagging: on Linux, **Bike Race and Sleic Pin-Ball
FM audio plays slow/degraded on current builds**, and it was fine when the
Pin-Ball/Bike Race sets were first added (#627). Some change merged since then
introduced it. Io Moon (added later) is unaffected, so it splits by driver family
(SLEIC1/SLEIC3 affected, SLEIC2 not). The YM3812 register streams are byte-identical
between the old and new builds, so the emulation is generating the same data — the
regression is downstream (timing/output), not in the game drivers. This PR neither
causes nor fixes it; noting it here for visibility. I only confirmed this in Linux (Kali), so I did
not confirm if this is Linux only.