### PR TITLE
Sleic Pin-Ball sound and DMD shading fixes

### DIFF
--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -745,17 +745,16 @@ static WRITE_HANDLER(pic_w) {
 
 /* Bike Race (SLEIC3) PACS peripheral chip-select block at segment A000h (base 0xA0000,
  * PCS0-PCS6 on 0x80 boundaries), read off schematic REF 011-026 sheets 3 and 4:
- *   0xA0000 PCS0  IC32 74LS273 control latch: bit 1 YA0 (YM3812 A0), bit 2 /RCS,
+ *   0xA0000 PCS0  IC32 74LS273 control latch: bit 1 YA0 (YM3812 A0), bit 2 RES,
  *                 bit 3 2CH (OKI channel), bit 4 /ST (OKI start), bits 5-7 X9103 pot
  *   0xA0080 PCS1  command byte to the I/O side (J1 link)
  *   0xA0280 PCS5  YM3812 -- ONE address; index vs data is PCS0 bit 1 (net YA0)
  *   0xA0300 PCS6  IC45 74LS273 OKI phrase latch, I0-I6 (bit 7 unconnected)
  *
  * YM3812 (IC41) = in-game FM music; OKI MSM6376 (IC46) = speech/FX, run as two
- * channels selected by 2CH at the /ST edge -> sleic3_oki_strobe.  A phrase written to
+ * channels selected by 2CH at the /ST edge -> sleic_oki_strobe.  A phrase written to
  * 0xA0300 ARMS the next /ST rising edge (0xA0000 bit 4), which STARTS it
- * -> locals.okiLatch / locals.okiPrevStrobe / locals.okiPending.  sleic_oki_trigger
- * just below is Pin-Ball's (SLEIC1) single-voice model and is left exactly as it was. */
+ * -> locals.okiLatch / locals.okiPrevStrobe / locals.okiPending. */
 
 /* J1 inbound byte latch (IC43 at 80188 PCS2 = 0xA0100): the last byte the Z80 strobed
  * across the J1 port. The Z80's port-0x81 bit-2 strobe latches the byte AND raises the
@@ -763,41 +762,39 @@ static WRITE_HANDLER(pic_w) {
  * pushes the byte into the display command queue at 4000:1220 and sets the frame-pending
  * flag [4000:1147] that vsync_check (D000:5D1B) waits on -> locals.j1* */
 
-static void sleic_oki_trigger(void) {
-  UINT8 sample =  locals.okiLatch & 0x7f;              /* phrase number     */
-  UINT8 voice  = (locals.okiLatch & 0x80) ? 0x1 : 0x2; /* ch A=v0 / ch B=v1 */
-  locals.okiPending = 0;
-  if (!sample) return;
-#ifdef DEBUG_SLEIC
-  if (getenv("SLEIC_TRACE_SND")) fprintf(stderr, "[oki] phrase %02x\n", sample);
-#endif
-  OKIM6376_data_0_w(0, 0x80 | sample); /* latch phrase number           */
-  OKIM6376_data_0_w(0, voice << 4);    /* trigger playback on the voice */
-}
-
-/* Bike Race (SLEIC3) OKI MSM6376 strobe.  Separate from sleic_oki_trigger above, which
- * Pin-Ball (SLEIC1) shares and which must keep its byte-for-byte behaviour.
+/* OKI MSM6376 strobe, shared by Bike Race (SLEIC3) and Sleic Pin-Ball (SLEIC1).  Both
+ * boards are schematic ref 011-026, so the same IC32 control latch drives both, and both
+ * firmwares run the 6376 as TWO concurrent channels.  (Io Moon has its own
+ * iomoon_oki_strobe: its channel really is latch bit 7.)
  *
- * The firmware runs the 6376 as TWO concurrent channels.  The channel is NOT a bit of
- * the phrase byte -- every 0xA0300 write is masked with AND AL,07F first (E0CCE / E0CF9),
- * and on the board bit 7 of the IC45 phrase latch is unconnected -- it is PCS0 bit 3,
- * IC32 4Q = 2CH (schematic sheet 3 p122, OKI pin 63 on sheet 4).  The channel-1 trigger
- * sub_E0CBF leaves 2CH high; the channel-2 trigger sub_E0CEA clears it (E0D0C-E0D14)
- * around the /ST pulse (bit 4, IC32 5Q) and restores it after (E0D1B-E0D23), so the
- * channel is the state of bit 3 at the /ST rising edge -- which is what this is given.
+ * The channel is NOT a bit of the phrase byte here -- Bike Race masks every 0xA0300 write
+ * with AND AL,07F (E0CCE / E0CF9), Pin-Ball never sets bit 7 at all (its 63 phrase stubs
+ * are 0x01-0x3F), and on the board bit 7 of the IC45 phrase latch is unconnected.  It is
+ * PCS0 bit 3, IC32 4Q = 2CH (sheet 3, OKI pin 63 on sheet 4), sampled at the /ST rising
+ * edge (bit 4, IC32 5Q), which is what this is given:
+ *   Bike Race -- channel-1 trigger sub_E0CBF leaves 2CH high; channel-2 trigger
+ *                sub_E0CEA clears it (E0D0C-E0D14) around the /ST pulse and restores it
+ *                after (E0D1B-E0D23).
+ *   Pin-Ball  -- one trigger (sp03 E000:1B26-1B6A) alternates on a toggle at [0x27c]:
+ *                even calls strobe with 2CH high, odd calls clear it (0x1B4F/0x1B55),
+ *                strobe (0x1B6B), then restore it (0x1B60/0x1B66).
  * Both channels reach the core's two 6376 voices (adpcm.c: bit 4 = voice 0, bit 5 =
- * voice 1 on data >> 4); collapsing them onto one voice, as the old model did, made
- * adpcm.c refuse the second of every overlapping pair (its start on a still-playing
- * voice is dropped at OKIM6376_data_w) -- exactly how START issues phrase 19, the 4.7 s
- * motor sample in BK03, on channel 2 while phrase 1 is still running on channel 1.
+ * voice 1 on data >> 4).  Collapsing them onto one voice, as the old model did, made
+ * adpcm.c refuse the second of every overlapping pair (a start on a still-playing voice
+ * is dropped in OKIM6376_data_w) -- Bike Race's START issues phrase 19, the 4.7 s motor
+ * sample in BK03, on channel 2 while phrase 1 still runs on channel 1; Pin-Ball's START
+ * issues 0x16 then 0x2f, and its tilt 0x21, 0x37, 0x2b.
  *
- * The abort-before-start is the same as iomoon_oki_strobe: the firmware's only busy
- * model is its own software counter per channel ([01BE] / [01C1]), which can expire a
- * little before the emulated sample ends (the interface rate is ~2 % under the
- * firmware-implied ~30.9 kHz), so a re-issue on a channel the firmware considers free
- * must restart, not be refused.  Phrase 0 is the stop-all sub_E0D2D (latch 0, /ST held
- * low, released two timer ticks later by sub_E0D7E): silence both voices */
-static void sleic3_oki_strobe(UINT8 pcs0) {
+ * The abort-before-start is the same as iomoon_oki_strobe.  Bike Race's only busy model
+ * is its own software counter per channel ([01BE] / [01C1]), which can expire a little
+ * before the emulated sample ends; Pin-Ball has no busy model at all -- no BUSY read, no
+ * counters, no drop rule, so its n-th phrase goes to channel n mod 2 whether or not that
+ * channel is still playing.  Either way a re-issue must restart, not be refused.
+ *
+ * Phrase 0 is a stop-all: Bike Race's sub_E0D2D (latch 0, /ST held low, released two
+ * timer ticks later by sub_E0D7E), and Pin-Ball's E000:1AEF, which strobes phrase 0 once
+ * per channel -- run at boot and again by the menu-exit soft reboot (F000:57FD) */
+static void sleic_oki_strobe(UINT8 pcs0) {
   const UINT8 phrase = locals.okiLatch & 0x7f;
   const UINT8 voice  = (pcs0 & 0x08) ? 0 : 1;     /* 2CH high = channel 1 = voice 0     */
   locals.okiPending = 0;
@@ -849,7 +846,7 @@ static WRITE_HANDLER(sleic_periph_w) {
        * channel is read from bit 3 at the /ST rising edge */
       locals.ymA0 = (data >> 1) & 1;
       if (locals.okiPending && (data & 0x10) && !(locals.okiPrevStrobe & 0x10))
-        sleic3_oki_strobe(data);
+        sleic_oki_strobe(data);
       locals.okiPrevStrobe = data;
       break;
     case 0x080:                        /* PCS1: command byte the 80188 sends to the I/O side */
@@ -1016,8 +1013,9 @@ static NVRAM_HANDLER(SLEIC1) {
  *    PCS5 (0xA0280)  = YM3812 register/data (A0 from PCS0 bit 1; see locals.ymA0).
  *    PCS6 (0xA0300)  = OKI MSM6376 phrase latch (the phrase number, sp03 0x1B36/0x1B47).
  *    PCS0 (0xA0000)  = shared control shadow [0x4da]: bit1 = YM3812 A0, bit4 (0x10) =
- *                      OKI /OKCS strobe (rising edge fires the latched phrase, sp03
- *                      0x1B6B), bit3 (0x08) = OKI channel.
+ *                      the OKI /ST start strobe (rising edge fires the latched phrase,
+ *                      sp03 0x1B6B), bit3 (0x08) = 2CH, the OKI channel select, which
+ *                      the trigger at sp03 0x1B26 alternates on every call.
  *
  * PCS4 (0xA0200) is the DMD frame strobe (shadow [0x4de]) -- left alone, since the
  * I8039 renders sleicpin's DMD from the 0x60410 frame buffer, not from a strobe */
@@ -1034,14 +1032,19 @@ static WRITE_HANDLER(sleic1_periph_w) {
       if (locals.ymA0) YM3812_write_port_0_w(0, data);
       else             YM3812_control_port_0_w(0, data);
       return;
-    case 0x300:                       /* PCS6: OKI MSM6376 phrase latch */
+    case 0x300:                       /* PCS6: IC45 OKI MSM6376 phrase latch, I0-I6 */
       locals.okiLatch = data;
-      if (data & 0x7f) locals.okiPending = 1;
+      /* Every value arms the next /ST edge, INCLUDING zero: sp03 E000:1AEF strobes
+       * phrase 0 once per channel as a stop-all, at boot and again on the menu-exit
+       * soft reboot (F000:57FD).  Gating this on a non-zero phrase discarded both */
+      locals.okiPending = 1;
       return;
-    case 0x000:                       /* PCS0: shared control (bit1 YM A0, bit4 /OKCS) */
+    case 0x000:                       /* PCS0: IC32 control latch */
+      /* bit 1 = YM3812 A0 (latched, sp03 0x1E05); bit 3 = 2CH OKI channel, read by
+       * sleic_oki_strobe at the /ST edge; bit 4 = /ST, the start strobe (sp03 0x1B6B) */
       locals.ymA0 = (data >> 1) & 1;
       if (locals.okiPending && (data & 0x10) && !(locals.okiPrevStrobe & 0x10)) {
-        sleic_oki_trigger();
+        sleic_oki_strobe(data);
       }
       locals.okiPrevStrobe = data;
       return;

--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -44,10 +44,6 @@ static struct {
   /* Bike Race (SLEIC3) interrupt-rate accumulators, see sleic3_irq_gen */
   double int0Acc, t0Acc;
 
-  /* DMD: how the two raster fields are weighted; set in MACHINE_INIT
-   * (see the per-machine notes above sleic_build_dmd_frame) */
-  int    dmdEqualFields;
-
   /* completed-frame latch for the I8039 machines, see SLEIC3_DMD_LATCH_TICKS */
   UINT8  dmdLatch[128 * 32];
   int    dmdLatchTtl;
@@ -429,40 +425,71 @@ static INTERRUPT_GEN(sleic3_irq_gen) {
   else if (locals.int0Acc >= 1.0) { locals.int0Acc -= 1.0; cpu_set_irq_line_and_vector(SLEIC_MAIN_CPU, 0, HOLD_LINE, 0x0C); }
 }
 
-/* How the panel's two raster fields are weighted, which differs per machine because the
- * two games ship different I8039 display ROMs:
+/* How the panel's two raster fields are weighted, and why Pin-Ball takes a different
+ * path through the core from Bike Race and Io Moon.
  *
- *   Sleic Pin-Ball (sp01-1_1.rom): both fields hold the row lit for essentially the same
- *     time -- P1.7 is raised for MOV R6,#30 / DJNZ (98 cycles) in field 1 against
- *     MOV R6,#2E / DJNZ (94 cycles) in field 2, a ratio of 1.04:1.  Two equal fields give
- *     THREE levels, not four: off, one plane (either one, ~50%), both planes (100%).  The
- *     artwork agrees -- in the source images the field-1 plane is a strict subset of the
- *     field-2 plane (e.g. at F000:9943: 0 pixels in field 1 only, 769 in field 2 only,
- *     872 in both), so the pair encodes "lit" plus "lit brightly", not a 2-bit number.
- *     Both single-plane states do occur in the frame buffer during play (measured over a
- *     scripted game: 7.9% of pixels field-1-only, 7.4% field-2-only), and the real panel
- *     shows them at the SAME brightness -- rendering them two levels apart is what made
- *     the shading look wrong against the machine.
+ * Bike Race and Sleic Pin-Ball share the 16-bit board 011-026: the Bike Race manual's
+ * schematic sheets "16 BITS CPU (1)" and "(3)" (REF 011-026 rev 2) carry the I8039 and
+ * the panel drive, and the Pin-Ball manual lists the same board with the same
+ * designators (IC8 80C39, IC6 27C64 DISPLAY, J2 to panel 011-022).  The port bits:
+ * P1.0-P1.5 = frame-RAM row and field address VA4-VA9 (VA9 shares RAM A9 with the
+ * 80188's A11 on an HC157, so raster field 2 reads +0x800), P1.6 = CLRLIN, P1.7 = VSYNC,
+ * P2.4 = RDATA, P2.5 = DE (display enable, active high through a non-inverting 7407 to
+ * J2), P2.6 = RCLK, P2.7 = COLLATCH, T1 = VGT1 (16 bytes shifted).  DE is the panel's
+ * light gate, and the two display ROMs drive it differently in their two fields:
+ *   sp01-1_1.rom (Pin-Ball): field 1 raises DE before the row shift ($015) and again
+ *     through its 48-iteration dwell ($028); field 2 clears DE before its shift ($052,
+ *     ANL P2,#$D0) and raises it only for its 46-iteration dwell ($065).  DE-high per
+ *     row: S+108 cycles against 104, S being the 128-dot shift time.
+ *   bkdsp01.bin (Bike Race): DE high through the shift in both fields, plus a
+ *     32-iteration dwell in field 1 only: S+74 against S+8.
+ * P1.7, whose 48- against 46-iteration dwells read as "equal fields" when it is taken
+ * for the gate, is VSYNC: Bike Race raises it once per frame in the inter-frame gap,
+ * after the 33rd row clock has walked the row select out, so as a light gate it would
+ * show no picture at all.
  *
- *   Bike Race (bkdsp01.bin): field 1 carries an extra MOV R6,#20 / DJNZ dwell (66 cycles)
- *     that field 2 does not have at all, so the fields are strongly asymmetric and the
- *     pair really is a weighted 2-bit value.  Keep the 4-level mapping there.
+ * What those DE times mean for brightness turns on one open question: whether the
+ * 011-022 panel emits light during the COLLATCH-low shift window.  If it does (the
+ * usual plasma-DMD operation), Pin-Ball's +0x000 plane collects S per row on top of
+ * its dwell and the two planes sit near 0.70 and 0.30 of a both-plane pixel at the
+ * sheet's 625 kHz dot clock (PCLK = OCLK/32; OCLK is not printed, 20 MHz is the sister
+ * board's value); if it does not, the planes are 108 against 104 cycles, i.e. equal.
+ * Video of a running machine decides between the two as far as a phone can: the same
+ * 1-dot text ("CREDITOS: 1" over the attract watermark) is +0x000-only in its upper
+ * rows and in both planes in its lower rows, and the lower rows measure about twice
+ * the upper ones (clipped, so a lower bound), where a shift-lit panel cannot exceed
+ * 1.43 at 625 kHz; and the +0x800-only watermark measures the same as +0x000-only
+ * text on the same screen within about ten percent.  Both single-plane levels are
+ * therefore about half of a both-plane pixel, and the panel is modelled as two EQUAL
+ * fields: sleic1_irq_i8039 hands the core each plane as a 1-bit field and the WPC_PH
+ * two-tap integrator averages them (0, 1/2, 1/2, 1), with COMBINER_SUM_2_1 keeping the
+ * raw frame at (p0 << 1) | p1 for the colorizers.  A scope on J2's DE and COLLATCH with
+ * a photodiode on the panel, or an unclipped photograph of a static screen, would pin
+ * the levels beyond what the video bounds; the two readings differ mainly in the
+ * +0x800-only level (0.30 against 0.5), so if fills, shadows and the watermark look too
+ * bright against the machine, that is the number to revisit.
  *
- *   Io Moon (IC23 PIC16C57): a third display program, and the most lopsided of the three
- *     -- 200 row-hold counts for plane 0 against 30 for plane 1.  4 levels, and see
- *     MACHINE_INIT(SLEIC2) for what that ratio does and does not settle.
+ * The same video shows single-plane text clipping white while it is being drawn, slid
+ * or blinked and settling to dim once static -- pixel by pixel on panel rows it shares
+ * with static text, with ten-frame intensity ramps a two-level display cannot produce.
+ * That is the phone's multi-frame processing, not the panel: nothing on 011-026 can
+ * light a freshly written pixel longer than a static one (the I8039 waits on nothing
+ * but VGT1, and the firmware writes blinking text to +0x000 alone), and it must not be
+ * emulated.
  *
- * Set in MACHINE_INIT (locals.dmdEqualFields); SLEIC1 (Sleic Pin-Ball) and SLEIC2 (Io Moon)
- * each state their own */
+ * Bike Race keeps the pre-integrated (p0 << 1) | p1 level frame through LINEAR_4: its
+ * fields are asymmetric under either reading of the shift window (S+74 against S+8, or
+ * 74 against 8).  Io Moon's PIC holds plane 0 for 200 counts against 30 -- see
+ * MACHINE_INIT(SLEIC2) */
 
 /* Decode one 128x32 two-bitplane frame -- 32 rows x 16 bytes per plane, MSB = leftmost
  * pixel, 1 = lit -- into the brightness grid core_dmd_submit_frame takes.  The two planes
  * arrive as pointers because the machines stage them differently: the I8039 games
  * interleave them in the panel buffer at 0x60410 (row stride 0x20, second plane +0x800),
  * Io Moon writes two flat 512-byte planes at 7000:0000 (row stride 0x10, second plane
- * +0x200, findings F13).  p0 is the MSB plane on all three -- see the per-machine
- * weighting note above and the PIC row-hold ratio in MACHINE_INIT(SLEIC2).  No machine
- * inverts: the firmware ANDs, ORs and copies these bytes and never NOTs or XORs them */
+ * +0x200, findings F13).  p0 is the MSB plane on all three -- see the field-weighting
+ * note above and the PIC row-hold ratio in MACHINE_INIT(SLEIC2).  No machine inverts:
+ * the firmware ANDs, ORs and copies these bytes and never NOTs or XORs them */
 static void sleic_build_dmd_frame(UINT8 *dst, const UINT8 *p0, const UINT8 *p1, int rowStride) {
   int ii;
   for (ii = 0; ii < 32; ii++, p0 += rowStride, p1 += rowStride) {
@@ -473,8 +500,7 @@ static void sleic_build_dmd_frame(UINT8 *dst, const UINT8 *p0, const UINT8 *p1, 
       int kk;
       for (kk = 7; kk >= 0; kk--) {
         const int a = (f1 >> kk) & 1, b = (f2 >> kk) & 1;
-        *dst++ = locals.dmdEqualFields ? (a | b ? (a & b ? 3 : 2) : 0) /* 3 levels */
-                                       : ((a << 1) | b);               /* 4 levels */
+        *dst++ = (a << 1) | b;
       }
     }
   }
@@ -529,22 +555,17 @@ static INTERRUPT_GEN(SLEIC_irq_i8039) {
    * lit for different lengths of time.  Bit 5 is the long-dwell field when clear, which
    * makes the +0x000 plane the bright one -- the MSB.
    *
-   * That cannot be read off the raster loop alone, because the 80188 sees the panel RAM
-   * through a scrambled decode (the buffer base 0x410 holds A10 and A4 high, rows step
-   * A5-A9, the plane is A11), so bit 5 cannot be traced to A11 without the board's PAL.
-   * What settles it is how Sleic Pin-Ball actually uses the two planes in play: of 822
-   * distinct in-game frames captured over a scripted game, 613 are drawn entirely into
-   * the +0x000 plane and none of the rest use +0x800 on its own.  The whole ordinary
-   * display -- score, JUGADOR/BOLA, the text screens -- is that one plane, and on the
-   * real machine it reads as a normally bright display with only the highlights (both
-   * planes) hotter.  Making +0x000 the LSB would run the entire game at one third
-   * brightness and leave the two brighter levels almost unused, which is not what the
-   * hardware does.  This also agrees with the blitter, where +0x000 is the primary
-   * lodsb/stosb stream, and with Io Moon's decode above, where the base plane is the
-   * MSB.  (A statistic over the attract animation appears to favour the opposite
-   * assignment by counting single-level pixel steps; it does not, because it assumes
-   * fades are done by toggling the LSB when this firmware fades by toggling the main
-   * plane, which is a two-level step) */
+   * That the two fields are +0x000 and +0x800 is read from the board: on the 011-026
+   * schematic the raster's VA9 (P1.5, row-counter bit 5) and the 80188's A11 are the two
+   * inputs of the same HC157 onto RAM A9, so field 1 (bit 5 clear) reads +0x000 and
+   * field 2 reads +0x800, and the dwell makes field 1 the longer-lit one: +0x000 is the
+   * MSB.  This agrees with the blitter, where +0x000 is the primary lodsb/stosb stream,
+   * with Io Moon's decode above, where the base plane is the MSB, and with how all three
+   * firmwares use the pair -- text in +0x000 alone, fills, shadows and sprite bodies in
+   * +0x800 alone, outlines in both.  (A statistic over the attract animation appears to
+   * favour the opposite assignment by counting single-level pixel steps; it does not,
+   * because it assumes fades are done by toggling the LSB when this firmware fades by
+   * toggling the main plane, which is a two-level step) */
   if (locals.dmdLatchTtl > 0) { /* firmware is announcing completed frames */
     locals.dmdLatchTtl--;
     memcpy(locals.rawDMD, locals.dmdLatch, sizeof locals.rawDMD);
@@ -555,6 +576,29 @@ static INTERRUPT_GEN(SLEIC_irq_i8039) {
   sleic_dmd_dump(locals.rawDMD);
 #endif
   core_dmd_submit_frame(core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout, locals.rawDMD, 1);
+}
+
+/* Sleic Pin-Ball's tick: the same 0x60410 buffer, handed to the core as the two raster
+ * fields it is -- 1-bit frames of 32 rows x 16 bytes, +0x000 first and +0x800 second --
+ * so that the WPC_PH two-tap integrator shows a single-plane pixel at half brightness and
+ * SUM_2_1 (older frame in the high bit) reports (p0 << 1) | p1 to the raw-frame consumers.
+ * See the field-weighting note above sleic_build_dmd_frame.  Pin-Ball's firmware redraws
+ * the buffer incrementally and announces no frames, so it is sampled directly, without
+ * Bike Race's latch */
+static INTERRUPT_GEN(sleic1_irq_i8039) {
+  const core_tLCDLayout * const layout = core_gameData->lcdLayout->importedLayout ? core_gameData->lcdLayout->importedLayout : core_gameData->lcdLayout;
+  const UINT8 * const buf = memory_region(SLEIC_MEMREG_CPU) + 0x60410;
+  UINT8 field[512];
+  int ii;
+  cpu_set_irq_line(SLEIC_DISPLAY_CPU, 0, PULSE_LINE);
+  for (ii = 0; ii < 32; ii++) memcpy(field + ii * 16, buf + ii * 0x20, 16);         /* field 1 = +0x000 */
+  core_dmd_submit_frame(layout, field, 1);
+  for (ii = 0; ii < 32; ii++) memcpy(field + ii * 16, buf + ii * 0x20 + 0x800, 16); /* field 2 = +0x800 */
+  core_dmd_submit_frame(layout, field, 1);
+#ifdef DEBUG_SLEIC
+  sleic3_build_dmd_frame(locals.rawDMD); /* the (p0 << 1) | p1 classes, for the headless dump */
+  sleic_dmd_dump(locals.rawDMD);
+#endif
 }
 
 /*-------------------------------------------------------------------------------------
@@ -1928,13 +1972,16 @@ static PORT_WRITE_START(SLEIC2_Z80_writeport)
   {0x80,0x87, iomoon_z80_write},
 MEMORY_END
 
-static MACHINE_INIT(SLEIC) {
-  /* The memset covers everything in locals -- the DMD latch and its TTL, the OKI
-   * phrase/strobe state, the J1 link latches, the YM3812 A0 select and the SLEIC3
-   * interrupt accumulators all start at zero on every machine start */
+/* The memset covers everything in locals -- the DMD latch and its TTL, the OKI
+ * phrase/strobe state, the J1 link latches, the YM3812 A0 select and the SLEIC3
+ * interrupt accumulators all start at zero on every machine start */
+static void sleic_init_locals(void) {
   memset(&locals, 0, sizeof locals);
   memset(&sleic_io, 0, sizeof sleic_io);
-  /* locals.dmdEqualFields stays 0 here (Bike Race weighting); SLEIC1 and SLEIC2 each state their own below */
+}
+
+static MACHINE_INIT(SLEIC) {
+  sleic_init_locals();
   core_dmd_pwm_init(core_gameData->lcdLayout, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, CORE_DMD_PWM_PREINTEGRATED_LINEAR_4, 0);
   /* Ball trough / ball-detect optos live on matrix COL4 (swMatrix[5]). The Z80 cmd-0xD5
    * ball-status query strobes COL4 (out 0x82 = 0x10), reads it into 0xC0DB and replies
@@ -1962,11 +2009,13 @@ static MACHINE_INIT(SLEIC) {
    * supplies trough state; the keys above are only for standalone testing */
 }
 
-/* Sleic Pin-Ball's display ROM lights both raster fields for the same time, so its panel
- * has three levels rather than four -- see locals.dmdEqualFields above */
+/* Sleic Pin-Ball: two equal raster fields integrated by the core instead of a
+ * pre-integrated level frame -- see sleic1_irq_i8039 and the field-weighting note above
+ * sleic_build_dmd_frame.  core_dmd_pwm_init allocates the state it is handed, so it is
+ * called once, here, and not through machine_init_SLEIC */
 static MACHINE_INIT(SLEIC1) {
-  machine_init_SLEIC();
-  locals.dmdEqualFields = 1;
+  sleic_init_locals();
+  core_dmd_pwm_init(core_gameData->lcdLayout, CORE_DMD_PWM_FILTER_WPC_PH, CORE_DMD_PWM_COMBINER_SUM_2_1, 0);
 }
 
 /* Io Moon: point the segment-6000 graphics bank somewhere valid before the first
@@ -1994,10 +2043,8 @@ static MACHINE_INIT(SLEIC2) {
    * one approximated:
    *
    *   SETTLED: the planes are strongly asymmetric, so this panel really does show a
-   *     weighted 2-bit value and not Sleic Pin-Ball's "lit / lit brightly" pair, and
-   *     plane 0 is unambiguously the MSB.  That is what locals.dmdEqualFields = 0
-   *     selects, and it is stated here rather than inherited from the base init so the
-   *     PIC is on record as the reason.
+   *     weighted 2-bit value, and plane 0 is unambiguously the MSB -- which is what the
+   *     shared (p0 << 1) | p1 decode in sleic_build_dmd_frame renders.
    *
    *   APPROXIMATED: the DUTY CYCLES the ratio implies are 0, 30/230 = 13%, 200/230 = 87%
    *     and 100%, whereas MACHINE_INIT(SLEIC)'s CORE_DMD_PWM_PREINTEGRATED_LINEAR_4 maps
@@ -2010,7 +2057,6 @@ static MACHINE_INIT(SLEIC2) {
    *     of 13% and 87%) is rejected because it would put values outside 0..3 into the raw
    *     frames every downstream consumer of a 4-shade DMD reads.  Revisit if the core
    *     ever grows a weighted 2-plane combiner */
-  locals.dmdEqualFields = 0;
   /* The ball trough starts EMPTY, and at the default "Balls" = 0 it stays that way: the
    * model is opt-in and the frontend owns those contacts.  It is filled by the first
    * SWITCH_UPDATE only if the operator has asked for it, because the complement comes
@@ -2669,7 +2715,7 @@ MACHINE_DRIVER_START(SLEIC1)
   MDRV_CPU_ADD_TAG("dcpu", I8039, 2000000)
   MDRV_CPU_MEMORY(SLEIC_8039_readmem, SLEIC_8039_writemem)
   MDRV_CPU_PORTS(SLEIC_8039_readport, SLEIC_8039_writeport)
-  MDRV_CPU_PERIODIC_INT(SLEIC_irq_i8039, 2000000/8192.) // DMD VSYNC at 244.14Hz
+  MDRV_CPU_PERIODIC_INT(sleic1_irq_i8039, 2000000/8192.) // 244.14 Hz tick, two 1-bit raster fields per tick
 
   MDRV_SOUND_ADD(YM3812, SLEIC_ym3812_intf)
   MDRV_SOUND_ADD(OKIM6295, SLEIC_okim6376_intf)


### PR DESCRIPTION
Two Sleic Pin-Ball (sleicpin) fixes, both in src/wpc/sleic.c. Bike Race and Io Moon
are unchanged: their driver paths are byte-for-byte the same, and all five SLEIC sets
run with -sound and pass the MAME_DEBUG validity checks.

## 1. The OKI MSM6376 is two channels, and its stop-all was being dropped

Sleic Pin-Ball drives its MSM6376 exactly as Bike Race does (same 16-bit board, ref
011-026, same IC32 74LS273 control latch: bit 3 = 2CH channel select, bit 4 = /ST
start strobe). The firmware's single trigger at E000:1B26 alternates the channel on
every call, and bit 7 of the phrase byte is never set. The driver picked the voice
from that unused bit, so every phrase landed on one voice and overlapping pairs
(START's 0x16 then 0x2f, a tilt's 0x21/0x37/0x2b) had their second phrase refused.
The old "if (data & 0x7f)" gate also discarded the firmware's only stop-all, the two
phrase-0 strobes at boot and on the menu-exit soft reboot.

Now sleicpin uses the strobe Bike Race uses (renamed sleic_oki_strobe, body unchanged)
and arms it on every phrase-latch write including zero. Verified: 28 phrases with the
channel alternating on 27 of 27 consecutive pairs, opening with the two stop-alls that
used to be dropped.

## 2. The DMD's two raster fields are equal; integrate them in the core

The driver drew every single-plane pixel at 2/3 of a both-plane pixel, so outlines
and highlights stood only 1.5:1 above text, fills, shadows and the attract watermark.
On the machine the ratio is about 2:1: in video of a running Pin-Ball the same 1-dot
text is +0x000-only in its upper rows and in both planes in its lower rows, and the
lower rows measure about twice the upper ones, while the +0x800-only watermark
measures the same as +0x000-only text on the same screen.

The earlier "equal fields, 98 vs 94 cycles" reasoning used the I8039's P1.7 as the
light gate. The Bike Race service manual's schematic of board 011-026 (the board
Pin-Ball's manual lists too) names P1.7 VSYNC; the panel's display enable is P2.5,
the column latch P2.7, the row clock P2.6. The comment in the driver now records the
wiring and what the video does and does not settle.

sleic1_irq_i8039 hands the core the +0x000 and +0x800 planes as two 1-bit fields per
tick through CORE_DMD_PWM_FILTER_WPC_PH, which averages them to 0 / 1/2 / 1/2 / 1,
with CORE_DMD_PWM_COMBINER_SUM_2_1 keeping the raw frame at (p0 << 1) | p1 for the
colorizers. core_dmd_pwm_init allocates per call, so the shared init is split into
sleic_init_locals and each machine calls core_dmd_pwm_init once. 