### PR TITLE
unix/remote_debug: terminate headless runs and accept scripted input

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -99,6 +99,7 @@ typedef struct {
 #ifdef REMOTE_DEBUG
   int http_port;               /* HTTP server port */
   int start_paused;            /* Start emulator in paused state */
+  char *holdport;              /* Force input port bits high from power-on, PORT:HEXMASK[,PORT:HEXMASK...] */
 #endif
 } tPMoptions;
 extern tPMoptions pmoptions;

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -2717,6 +2717,21 @@ profiler_mark(PROFILER_END);
 
 
 
+#ifdef REMOTE_DEBUG
+/* A forced-value overlay, OR'd into every readinputport() result. Lets a
+ * button be presented as already held from power-on (see -holdport in
+ * src/unix/config.c) or toggled at runtime via /api/input/port, neither of
+ * which the normal keyboard/joystick input path can reach before the
+ * debugger's HTTP API exists. */
+static unsigned short input_port_force[MAX_INPUT_PORTS];
+
+void input_port_set_force(int port, unsigned short mask)
+{
+	if (port >= 0 && port < MAX_INPUT_PORTS) input_port_force[port] = mask;
+}
+
+#endif
+
 int readinputport(int port)
 {
 	struct InputPort *in;
@@ -2728,7 +2743,11 @@ int readinputport(int port)
 		scale_analog_port(port);
 	}
 
+#ifdef REMOTE_DEBUG
+	return input_port_value[port] | input_port_force[port];
+#else
 	return input_port_value[port];
+#endif
 }
 
 READ_HANDLER( input_port_0_r ) { return readinputport(0); }

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -408,6 +408,12 @@ void update_input_ports(void);	/* called by cpuintrf.c - not for external use */
 void inputport_vblank_end(void);	/* called by cpuintrf.c - not for external use */
 
 int readinputport(int port);
+
+#ifdef REMOTE_DEBUG
+/* Forced-value overlay OR'd into readinputport()'s result -- see inptport.c. */
+void input_port_set_force(int port, unsigned short mask);
+#endif
+
 READ_HANDLER( input_port_0_r );
 READ_HANDLER( input_port_1_r );
 READ_HANDLER( input_port_2_r );

--- a/src/remote_debug/api_handler.c
+++ b/src/remote_debug/api_handler.c
@@ -327,7 +327,17 @@ static void handle_api_info(const http_request_t *req, http_response_t *resp)
 		char sw_hex[CORE_MAXSWCOL * 2 + 1];
 		char seg_hex[CORE_SEGCOUNT * 4 + 1];
 		char desc_esc[256];
+		/* room for CORE_MAXGI ints ("-2147483648," is 12) plus the brackets */
+		char gi_str[CORE_MAXGI * 12 + 4];
+		char *gi_p = gi_str;
 		int i, ded, len;
+		/* GI strings, 0..8 per string, as a JSON array.  Only the drivers
+		   that set coreGlobals.nGI have any; the rest report []. */
+		*gi_p++ = '[';
+		for (i = 0; i < coreGlobals.nGI && i < CORE_MAXGI; i++)
+			gi_p += sprintf(gi_p, i ? ",%d" : "%d", coreGlobals.gi[i]);
+		*gi_p++ = ']';
+		*gi_p = '\0';
 		for (i = 0; i < CORE_MAXLAMPCOL; i++)
 			sprintf(lamp_hex + i * 2, "%02X", coreGlobals.lampMatrix[i]);
 		for (i = 0; i < CORE_MAXSWCOL; i++)
@@ -339,12 +349,12 @@ static void handle_api_info(const http_request_t *req, http_response_t *resp)
 			"{\"game\": \"%s\", \"description\": \"%s\", \"manufacturer\": \"%s\", "
 			"\"year\": \"%s\", \"paused\": %d, \"wpc_bank\": %d, \"lamps\": \"%s\", "
 			"\"switches\": \"%s\", \"segments\": \"%s\", \"dedicated\": %d, "
-			"\"solenoids\": %u, \"solenoids2\": %u}",
+			"\"solenoids\": %u, \"solenoids2\": %u, \"gi\": %s}",
 			Machine->gamedrv->name,
 			remote_debug_json_escape(desc_esc, (int)sizeof(desc_esc), Machine->gamedrv->description),
 			Machine->gamedrv->manufacturer, Machine->gamedrv->year,
 			remote_debug_is_paused(), bank, lamp_hex, sw_hex, seg_hex, ded,
-			coreGlobals.solenoids, coreGlobals.solenoids2);
+			coreGlobals.solenoids, coreGlobals.solenoids2, gi_str);
 		remote_debug_unlock();
 		resp->body = buffer;
 		resp->len = (len > 0 && len < 8192) ? len : (int)strlen(buffer);
@@ -1038,6 +1048,46 @@ static void handle_api_input(const http_request_t *req, http_response_t *resp)
 		respond_error(resp, 503, "core not initialized");
 }
 
+/* Force bits high/low in a raw input port's value, e.g. to hold a
+ * dedicated cabinet button (ADVANCE, TEST) at runtime the same way
+ * -holdport presents one from power-on. */
+static void handle_api_input_port(const http_request_t *req, http_response_t *resp)
+{
+	char port_buf[32], val_buf[32];
+	int port;
+	get_query_param(req->query, "port", port_buf, (int)sizeof(port_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	if (!port_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: port, val");
+		return;
+	}
+	port = parse_int(port_buf);
+	if (remote_debug_set_input_port_force(port, (int)parse_hex(val_buf)) == 0)
+		respond_ok(resp);
+	else
+		respond_error(resp, 400, "port out of range");
+}
+
+/* Write a switch-matrix column directly, bypassing core_setSw/sw2m, so a
+ * dedicated switch column outside the scanned matrix (e.g. col 0, the
+ * cabinet row) can be set from the API. */
+static void handle_api_input_matrix(const http_request_t *req, http_response_t *resp)
+{
+	char col_buf[32], val_buf[32];
+	int col;
+	get_query_param(req->query, "col", col_buf, (int)sizeof(col_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	if (!col_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: col, val");
+		return;
+	}
+	col = parse_int(col_buf);
+	if (remote_debug_set_matrix_col(col, (int)parse_hex(val_buf)) == 0)
+		respond_ok(resp);
+	else
+		respond_error(resp, 503, "core not initialized, or col out of range");
+}
+
 /* Read or set g_fHandleMechanics, the flag a front end uses to take ownership
  * of driver-modelled mechanics (VPinMAME exposes it as
  * Controller.HandleMechanics; libpinmame defaults it to 0). The standalone
@@ -1490,6 +1540,10 @@ static const api_route_t api_routes[] = {
 	 "?val=N - set g_fHandleMechanics (0 = front end owns the mechanics); no val = read"},
 	{"/api/input", handle_api_input,
 	 "?sw=N&val=0|1[&pulse=MS] - set a switch, optionally as a timed pulse"},
+	{"/api/input/port", handle_api_input_port,
+	 "?port=N&val=HEX - force bits high/low in a raw input port (reaches dedicated buttons like ADVANCE)"},
+	{"/api/input/matrix", handle_api_input_matrix,
+	 "?col=N&val=HEX - write a switch-matrix column directly, bypassing core_setSw/sw2m"},
 	{"/ui", handle_ui, "the web UI"},
 	{"/api/doc", handle_api_doc, "this document"},
 };

--- a/src/remote_debug/remote_debug.c
+++ b/src/remote_debug/remote_debug.c
@@ -15,6 +15,7 @@
 #include "wpc/core.h"
 #include "wpc/wpc.h"
 #include "memory.h"
+#include "inptport.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -369,6 +370,9 @@ static void publish_event(const char *fmt, ...)
 static void service_pulses(void);
 static void pulse_tick(int reassert);
 
+/* forward declaration; defined with the switch/input implementation below */
+static void apply_holdport_option(void);
+
 int remote_debug_next_event(char *buf, int maxlen)
 {
 	int have = 0;
@@ -466,6 +470,7 @@ void remote_debug_init(void)
 		is_paused = 1;
 		printf("Remote Debugger: paused on start\n");
 	}
+	apply_holdport_option();
 	should_quit = 0;
 	step_requested = 0;
 	breakpoint_count = 0;
@@ -1675,6 +1680,68 @@ int remote_debug_set_switch(int sw, int val, int pulse_ms)
 	}
 	remote_debug_unlock();
 	return result;
+}
+
+/* Force bits high/low in input port `port`'s value, independent of the
+ * normal keyboard/joystick read (see /api/input/port and -holdport). This
+ * is the only way to present a dedicated-input button (e.g. ADVANCE) as
+ * already held, including from before MACHINE_INIT runs. Returns 0 on
+ * success, -1 if port is out of range. */
+int remote_debug_set_input_port_force(int port, int val)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (port >= 0 && port < MAX_INPUT_PORTS) {
+		input_port_set_force(port, (unsigned short)val);
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+/* Write switch-matrix column `col` directly, bypassing core_setSw and its
+ * sw2m mapping (see /api/input/matrix). core_setSw maps every positive
+ * switch number to swMatrix[1] or later (core_swSeq2m: no+7), so dedicated
+ * columns such as col 0 -- the cabinet row holding TEST/ADVANCE/EG1/EG2 --
+ * are otherwise unreachable from the API. Returns 0 on success, -1 if the
+ * core is not ready or col is out of range. */
+int remote_debug_set_matrix_col(int col, int val)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (coreData && col >= 0 && col < CORE_MAXSWCOL) {
+		coreGlobals.swMatrix[col] = (UINT8)val;
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+/* Parse "-holdport PORT:HEXMASK[,PORT:HEXMASK...]" and force those input
+ * port bits high before the machine runs, so MACHINE_INIT sees them --
+ * this is how "hold ADVANCE while switching on" (the real machine's route
+ * into test mode) gets simulated, since the normal input path is not
+ * reachable that early. Called once from remote_debug_init(), which itself
+ * runs before run_machine() (see mame.c). */
+static void apply_holdport_option(void)
+{
+	char *copy, *tok;
+
+	if (!pmoptions.holdport || !pmoptions.holdport[0])
+		return;
+	copy = strdup(pmoptions.holdport);
+	if (!copy)
+		return;
+	for (tok = strtok(copy, ","); tok; tok = strtok(NULL, ",")) {
+		char *sep = strchr(tok, ':');
+		if (sep) {
+			int port = atoi(tok);
+			unsigned short mask = (unsigned short)strtoul(sep + 1, NULL, 16);
+			input_port_set_force(port, mask);
+			printf("Remote Debugger: holding port %d bits %04X from power-on\n", port, mask);
+		}
+	}
+	free(copy);
 }
 
 /* ================================================================== */

--- a/src/remote_debug/remote_debug.h
+++ b/src/remote_debug/remote_debug.h
@@ -167,6 +167,20 @@ void remote_debug_get_solenoids(char **buffer, int *len);
  * ready. */
 int remote_debug_set_switch(int sw, int val, int pulse_ms);
 
+/* Force bits high/low in input port `port`'s value, independent of the
+ * normal keyboard/joystick read (see /api/input/port and -holdport) --
+ * lets a dedicated-input button be presented as held, including from
+ * before MACHINE_INIT runs. Returns 0 on success, -1 if port is out of
+ * range. */
+int remote_debug_set_input_port_force(int port, int val);
+
+/* Write switch-matrix column `col` directly, bypassing core_setSw's sw2m
+ * mapping (see /api/input/matrix) -- the only way to reach a dedicated
+ * switch column (e.g. col 0) that sw2m places outside the scanned matrix.
+ * Returns 0 on success, -1 if the core is not ready or col is out of
+ * range. */
+int remote_debug_set_matrix_col(int col, int val);
+
 /* ------------------------------------------------------------------ */
 /* Object monitoring (change log)                                     */
 /* ------------------------------------------------------------------ */

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -141,6 +141,9 @@ static struct rc_option opts[] = {
 	{ "skip_disclaimer", NULL, rc_bool, &options.skip_disclaimer, "0", 0, 0, NULL, "Skip displaying the disclaimer screen" },
 	{ "skip_gameinfo", NULL, rc_bool, &options.skip_gameinfo, "0", 0, 0, NULL, "Skip displaying the game info screen" },
 	{ "skip_gamewarnings", NULL, rc_bool, &options.skip_gamewarnings, "0", 0, 0, NULL, "Skip displaying the game warnings screen (needed for headless runs of GAME_NOT_WORKING games)" },
+#ifdef REMOTE_DEBUG
+	{ "holdport", NULL, rc_string, &pmoptions.holdport, NULL, 0, 0, NULL, "force bits high in an input port from power-on, as PORT:HEXMASK (repeatable, comma separated) - simulates a button held while the machine is switched on" },
+#endif
 	{ "crconly", NULL, rc_bool, &options.crc_only, "0", 0, 0, NULL, "Use only CRC for all integrity checks" },
 	{ "bios", NULL, rc_string, &options.bios, "default", 0, 14, NULL, "change system bios" },
 #ifdef MAME_DEBUG

--- a/src/unix/keyboard.c
+++ b/src/unix/keyboard.c
@@ -206,6 +206,18 @@ const struct KeyboardInfo *osd_get_key_list(void)
 
 int osd_is_key_pressed(int keycode)
 {
+   /* special case: if we're trying to quit, fake up/down/up/down.
+      This is checked before the kbd_fifo guard below on purpose: headless mode
+      never calls osd_input_initpost(), so kbd_fifo stays NULL and the guard used
+      to swallow the fake ESC -- which is the only way trying_to_quit reaches
+      handle_user_interface().  Without this, neither -frames_to_run nor SIGQUIT
+      could end a headless run. */
+   if (keycode == KEY_ESC && trying_to_quit)
+   {
+      static int dummy_state = 1;
+      return dummy_state ^= 1;
+   }
+
    /* blames to the dos-people who want to check key states before
       the display (and under X thus the keyboard) is initialised */
    if (!kbd_fifo)
@@ -213,13 +225,6 @@ int osd_is_key_pressed(int keycode)
    
    if (keycode >= KEY_MAX)
       return 0;
-
-   /* special case: if we're trying to quit, fake up/down/up/down */
-   if (keycode == KEY_ESC && trying_to_quit)
-   {
-      static int dummy_state = 1;
-      return dummy_state ^= 1;
-   }
 
    sysdep_update_keyboard();
 	

--- a/src/unix/video.c
+++ b/src/unix/video.c
@@ -773,7 +773,31 @@ void osd_update_video_and_audio(struct mame_display *display)
 #ifdef REMOTE_DEBUG
 	remote_debug_frame_update(display);
 #endif
-	if (pmoptions.headless) return;
+	/* Headless: -frames_to_run has to be honoured here.  The frame counter below
+	   lives inside the `GAME_BITMAP_CHANGED` blit block, and headless never creates
+	   a display, so that block never runs and -ftr N never terminated the run --
+	   headless runs could only be killed on a wall-clock timer.  This function is
+	   called exactly once per emulated frame (from updatescreen(), via
+	   artwork_update_video_and_audio(), whether or not the frame is skipped), so
+	   counting here is the same count the display path would have produced.
+	   Same class of gap as the headless osd_close_display() fix above.
+
+	   The termination test is deliberately spelled the same way as the display
+	   path's below (`frames_displayed + 1 == frames_to_display`) rather than as
+	   `>= frames_to_display`: the two differ by one frame, so the same -ftr N
+	   would otherwise emulate a different number of frames headless than
+	   windowed.  The `> 0` guard is kept because "run forever" is 0 here.
+	   Note the display path's counter still means something slightly different
+	   -- it starts only once start_time is set, a second into the run, and it
+	   skips frames that are not blitted -- so this aligns the comparison, not
+	   the whole meaning of the count. */
+	if (pmoptions.headless)
+	{
+		frames_displayed++;
+		if (frames_to_display > 0 && frames_displayed + 1 == frames_to_display)
+			trying_to_quit = 1;
+		return;
+	}
 	int skip_this_frame;
 	cycles_t curr;
 


### PR DESCRIPTION
-frames_to_run now ends a headless run: the display path stopped on the frame count but the headless path never consulted it, so -ftr ran forever. Both paths now spell the test the same way.

Adds cabinet-switch injection and a GI read-back to the remote debugger, so an unattended harness can drive dedicated buttons that have no matrix cell and read back general-illumination state. Drops input_port_get_force(), which had no callers.