### PR TITLE
i8051: serial callbacks, Timer 1 baud clock, and MOVX @Ri's P2 page

### DIFF
--- a/scripts/i8051_sweep.sh
+++ b/scripts/i8051_sweep.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# i8051_sweep.sh -- run every 8051-family game in this tree headless and record,
+# per game, a checksum of everything it played plus a per-source count of the
+# interrupts its sound CPU actually took.
+#
+# Why: check_interrupts() in src/cpu/i8051/i8051.c is shared by 36 games across
+# 5 drivers, and a previous attempt to fix it shipped a regression because there
+# was no way to tell whether a change altered what a game sounds like.  Run this
+# before a change and after it and diff the two TSVs: a game whose audio_hash is
+# unchanged is provably unaffected; a game whose hash moved has its cause named
+# by whichever of the six interrupt counters moved with it.
+#
+# Requires a binary built with the instrumentation compiled in, and built with
+# NEITHER REMOTE_DEBUG NOR DEBUG:
+#
+#   make -f makefile.unix I8051_SWEEP=1 -j$(nproc)      # -> ./xpinmames.x11
+#
+# The trailing "s" comes from I8051_SWEEP and gives the instrumented build its
+# own object dir, so it can never be half-mixed with a normal xpinmame build.
+#
+# REMOTE_DEBUG must be OFF, and this is not a preference.  Measured on this
+# tree, 2026-08-31:
+#   * Speed.  REMOTE_DEBUG puts a usleep(1) inside cpu_run()'s inner loop
+#     (src/cpuexec.c, "Tiny gap to allow HTTP thread to grab the lock").  One
+#     game at -ftr 3600 takes 119 s with it and 5 s without -- 24x.
+#   * Determinism.  It also starts a polling HTTP thread, and with it running
+#     the sweep does not reproduce: over two full 35-game passes, 13 of 35 rows
+#     differed, including two audio checksums.  Without it, the same games are
+#     stable (e.g. bsv103's serial count was 11 in one pass and 249 in the
+#     other; without REMOTE_DEBUG it is 249 three times out of three).
+#   * NVRAM.  Each run is started from a cleared per-game NVRAM file (see
+#     run_one below).  Without that, a game's numbers depend on how many times
+#     it has been booted before, which is not something a before/after diff can
+#     see or control.
+# A residual +-1 jitter remains in the Alvin G games' ie1/tf0 counts (~0.05%),
+# and jolypark's audio checksum still moves run to run with its counters fixed;
+# see docs/findings/2026-08-31-i8051-interrupt-fix.md.
+#
+# Usage:
+#   scripts/i8051_sweep.sh OUTPUT.tsv [BINARY] [ROMPATH]
+#
+# Environment overrides:
+#   FTR=3600        frames to run per game (60 fps => 3600 = 60 s emulated)
+#   TIMEOUT=300     wall-clock backstop per game, seconds
+#   LOGDIR=<dir>    keep each game's full stdout+stderr here
+#
+set -u
+
+die() { echo "i8051_sweep: $*" >&2; exit 1; }
+
+OUT=${1:-}
+[ -n "$OUT" ] || die "usage: $0 OUTPUT.tsv [BINARY] [ROMPATH]"
+
+HERE=$(cd -- "$(dirname -- "$0")/.." && pwd)          # the pinmame checkout
+BIN=${2:-$HERE/xpinmames.x11}
+# The ROM sets live outside the repo, in the workspace's rompath of symlinks /
+# zips.  Override with argument 2 or point it wherever they are.
+ROMPATH=${3:-$(cd -- "$HERE/.." && pwd)/build/sweep-roms}
+
+FTR=${FTR:-3600}
+TIMEOUT=${TIMEOUT:-300}
+LOGDIR=${LOGDIR:-}
+
+[ -x "$BIN" ]     || die "no instrumented binary at $BIN (make -f makefile.unix I8051_SWEEP=1)"
+[ -d "$ROMPATH" ] || die "no rompath at $ROMPATH"
+[ -n "$LOGDIR" ] && mkdir -p "$LOGDIR"
+
+# Sound flags.  Read this before changing them.
+#
+#   -fakesound is mandatory.  Without it Machine->sample_rate is 0, and
+#   cpuexec.c:347 then SUSPENDS every CPU flagged CPU_AUDIO_CPU -- the 8051
+#   would never execute an instruction and every number in this table would be
+#   a measurement of nothing.
+#
+#   -nosound alone would do exactly that, which is why it must never appear on
+#   its own.  Paired with -fakesound it does something different and useful: it
+#   stops PinMAME opening the host audio device, so sample_rate lands on the
+#   fake 8000 Hz path instead of the card's 44100, and the run is not throttled
+#   to real time by the ALSA write.  The sound CPU still runs -- verified by the
+#   interrupt counters being identical with and without it.
+#
+#   -skip_gamewarnings is mandatory too: GAME_NOT_WORKING titles (sport2k) stop
+#   at a warning screen waiting for a keypress that headless can never deliver.
+SNDFLAGS="-nosound -fakesound"
+
+# Every game in this tree that instantiates an 8051-family CPU and whose ROMs are
+# present, per docs/reference/i8051-test-roms.md.  Override with GAMES="a b c".
+GAMES=${GAMES:-"
+sport2k mephisto mephist1 uboat65
+wrldtour wrldtou2 wrldtou3 mystcast mystcasa pstlpkr pstlpkr1
+pmv112 pmv112r abv106 abv105 abv106r bsv103 bsv102 bsv100r bsv102r bsb105 pp100
+ffv104 ffv103 ffv101 bbb109 bbb108 kpb105
+bushido bushidoa bushidob mach2 mach2a jolypark vrnwrld
+"}
+
+# NVRAM is per-game persistent state and it IS written -- every game in this
+# list leaves a $HOME/.xpinmame/nvram/<game>.nv behind.  It changes what the
+# next run measures, and by a lot: with NVRAM carried over, bsb105 reports
+# ie0=8 riti=247, and with it cleared, ie0=51 riti=265 -- a 6x difference on a
+# counter this sweep exists to interpret.  bbb109's riti goes 8 -> 11 -> 23
+# over successive boots from the same virgin state.  Each of those values is
+# perfectly reproducible (3/3 runs) once the NVRAM state is pinned, so this is
+# not emulator nondeterminism, it is a hidden input.  Clear it per game so a
+# before/after comparison measures the code change and nothing else.
+NVDIR=${NVDIR:-$HOME/.xpinmame/nvram}
+
+run_one() {   # $1 = game ; leaves the captured output in $CAP
+	local game=$1
+	CAP=$(mktemp)
+	local t0 t1
+	rm -f "$NVDIR/$game.nv"
+	t0=$(date +%s)
+	timeout -k 5 "$TIMEOUT" "$BIN" \
+		-headless $SNDFLAGS -skip_gamewarnings -skip_gameinfo \
+		-ftr "$FTR" -rompath "$ROMPATH" "$game" \
+		>"$CAP" 2>&1
+	RC=$?
+	t1=$(date +%s)
+	WALL=$(( t1 - t0 ))
+	[ -n "$LOGDIR" ] && cp "$CAP" "$LOGDIR/$game.log"
+	return 0
+}
+
+field() {     # $1 = probe line prefix, $2 = key ; prints the value or "-"
+	# Character class covers both hex digests/integer counters (e.g. "1ad5b7ff", "247")
+	# and the decimal metrics added 2026-08-31 (e.g. "982.451"); a "." never appears in
+	# a hex/integer field, so widening the class costs nothing for the old fields.
+	sed -n "s/.*$1 .*\\b$2=\\([0-9a-f.]*\\).*/\\1/p" "$CAP" | tail -1
+}
+
+# ---------------------------------------------------------------------------
+# Self-check.  A silent oracle is worse than none, so refuse to sweep unless a
+# single game demonstrably produces both probe lines.
+# ---------------------------------------------------------------------------
+echo "i8051_sweep: self-check on mephisto (ftr=120)..." >&2
+CAP=$(mktemp)
+rm -f "${NVDIR:-$HOME/.xpinmame/nvram}/mephisto.nv"
+timeout -k 5 120 "$BIN" -headless $SNDFLAGS -skip_gamewarnings -skip_gameinfo \
+	-ftr 120 -rompath "$ROMPATH" mephisto >"$CAP" 2>&1
+grep -q "I8051_SWEEP AUDIO" "$CAP" || die "binary printed no AUDIO probe line -- not an I8051_SWEEP build?"
+grep -q "I8051_SWEEP IRQ"   "$CAP" || die "binary printed no IRQ probe line -- not an I8051_SWEEP build?"
+grep -q "I8051_SWEEP AUDIO .* seen=0 " "$CAP" && die "AUDIO probe saw zero samples -- is -fakesound reaching the binary?"
+rm -f "$CAP"
+echo "i8051_sweep: self-check ok" >&2
+
+# ---------------------------------------------------------------------------
+# Status labels, corrected 2026-08-31.
+#
+# The original logic set status=ok as soon as loud>0 -- "at least one sample
+# anywhere in sixty seconds exceeded +-1 LSB".  A constant DC offset satisfies
+# that on its first sample and every sample thereafter, so a stuck AY-3-8910
+# outputting a flat rail scored exactly the same "ok" as a stream that is
+# actually varying.  Measured case in point: mephisto pre-fix has AC rms
+# *exactly* 0.000 (476,136 of 479,066 samples pinned at +32,767) and scored
+# loud=478,754, status=ok.  See .superpowers/i8051-fix-review.md section 1 for
+# the full audit; that document is what this fix implements.
+#
+# loud==0 remains untouched and is still a valid silence test: dither can
+# never exceed 1 LSB, so loud==0 really does mean nothing left the dither
+# floor.  Only the converse -- treating loud>0 as meaning something -- was
+# broken, and only that direction changes here.
+#
+# For loud>0, ac_rms (mixer.c's Welford stddev, skipping the first emulated
+# second to clear the boot transient -- see the comment above
+# sweep_audio_digest() in src/sound/mixer.c) now decides the label.  A rail's
+# ac_rms is at most the dither floor's own ~0.5 LSB; every genuinely varying
+# stream this project has measured sits at 20+ LSB.  AC_RMS_RAIL_THRESHOLD
+# sits well above the first and below the second, so it does not need to be
+# precise to separate the two groups correctly.  Measured on this tree:
+#   - uboat65 (pure DC + dither, unchanged control):      ac_rms  0.5
+#   - mephisto pre-fix (literally constant):              ac_rms  0.0
+#   - pmv112 (the one game confirmed playing something,
+#     a burst in seconds 2-3 then silence): ac_rms clears the threshold
+#   - sport2k / mephisto post-fix (AY noise generator, not music): ac_rms in
+#     the hundreds -- also NOT a rail by this test, and that is intentional.
+#     "not a rail" is as far as this metric is licensed to go; it does not and
+#     cannot certify that a varying signal is music rather than noise.  See
+#     docs/findings/2026-08-31-i8051-interrupt-fix.md section 5 for why
+#     sport2k's post-fix "not_silent" reading is a stuck noise generator, not
+#     audio.
+AC_RMS_RAIL_THRESHOLD=5.0
+
+is_rail() {   # $1 = ac_rms ; true (0) if below the threshold
+	awk -v v="$1" -v t="$AC_RMS_RAIL_THRESHOLD" 'BEGIN{exit !(v!="" && v+0<t)}'
+}
+
+printf 'game\trc\twall_s\taudio_hash\taudio_n\taudio_seen\tnonzero\tloud\tac_rms\tclip_pct\tac_n\tie0\ttf0\tie1\ttf1\triti\ttf2\tirq_total\tstatus\n' > "$OUT"
+
+for game in $GAMES; do
+	run_one "$game"
+
+	hash=$(field AUDIO hash);  an=$(field AUDIO n);       aseen=$(field AUDIO seen)
+	nz=$(field AUDIO nonzero); loud=$(field AUDIO loud)
+	acrms=$(field AUDIO ac_rms); clippct=$(field AUDIO clip_pct); acn=$(field AUDIO ac_n)
+	ie0=$(field IRQ ie0); tf0=$(field IRQ tf0); ie1=$(field IRQ ie1)
+	tf1=$(field IRQ tf1); riti=$(field IRQ riti); tf2=$(field IRQ tf2)
+
+	status=not_silent
+	if [ -z "$hash" ] || [ -z "$ie0" ]; then
+		# No probe line at all: the process never reached a clean teardown.
+		if [ "$RC" -ge 124 ]; then status=timeout; else status=no_probe_rc$RC; fi
+		hash=${hash:--}; an=${an:--}; aseen=${aseen:--}; nz=${nz:--}; loud=${loud:--}
+		acrms=${acrms:--}; clippct=${clippct:--}; acn=${acn:--}
+		ie0=${ie0:--}; tf0=${tf0:--}; ie1=${ie1:--}; tf1=${tf1:--}
+		riti=${riti:--}; tf2=${tf2:--}; irqtot=-
+	else
+		irqtot=$(( ie0 + tf0 + ie1 + tf1 + riti + tf2 ))
+		[ "$irqtot" -eq 0 ] && status=no_irq
+		# "loud" is |sample| > 1.  Plain "nonzero" cannot be used as a silence
+		# test: the mixer adds +-1 LSB of TPDF dither to every sample whether or
+		# not anything is playing, so a silent machine still shows nonzero for
+		# about half its samples.  Dither can never exceed 1 LSB, so loud==0 is
+		# a real silence test.
+		if [ "$loud" -eq 0 ]; then
+			if [ "$status" = no_irq ]; then status=silent_no_irq; else status=silent; fi
+		elif is_rail "$acrms"; then
+			# loud>0 but the signal doesn't vary: a DC offset (at any level)
+			# plus dither, not something worth calling "not silent".
+			if [ "$status" = no_irq ]; then status=rail_no_irq; else status=rail; fi
+		fi
+		# else: loud>0 and ac_rms clears the rail threshold -- leave status at
+		# "not_silent".  That is a claim about variance, not about music; see
+		# the comment block above.
+	fi
+
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$game" "$RC" "$WALL" "$hash" "$an" "$aseen" "$nz" "$loud" \
+		"$acrms" "$clippct" "$acn" \
+		"$ie0" "$tf0" "$ie1" "$tf1" "$riti" "$tf2" "$irqtot" "$status" >> "$OUT"
+	printf '%-10s rc=%-3s %3ss  hash=%-8s loud=%-8s ac_rms=%-8s clip%%=%-7s irq=%-8s %s\n' \
+		"$game" "$RC" "$WALL" "$hash" "$loud" "$acrms" "$clippct" "$irqtot" "$status" >&2
+
+	rm -f "$CAP"
+done
+
+echo "i8051_sweep: wrote $OUT" >&2

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -111,6 +111,7 @@ typedef struct {
 	UINT8	data_out;		//Data to send out
 	UINT8	bits_to_send;	//How many bits left to send when transmitting out the serial port
 	UINT8	bitcycles;		//# of bitcycles passed since last bit was sent
+	UINT8	baudcycles;		//# of Timer 1 overflows since the last bit, when Timer 1 is the baud generator
 } I8051_UART;
 
 typedef struct {
@@ -341,6 +342,8 @@ static READ32_HANDLER((*hold_eram_iaddr_callback));
 /***************************************************************
  * Easy macros for Getting Flags
  ***************************************************************/
+/*PCON Flags*/
+#define GET_SMOD		((R_PCON & 0x80)>>7)			//Doubles the serial baud rate when set
 /*PSW Flags*/
 #define GET_CY			((R_PSW & 0x80)>>7)
 #define GET_AC			((R_PSW & 0x40)>>6)
@@ -2078,6 +2081,38 @@ INLINE void do_sub_flags(UINT8 a, UINT8 data, UINT8 c)
 #endif
 }
 
+/* Timer 1 doubles as the UART's baud rate generator in serial modes 1 and 3,
+   which is the single most common 8051 UART configuration there is and was
+   left as a //TODO here until 2026-08-31.  Without it uart.bits_to_send never
+   reached 0 in mode 1, so update_serial() never called serial_tx_callback and
+   never set TI: a firmware that wrote SBUF in mode 1 transmitted exactly
+   nothing, forever.  mephisto.c's sound board (sport2k, mephisto, mephist1) is
+   the case that exposed it.
+
+   MCS-51: baud = (2^SMOD / 32) * (Timer 1 overflow rate), so one bit takes 32
+   Timer 1 overflows, or 16 with PCON.SMOD set.  Count the overflows rather
+   than spending a bit on each one.  (The Timer 2 baud block further down does
+   spend a bit per overflow, i.e. runs 16x fast; that is pre-existing and is
+   deliberately not touched here -- every 8052 game in the tree was measured
+   against it.) */
+INLINE void timer1_baud_tick(void)
+{
+	if(!uart.sending || !uart.bits_to_send || !uart.timerbaud)
+		return;
+#if (HAS_I8052 || HAS_I8752)
+	//An 8052 can clock the serial port from Timer 2 instead.  If it does, the
+	//Timer 2 block owns the bit clock and Timer 1 must keep out of it.  R_T2CON
+	//is always 0 on an I8051, so this costs those instances nothing.
+	if(GET_TCLK || GET_RCLK)
+		return;
+#endif
+	uart.baudcycles++;
+	if(uart.baudcycles >= (32 >> GET_SMOD)) {
+		uart.baudcycles = 0;
+		uart.bits_to_send-=1;
+	}
+}
+
 INLINE void update_timer(int cyc)
 {
 	//This code sucks, needs to be rewritten SJE
@@ -2192,7 +2227,8 @@ INLINE void update_timer(int cyc)
 				//Check for overflow
 				if((UINT32)(count+(cyc/12))>overflow) {
 
-					//TODO: Timer 1 can be set as Serial Baud Rate in the 8051 only... process bits here..
+					//Timer 1 can be set as Serial Baud Rate in the 8051 only
+					timer1_baud_tick();
 
 					//Any overflow from cycles?
 					cyc-= (int)(overflow-count)*12;
@@ -2225,6 +2261,9 @@ INLINE void update_timer(int cyc)
 				//Check for overflow
 				if((UINT32)(count+(cyc/12))>overflow) {
                     SET_TF1(1);
+					//Timer 1 can be set as Serial Baud Rate in the 8051 only.  This is
+					//the mode both Cirsa sound ROMs use (TH1 = TL1 = 0xFE).
+					timer1_baud_tick();
 					//Reload
 					count = R_TH1+(overflow-count);
 				}
@@ -2309,6 +2348,7 @@ INLINE void serial_transmit(UINT8 data)
 		case 1:
 			uart.timerbaud = 1;
 			uart.bits_to_send = 8+2;
+			uart.baudcycles = 0;
 			break;
 		//9 bit uart
 		case 2:

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -563,10 +563,17 @@ void i8051_reset(void *param)
 	i8051.iram_iwrite = internal_ram_write;		//Indirect ram read/write handled the same as direct for 8051!
 
 	//Set up serial call back handlers
+	//The hold_* statics are deliberately NOT cleared here.  A driver registers
+	//its callbacks once, from MACHINE_INIT, before the first reset; clearing them
+	//made the *second* and every later reset install NULL, leaving the CPU
+	//permanently unable to talk to its driver.  A driver that pulses this CPU's
+	//reset line -- mephisto.c drives RST ASIN that way -- needs the registration
+	//to survive every reset, not just the first.  (hold_eram_iaddr_callback below
+	//has the same shape; it is left as it was because no driver in this tree both
+	//registers it and resets its 8051 more than once.  See
+	//docs/findings/2026-08-31-sound-link-fixes.md.)
 	i8051.serial_tx_callback = hold_serial_tx_callback;
-	hold_serial_tx_callback = NULL;
 	i8051.serial_rx_callback = hold_serial_rx_callback;
-	hold_serial_rx_callback = NULL;
 
 	//Setup External ram callback handlers
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;
@@ -2367,10 +2374,9 @@ void i8752_reset (void *param)
 	i8051.iram_iwrite = i8052_internal_ram_iwrite;
 
 	//Set up serial call back handlers
+	//hold_* deliberately not cleared -- see the note in i8051_reset().
 	i8051.serial_tx_callback = hold_serial_tx_callback;
-	hold_serial_tx_callback = NULL;
 	i8051.serial_rx_callback = hold_serial_rx_callback;
-	hold_serial_rx_callback = NULL;
 
 	//Setup External ram callback handlers
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -516,6 +516,26 @@ void i8051_init(void)
 {
 	int cpu = cpu_getactivecpu();
 
+	//Drop any callbacks a PREVIOUS game registered.  These three statics are
+	//file scope, so without this they live for the whole process -- and
+	//libpinmame and VPinMAME run more than one game per process
+	//(PinmameRun/PinmameStop).  Run a spinb game, which registers both an
+	//eram_iaddr_callback and a serial callback, then stop and run an Alvin G
+	//game: alvgdmd.c instantiates an I8051 and registers nothing, so its DMD
+	//CPU would inherit spinb's eram_iaddr_callback and re-address every
+	//MOVX @Ri through another driver's state.  nuova.c has the same shape.
+	//
+	//This is the right place for it, and i8051_reset() is not: cpu_init()
+	//runs once per game start, from init_machine() (mame.c), and a driver's
+	//MACHINE_INIT -- where registration happens -- runs later, inside
+	//cpu_pre_run() (cpuexec.c), which calls machine_init() and only then
+	//cpunum_reset().  So registration still precedes the first reset and
+	//survives every later one, which is what the note in i8051_reset()
+	//needs, while a new game no longer inherits the old game's callbacks.
+	hold_serial_tx_callback = NULL;
+	hold_serial_rx_callback = NULL;
+	hold_eram_iaddr_callback = NULL;
+
 	//Internal stuff
 	state_save_register_UINT16("i8051", cpu, "PPC",       &i8051.ppc,    1);
 	state_save_register_UINT16("i8051", cpu, "PC",        &i8051.pc,     1);

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -426,17 +426,36 @@ static READ32_HANDLER((*hold_eram_iaddr_callback));
 
 #define V_TF2	0x02b	/* Timer 2 Overflow */
 
-/* Any pending IRQ */
+#ifdef I8051_SWEEP
+/* Sweep instrumentation.  Defined next to check_interrupts(), where the counting
+   happens; declared here only so i8051_exit() below can print the totals. */
+static void sweep_irq_report(void);
+#endif
+
+/* Any pending IRQ.
+   MCS-51 requires BOTH a source's flag and that source's own enable bit in IE
+   before it can interrupt (the global EA is tested separately, at the top of
+   check_interrupts()).  Each term below therefore pairs a flag with its enable.
+   These must stay in step with the matching proposals in check_interrupts():
+   if this macro lets a call through but no proposal then matches, the dispatch
+   at the bottom of that function runs with int_vec still 0 and sets PC to the
+   reset vector.  There is a belt-and-braces test for that case there as well.
+   TIMER2_IRQ additionally tests the CPU subtype.  An 8051 has no Timer 2 at
+   all, but every Timer 2 guard in this file is compile-time (HAS_I8052 /
+   HAS_I8752 are properties of the build, not of the instance), so without a
+   runtime check the Timer 2 path also runs for I8051 instances -- spinb.c,
+   mephisto.c and alvgdmd.c all instantiate I8051. */
+#define EXT0_IRQ          (GET_IE0 && GET_EX0)
+#define TIMER0_IRQ        (GET_TF0 && GET_ET0)
+#define EXT1_IRQ          (GET_IE1 && GET_EX1)
+#define TIMER1_IRQ        (GET_TF1 && GET_ET1)
 #define SERIALPORT_IRQ    ((R_SCON & 0x03) && GET_ES)
 
 #if (HAS_I8052 || HAS_I8752)
-#ifdef PINMAME // otherwise no sound on spinball games
-#define NO_PENDING_IRQ  !(R_TCON & 0xaa) && !(SERIALPORT_IRQ) && !GET_TF2 && !GET_EXF2
+#define TIMER2_IRQ        (TYPE != 8051 && GET_ET2 && (GET_TF2 || GET_EXF2))
+#define NO_PENDING_IRQ  !(EXT0_IRQ) && !(TIMER0_IRQ) && !(EXT1_IRQ) && !(TIMER1_IRQ) && !(SERIALPORT_IRQ) && !(TIMER2_IRQ)
 #else
-#define NO_PENDING_IRQ  !(R_TCON & 0xaa) && !(SERIALPORT_IRQ) && !GET_ET2 //!GET_TF2 && !GET_EXF2
-#endif
-#else
-#define NO_PENDING_IRQ  !(R_TCON & 0xaa) && !(SERIALPORT_IRQ)
+#define NO_PENDING_IRQ  !(EXT0_IRQ) && !(TIMER0_IRQ) && !(EXT1_IRQ) && !(TIMER1_IRQ) && !(SERIALPORT_IRQ)
 #endif
 
 /* Clear Current IRQ  */
@@ -516,26 +535,6 @@ void i8051_init(void)
 {
 	int cpu = cpu_getactivecpu();
 
-	//Drop any callbacks a PREVIOUS game registered.  These three statics are
-	//file scope, so without this they live for the whole process -- and
-	//libpinmame and VPinMAME run more than one game per process
-	//(PinmameRun/PinmameStop).  Run a spinb game, which registers both an
-	//eram_iaddr_callback and a serial callback, then stop and run an Alvin G
-	//game: alvgdmd.c instantiates an I8051 and registers nothing, so its DMD
-	//CPU would inherit spinb's eram_iaddr_callback and re-address every
-	//MOVX @Ri through another driver's state.  nuova.c has the same shape.
-	//
-	//This is the right place for it, and i8051_reset() is not: cpu_init()
-	//runs once per game start, from init_machine() (mame.c), and a driver's
-	//MACHINE_INIT -- where registration happens -- runs later, inside
-	//cpu_pre_run() (cpuexec.c), which calls machine_init() and only then
-	//cpunum_reset().  So registration still precedes the first reset and
-	//survives every later one, which is what the note in i8051_reset()
-	//needs, while a new game no longer inherits the old game's callbacks.
-	hold_serial_tx_callback = NULL;
-	hold_serial_rx_callback = NULL;
-	hold_eram_iaddr_callback = NULL;
-
 	//Internal stuff
 	state_save_register_UINT16("i8051", cpu, "PPC",       &i8051.ppc,    1);
 	state_save_register_UINT16("i8051", cpu, "PC",        &i8051.pc,     1);
@@ -591,16 +590,16 @@ void i8051_reset(void *param)
 	//made the *second* and every later reset install NULL, leaving the CPU
 	//permanently unable to talk to its driver.  A driver that pulses this CPU's
 	//reset line -- mephisto.c drives RST ASIN that way -- needs the registration
-	//to survive every reset, not just the first.  (hold_eram_iaddr_callback below
-	//has the same shape; it is left as it was because no driver in this tree both
-	//registers it and resets its 8051 more than once.  See
-	//docs/findings/2026-08-31-sound-link-fixes.md.)
+	//to survive every reset, not just the first.  See
+	//docs/findings/2026-08-31-sound-link-fixes.md.
 	i8051.serial_tx_callback = hold_serial_tx_callback;
 	i8051.serial_rx_callback = hold_serial_rx_callback;
 
-	//Setup External ram callback handlers
+	//Setup External ram callback handlers.  Same rule, and it stopped being
+	//hypothetical when mephisto.c registered one: RST ASIN resets that 8051
+	//dozens of times a minute, and clearing the static here put every paged
+	//MOVX @Ri back on page 0 from the second reset onwards.
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;
-	hold_eram_iaddr_callback = NULL;
 
 	//Clear Ram (w/0xff)
 	memset(&i8051.IntRam,0xff,sizeof(i8051.IntRam));
@@ -638,7 +637,10 @@ void i8051_reset(void *param)
 /* Shut down CPU core */
 void i8051_exit(void)
 {
-	/* nothing to do */
+#ifdef I8051_SWEEP
+	sweep_irq_report();
+#endif
+	/* nothing else to do */
 }
 
 /* Execute cycles - returns number of cycles actually run */
@@ -1521,6 +1523,42 @@ void i8051_set_irq_line(int irqline, int state)
 		e) RI+TI
 		f) TF2+EXF2
  **********************************************************************************/
+/***********************************************************************************
+ I8051_SWEEP -- per-source interrupt dispatch counters (compiled out unless
+ -DI8051_SWEEP).
+
+ check_interrupts() proposes a vector in up to six separate if-blocks, each of
+ which may overwrite the previous one's i8051.int_vec.  Counting at those sites
+ would therefore over-count: a proposal is not a dispatch.  The counters below
+ are incremented at the single point where the dispatch is committed -- after
+ the last early-return, immediately before push_pc() -- so each increment is one
+ interrupt the CPU actually took.
+
+ Purpose: when a game's audio digest moves after a change to the enable-bit
+ logic, these say which of the five sources caused it.  Purely observational;
+ no emulation state is read or written that the core does not already read.
+ ***********************************************************************************/
+#ifdef I8051_SWEEP
+static unsigned long long sweep_irq_ie0  = 0;	/* External 0        */
+static unsigned long long sweep_irq_tf0  = 0;	/* Timer 0 overflow  */
+static unsigned long long sweep_irq_ie1  = 0;	/* External 1        */
+static unsigned long long sweep_irq_tf1  = 0;	/* Timer 1 overflow  */
+static unsigned long long sweep_irq_riti = 0;	/* Serial RI/TI      */
+static unsigned long long sweep_irq_tf2  = 0;	/* Timer 2 TF2/EXF2  */
+
+static void sweep_irq_report(void)
+{
+	static int reported = 0;
+	if (reported) return;
+	reported = 1;
+
+	printf("I8051_SWEEP IRQ ie0=%llu tf0=%llu ie1=%llu tf1=%llu riti=%llu tf2=%llu\n",
+		sweep_irq_ie0, sweep_irq_tf0, sweep_irq_ie1,
+		sweep_irq_tf1, sweep_irq_riti, sweep_irq_tf2);
+	fflush(stdout);
+}
+#endif /* I8051_SWEEP */
+
 INLINE UINT8 check_interrupts(void)
 {
 #if FIXIRQ
@@ -1540,42 +1578,40 @@ INLINE UINT8 check_interrupts(void)
 	//NOTE: The order of checking is based on the internal/default priority levels when levels are the same
 
 	//External Int 0
-	if(GET_IE0) {
+	if(EXT0_IRQ) {
 		//Set vector & priority level request
 		i8051.int_vec = V_IE0;
 		i8051.priority_request = GET_PX0;
 	}
 	//Timer 0 overflow
-	if(!i8051.priority_request && GET_TF0 && (!i8051.int_vec || (i8051.int_vec && GET_PT0))) {
+	if(!i8051.priority_request && TIMER0_IRQ && (!i8051.int_vec || (i8051.int_vec && GET_PT0))) {
 		//Set vector & priority level request
 		i8051.int_vec = V_TF0;
 		i8051.priority_request = GET_PT0;
 	}
 	//External Int 1
-	if(!i8051.priority_request && GET_IE1 && (!i8051.int_vec || (i8051.int_vec && GET_PX1))) {
+	if(!i8051.priority_request && EXT1_IRQ && (!i8051.int_vec || (i8051.int_vec && GET_PX1))) {
 		//Set vector & priority level request
 		i8051.int_vec = V_IE1;
 		i8051.priority_request = GET_PX1;
 	}
 	//Timer 1 overflow
-	if(!i8051.priority_request && GET_TF1 && (!i8051.int_vec || (i8051.int_vec && GET_PT1))) {
+	if(!i8051.priority_request && TIMER1_IRQ && (!i8051.int_vec || (i8051.int_vec && GET_PT1))) {
 		//Set vector & priority level request
 		i8051.int_vec = V_TF1;
 		i8051.priority_request = GET_PT1;
 	}
 	//Serial Interrupt Transmit/Receive Interrupts (Note: ES Bit - Serial Interrupts must be enabled)
-	if(!i8051.priority_request && GET_ES && (GET_TI || GET_RI) && (!i8051.int_vec || (i8051.int_vec && GET_PS))) {
+	if(!i8051.priority_request && SERIALPORT_IRQ && (!i8051.int_vec || (i8051.int_vec && GET_PS))) {
 		//Set vector & priority level request
 		i8051.int_vec = V_RITI;
 		i8051.priority_request = GET_PS;
 	}
 #if (HAS_I8052 || HAS_I8752)
-	//Timer 2 overflow (Either Timer Overflow OR External Interrupt)
-#ifdef PINMAME // otherwise no sound on spinball games
-	if(!i8051.priority_request && (GET_TF2 || GET_EXF2) && (!i8051.int_vec || (i8051.int_vec && GET_PT2))) {
-#else
-	if(!i8051.priority_request && GET_ET2 && (GET_TF2 || GET_EXF2) && (!i8051.int_vec || (i8051.int_vec && GET_PT2))) {
-#endif		//Set vector & priority level request
+	//Timer 2 overflow (Either Timer Overflow OR External Interrupt).
+	//TIMER2_IRQ gates on ET2 and on the CPU subtype -- see the macro's comment.
+	if(!i8051.priority_request && TIMER2_IRQ && (!i8051.int_vec || (i8051.int_vec && GET_PT2))) {
+		//Set vector & priority level request
 		i8051.int_vec = V_TF2;
 		i8051.priority_request = GET_PT2;
 	}
@@ -1585,7 +1621,27 @@ INLINE UINT8 check_interrupts(void)
 	if(i8051.cur_irq < 0xff && !i8051.priority_request)
 		{ LOG(("low priority irq in progress already, skipping low irq request\n")); return 0; }
 
+	//No source was actually selected above, so there is nothing to dispatch.
+	//Without this, PC would be set to int_vec == 0 -- i.e. the reset vector --
+	//with a return address pushed.  Reachable whenever NO_PENDING_IRQ and the
+	//proposals disagree, which the enable bits make possible if either is ever
+	//changed without the other.
+	if(!i8051.int_vec) return 0;
+
     /*** --- Perform the interrupt --- ***/
+
+#ifdef I8051_SWEEP
+	/* Committed: past every early return, the vector is final.  One increment
+	   here == one interrupt actually taken.  See the block above check_interrupts(). */
+	switch(i8051.int_vec) {
+		case V_IE0:  sweep_irq_ie0++;  break;
+		case V_TF0:  sweep_irq_tf0++;  break;
+		case V_IE1:  sweep_irq_ie1++;  break;
+		case V_TF1:  sweep_irq_tf1++;  break;
+		case V_RITI: sweep_irq_riti++; break;
+		case V_TF2:  sweep_irq_tf2++;  break;
+	}
+#endif
 
 	//Save current pc to stack, set pc to new interrupt vector
 	push_pc();
@@ -2440,7 +2496,6 @@ void i8752_reset (void *param)
 
 	//Setup External ram callback handlers
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;
-	hold_eram_iaddr_callback = NULL;
 
 	//Clear Ram (w/0xff)
 	memset(&i8051.IntRam,0xff,sizeof(i8051.IntRam));

--- a/src/driver.h
+++ b/src/driver.h
@@ -99,6 +99,7 @@ typedef struct {
 #ifdef REMOTE_DEBUG
   int http_port;               /* HTTP server port */
   int start_paused;            /* Start emulator in paused state */
+  char *holdport;              /* Force input port bits high from power-on, PORT:HEXMASK[,PORT:HEXMASK...] */
 #endif
 } tPMoptions;
 extern tPMoptions pmoptions;

--- a/src/inptport.c
+++ b/src/inptport.c
@@ -2717,6 +2717,21 @@ profiler_mark(PROFILER_END);
 
 
 
+#ifdef REMOTE_DEBUG
+/* A forced-value overlay, OR'd into every readinputport() result. Lets a
+ * button be presented as already held from power-on (see -holdport in
+ * src/unix/config.c) or toggled at runtime via /api/input/port, neither of
+ * which the normal keyboard/joystick input path can reach before the
+ * debugger's HTTP API exists. */
+static unsigned short input_port_force[MAX_INPUT_PORTS];
+
+void input_port_set_force(int port, unsigned short mask)
+{
+	if (port >= 0 && port < MAX_INPUT_PORTS) input_port_force[port] = mask;
+}
+
+#endif
+
 int readinputport(int port)
 {
 	struct InputPort *in;
@@ -2728,7 +2743,11 @@ int readinputport(int port)
 		scale_analog_port(port);
 	}
 
+#ifdef REMOTE_DEBUG
+	return input_port_value[port] | input_port_force[port];
+#else
 	return input_port_value[port];
+#endif
 }
 
 READ_HANDLER( input_port_0_r ) { return readinputport(0); }

--- a/src/inptport.h
+++ b/src/inptport.h
@@ -408,6 +408,12 @@ void update_input_ports(void);	/* called by cpuintrf.c - not for external use */
 void inputport_vblank_end(void);	/* called by cpuintrf.c - not for external use */
 
 int readinputport(int port);
+
+#ifdef REMOTE_DEBUG
+/* Forced-value overlay OR'd into readinputport()'s result -- see inptport.c. */
+void input_port_set_force(int port, unsigned short mask);
+#endif
+
 READ_HANDLER( input_port_0_r );
 READ_HANDLER( input_port_1_r );
 READ_HANDLER( input_port_2_r );

--- a/src/remote_debug/api_handler.c
+++ b/src/remote_debug/api_handler.c
@@ -327,7 +327,17 @@ static void handle_api_info(const http_request_t *req, http_response_t *resp)
 		char sw_hex[CORE_MAXSWCOL * 2 + 1];
 		char seg_hex[CORE_SEGCOUNT * 4 + 1];
 		char desc_esc[256];
+		/* room for CORE_MAXGI ints ("-2147483648," is 12) plus the brackets */
+		char gi_str[CORE_MAXGI * 12 + 4];
+		char *gi_p = gi_str;
 		int i, ded, len;
+		/* GI strings, 0..8 per string, as a JSON array.  Only the drivers
+		   that set coreGlobals.nGI have any; the rest report []. */
+		*gi_p++ = '[';
+		for (i = 0; i < coreGlobals.nGI && i < CORE_MAXGI; i++)
+			gi_p += sprintf(gi_p, i ? ",%d" : "%d", coreGlobals.gi[i]);
+		*gi_p++ = ']';
+		*gi_p = '\0';
 		for (i = 0; i < CORE_MAXLAMPCOL; i++)
 			sprintf(lamp_hex + i * 2, "%02X", coreGlobals.lampMatrix[i]);
 		for (i = 0; i < CORE_MAXSWCOL; i++)
@@ -339,12 +349,12 @@ static void handle_api_info(const http_request_t *req, http_response_t *resp)
 			"{\"game\": \"%s\", \"description\": \"%s\", \"manufacturer\": \"%s\", "
 			"\"year\": \"%s\", \"paused\": %d, \"wpc_bank\": %d, \"lamps\": \"%s\", "
 			"\"switches\": \"%s\", \"segments\": \"%s\", \"dedicated\": %d, "
-			"\"solenoids\": %u, \"solenoids2\": %u}",
+			"\"solenoids\": %u, \"solenoids2\": %u, \"gi\": %s}",
 			Machine->gamedrv->name,
 			remote_debug_json_escape(desc_esc, (int)sizeof(desc_esc), Machine->gamedrv->description),
 			Machine->gamedrv->manufacturer, Machine->gamedrv->year,
 			remote_debug_is_paused(), bank, lamp_hex, sw_hex, seg_hex, ded,
-			coreGlobals.solenoids, coreGlobals.solenoids2);
+			coreGlobals.solenoids, coreGlobals.solenoids2, gi_str);
 		remote_debug_unlock();
 		resp->body = buffer;
 		resp->len = (len > 0 && len < 8192) ? len : (int)strlen(buffer);
@@ -1038,6 +1048,46 @@ static void handle_api_input(const http_request_t *req, http_response_t *resp)
 		respond_error(resp, 503, "core not initialized");
 }
 
+/* Force bits high/low in a raw input port's value, e.g. to hold a
+ * dedicated cabinet button (ADVANCE, TEST) at runtime the same way
+ * -holdport presents one from power-on. */
+static void handle_api_input_port(const http_request_t *req, http_response_t *resp)
+{
+	char port_buf[32], val_buf[32];
+	int port;
+	get_query_param(req->query, "port", port_buf, (int)sizeof(port_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	if (!port_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: port, val");
+		return;
+	}
+	port = parse_int(port_buf);
+	if (remote_debug_set_input_port_force(port, (int)parse_hex(val_buf)) == 0)
+		respond_ok(resp);
+	else
+		respond_error(resp, 400, "port out of range");
+}
+
+/* Write a switch-matrix column directly, bypassing core_setSw/sw2m, so a
+ * dedicated switch column outside the scanned matrix (e.g. col 0, the
+ * cabinet row) can be set from the API. */
+static void handle_api_input_matrix(const http_request_t *req, http_response_t *resp)
+{
+	char col_buf[32], val_buf[32];
+	int col;
+	get_query_param(req->query, "col", col_buf, (int)sizeof(col_buf));
+	get_query_param(req->query, "val", val_buf, (int)sizeof(val_buf));
+	if (!col_buf[0] || !val_buf[0]) {
+		respond_error(resp, 400, "missing parameters: col, val");
+		return;
+	}
+	col = parse_int(col_buf);
+	if (remote_debug_set_matrix_col(col, (int)parse_hex(val_buf)) == 0)
+		respond_ok(resp);
+	else
+		respond_error(resp, 503, "core not initialized, or col out of range");
+}
+
 /* Read or set g_fHandleMechanics, the flag a front end uses to take ownership
  * of driver-modelled mechanics (VPinMAME exposes it as
  * Controller.HandleMechanics; libpinmame defaults it to 0). The standalone
@@ -1490,6 +1540,10 @@ static const api_route_t api_routes[] = {
 	 "?val=N - set g_fHandleMechanics (0 = front end owns the mechanics); no val = read"},
 	{"/api/input", handle_api_input,
 	 "?sw=N&val=0|1[&pulse=MS] - set a switch, optionally as a timed pulse"},
+	{"/api/input/port", handle_api_input_port,
+	 "?port=N&val=HEX - force bits high/low in a raw input port (reaches dedicated buttons like ADVANCE)"},
+	{"/api/input/matrix", handle_api_input_matrix,
+	 "?col=N&val=HEX - write a switch-matrix column directly, bypassing core_setSw/sw2m"},
 	{"/ui", handle_ui, "the web UI"},
 	{"/api/doc", handle_api_doc, "this document"},
 };

--- a/src/remote_debug/remote_debug.c
+++ b/src/remote_debug/remote_debug.c
@@ -15,6 +15,7 @@
 #include "wpc/core.h"
 #include "wpc/wpc.h"
 #include "memory.h"
+#include "inptport.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -369,6 +370,9 @@ static void publish_event(const char *fmt, ...)
 static void service_pulses(void);
 static void pulse_tick(int reassert);
 
+/* forward declaration; defined with the switch/input implementation below */
+static void apply_holdport_option(void);
+
 int remote_debug_next_event(char *buf, int maxlen)
 {
 	int have = 0;
@@ -466,6 +470,7 @@ void remote_debug_init(void)
 		is_paused = 1;
 		printf("Remote Debugger: paused on start\n");
 	}
+	apply_holdport_option();
 	should_quit = 0;
 	step_requested = 0;
 	breakpoint_count = 0;
@@ -1675,6 +1680,68 @@ int remote_debug_set_switch(int sw, int val, int pulse_ms)
 	}
 	remote_debug_unlock();
 	return result;
+}
+
+/* Force bits high/low in input port `port`'s value, independent of the
+ * normal keyboard/joystick read (see /api/input/port and -holdport). This
+ * is the only way to present a dedicated-input button (e.g. ADVANCE) as
+ * already held, including from before MACHINE_INIT runs. Returns 0 on
+ * success, -1 if port is out of range. */
+int remote_debug_set_input_port_force(int port, int val)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (port >= 0 && port < MAX_INPUT_PORTS) {
+		input_port_set_force(port, (unsigned short)val);
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+/* Write switch-matrix column `col` directly, bypassing core_setSw and its
+ * sw2m mapping (see /api/input/matrix). core_setSw maps every positive
+ * switch number to swMatrix[1] or later (core_swSeq2m: no+7), so dedicated
+ * columns such as col 0 -- the cabinet row holding TEST/ADVANCE/EG1/EG2 --
+ * are otherwise unreachable from the API. Returns 0 on success, -1 if the
+ * core is not ready or col is out of range. */
+int remote_debug_set_matrix_col(int col, int val)
+{
+	int result = -1;
+	remote_debug_lock();
+	if (coreData && col >= 0 && col < CORE_MAXSWCOL) {
+		coreGlobals.swMatrix[col] = (UINT8)val;
+		result = 0;
+	}
+	remote_debug_unlock();
+	return result;
+}
+
+/* Parse "-holdport PORT:HEXMASK[,PORT:HEXMASK...]" and force those input
+ * port bits high before the machine runs, so MACHINE_INIT sees them --
+ * this is how "hold ADVANCE while switching on" (the real machine's route
+ * into test mode) gets simulated, since the normal input path is not
+ * reachable that early. Called once from remote_debug_init(), which itself
+ * runs before run_machine() (see mame.c). */
+static void apply_holdport_option(void)
+{
+	char *copy, *tok;
+
+	if (!pmoptions.holdport || !pmoptions.holdport[0])
+		return;
+	copy = strdup(pmoptions.holdport);
+	if (!copy)
+		return;
+	for (tok = strtok(copy, ","); tok; tok = strtok(NULL, ",")) {
+		char *sep = strchr(tok, ':');
+		if (sep) {
+			int port = atoi(tok);
+			unsigned short mask = (unsigned short)strtoul(sep + 1, NULL, 16);
+			input_port_set_force(port, mask);
+			printf("Remote Debugger: holding port %d bits %04X from power-on\n", port, mask);
+		}
+	}
+	free(copy);
 }
 
 /* ================================================================== */

--- a/src/remote_debug/remote_debug.h
+++ b/src/remote_debug/remote_debug.h
@@ -167,6 +167,20 @@ void remote_debug_get_solenoids(char **buffer, int *len);
  * ready. */
 int remote_debug_set_switch(int sw, int val, int pulse_ms);
 
+/* Force bits high/low in input port `port`'s value, independent of the
+ * normal keyboard/joystick read (see /api/input/port and -holdport) --
+ * lets a dedicated-input button be presented as held, including from
+ * before MACHINE_INIT runs. Returns 0 on success, -1 if port is out of
+ * range. */
+int remote_debug_set_input_port_force(int port, int val);
+
+/* Write switch-matrix column `col` directly, bypassing core_setSw's sw2m
+ * mapping (see /api/input/matrix) -- the only way to reach a dedicated
+ * switch column (e.g. col 0) that sw2m places outside the scanned matrix.
+ * Returns 0 on success, -1 if the core is not ready or col is out of
+ * range. */
+int remote_debug_set_matrix_col(int col, int val);
+
 /* ------------------------------------------------------------------ */
 /* Object monitoring (change log)                                     */
 /* ------------------------------------------------------------------ */

--- a/src/sound/mixer.c
+++ b/src/sound/mixer.c
@@ -212,6 +212,123 @@ INLINE float triangular(const float r) // from -1..1, c=0 (with random no r=0..1
 //   -> but then also use triangular() instead of rand()-rand()!
 
 /***************************************************************************
+	I8051_SWEEP -- audio digest probe (compiled out unless -DI8051_SWEEP)
+
+	Every mixed sample the emulator produces passes through the single call to
+	osd_update_audio_stream() in mixer_sh_update(), so a checksum taken there
+	is a checksum of the machine's entire audio output.  It exists to answer
+	exactly one question: did a change to a shared CPU core alter what a game
+	plays?  Identical digest before and after == provably no change.
+
+	The digest is bounded by SAMPLE COUNT, never by wall clock, so two runs
+	that are stopped at different moments still produce comparable numbers as
+	long as both reached the cap (or both ran the same number of frames).
+
+	A warning about "nonzero": mixer_sh_update() adds TPDF dither of +-1 LSB
+	to every sample before quantising, and it does so whether or not anything
+	is playing.  A perfectly silent machine therefore still emits a stream of
+	0/+1/-1 values, and "nonzero" counts roughly half of them.  "nonzero" is
+	NOT a silence test.  "loud" (|s| > 1) is: it is exactly zero for a machine
+	that is producing no audio, because dither alone can never exceed 1 LSB.
+
+	This probe never touches the buffer and never changes emulation state.
+***************************************************************************/
+#ifdef I8051_SWEEP
+
+/* Bound the digest at this many INT16 values (stereo counts 2 per sample). */
+#define SWEEP_AUDIO_MAX_VALUES	2000000u
+
+/*
+	2026-08-31 addendum: `loud` (|s|>1) tells you a stream left the dither floor, and
+	nothing about *how*.  A DC rail leaves it on sample one and stays there, which is
+	exactly what let a constant AY-3-8910 output score as "ok" upstream in
+	scripts/i8051_sweep.sh -- see the adversarial review that caught it,
+	.superpowers/i8051-fix-review.md section 1.  AC rms (stddev about the running mean)
+	is the discriminator that review used to tell a rail from a varying signal: a rail's
+	AC rms is at most the dither's own ~0.5 LSB, regardless of its DC offset, while every
+	genuinely varying stream measured was two orders of magnitude higher.  Computed with
+	Welford's online algorithm so it stays O(1) memory over a run.
+
+	Skipped over the first SWEEP_AC_SKIP_VALUES values to sit past the boot transient.
+	The review's own per-second breakdown (section 1.2, "per-second std (after boot
+	second)") is the source for how long that transient actually lasts: every stream it
+	measured is already representative from the *second* emulated second onward -- one
+	second, not the 20-24 s window used elsewhere in that document for a more detailed
+	presentation of four specific streams.  One second matters here: `pmv112`, the
+	review's control for "a game genuinely playing something", has its whole burst in
+	seconds 2-3 and is flat for the rest of the 60 s run, so a longer skip (20 s was tried
+	first) throws the one real positive example away and mislabels it a rail.  At the
+	sweep's fake 8 kHz mono rate one second is 8,000 values.
+*/
+#define SWEEP_AC_SKIP_VALUES	8000ull
+
+static unsigned int       sweep_audio_hash	= 2166136261u;	/* FNV-1a offset basis */
+static unsigned long long sweep_audio_seen	= 0;	/* INT16 values produced, unbounded */
+static unsigned long long sweep_audio_n	= 0;	/* INT16 values actually digested   */
+static unsigned long long sweep_audio_nonzero	= 0;	/* of those, != 0  (dither included) */
+static unsigned long long sweep_audio_loud	= 0;	/* of those, |s|>1 (dither excluded) */
+
+static double             sweep_ac_mean	= 0.0;	/* running mean, post-skip samples only */
+static double             sweep_ac_m2		= 0.0;	/* Welford's M2 (sum of squared deviations) */
+static unsigned long long sweep_ac_n		= 0;	/* samples folded into mean/m2 */
+static unsigned long long sweep_ac_clip	= 0;	/* of those, at a full-scale rail */
+
+static void sweep_audio_digest(const INT16 *buf, unsigned int count)
+{
+	unsigned int i;
+
+	sweep_audio_seen += count;
+
+	for (i = 0; i < count && sweep_audio_n < SWEEP_AUDIO_MAX_VALUES; i++)
+	{
+		const INT16 s = buf[i];
+		const unsigned int u = (unsigned int)(unsigned short)s;
+
+		sweep_audio_hash = (sweep_audio_hash ^ (u & 0xff)) * 16777619u;
+		sweep_audio_hash = (sweep_audio_hash ^ (u >> 8))   * 16777619u;
+
+		if (s != 0)			sweep_audio_nonzero++;
+		if (s > 1 || s < -1)	sweep_audio_loud++;
+
+		if (sweep_audio_n >= SWEEP_AC_SKIP_VALUES)
+		{
+			const double x = (double)s;
+			const double delta = x - sweep_ac_mean;
+
+			sweep_ac_n++;
+			sweep_ac_mean += delta / (double)sweep_ac_n;
+			sweep_ac_m2   += delta * (x - sweep_ac_mean);
+
+			if (s == 32767 || s == -32768)	sweep_ac_clip++;
+		}
+
+		sweep_audio_n++;
+	}
+}
+
+static void sweep_audio_report(void)
+{
+	static int reported = 0;
+	double ac_rms, clip_pct;
+
+	if (reported) return;
+	reported = 1;
+
+	ac_rms   = (sweep_ac_n > 0) ? sqrt(sweep_ac_m2 / (double)sweep_ac_n) : 0.0;
+	clip_pct = (sweep_ac_n > 0) ? (100.0 * (double)sweep_ac_clip / (double)sweep_ac_n) : 0.0;
+
+	printf("I8051_SWEEP AUDIO hash=%08x n=%llu seen=%llu nonzero=%llu loud=%llu "
+		"ac_rms=%.3f clip_pct=%.3f ac_n=%llu\n",
+		sweep_audio_hash,
+		sweep_audio_n, sweep_audio_seen,
+		sweep_audio_nonzero, sweep_audio_loud,
+		ac_rms, clip_pct, sweep_ac_n);
+	fflush(stdout);
+}
+
+#endif /* I8051_SWEEP */
+
+/***************************************************************************
 	mixer_channel_resample
 ***************************************************************************/
 
@@ -780,6 +897,10 @@ void mixer_sh_stop()
 	struct mixer_channel_data *channel;
 	int i;
 
+#ifdef I8051_SWEEP
+	sweep_audio_report();
+#endif
+
 	osd_stop_audio_stream();
 
 	for (i = 0, channel = mixer_channel; i < MIXER_MAX_CHANNELS; i++, channel++)
@@ -931,6 +1052,10 @@ void mixer_sh_update()
     extern void pm_wave_record(INT16 *buffer, int samples);
     pm_wave_record(mix_buffer, samples_this_frame);
     }
+
+#ifdef I8051_SWEEP
+	sweep_audio_digest(mix_buffer, samples_this_frame * (is_stereo ? 2 : 1));
+#endif
 
 	samples_this_frame = osd_update_audio_stream(mix_buffer);
 

--- a/src/unix/config.c
+++ b/src/unix/config.c
@@ -141,6 +141,9 @@ static struct rc_option opts[] = {
 	{ "skip_disclaimer", NULL, rc_bool, &options.skip_disclaimer, "0", 0, 0, NULL, "Skip displaying the disclaimer screen" },
 	{ "skip_gameinfo", NULL, rc_bool, &options.skip_gameinfo, "0", 0, 0, NULL, "Skip displaying the game info screen" },
 	{ "skip_gamewarnings", NULL, rc_bool, &options.skip_gamewarnings, "0", 0, 0, NULL, "Skip displaying the game warnings screen (needed for headless runs of GAME_NOT_WORKING games)" },
+#ifdef REMOTE_DEBUG
+	{ "holdport", NULL, rc_string, &pmoptions.holdport, NULL, 0, 0, NULL, "force bits high in an input port from power-on, as PORT:HEXMASK (repeatable, comma separated) - simulates a button held while the machine is switched on" },
+#endif
 	{ "crconly", NULL, rc_bool, &options.crc_only, "0", 0, 0, NULL, "Use only CRC for all integrity checks" },
 	{ "bios", NULL, rc_string, &options.bios, "default", 0, 14, NULL, "change system bios" },
 #ifdef MAME_DEBUG

--- a/src/unix/keyboard.c
+++ b/src/unix/keyboard.c
@@ -206,6 +206,18 @@ const struct KeyboardInfo *osd_get_key_list(void)
 
 int osd_is_key_pressed(int keycode)
 {
+   /* special case: if we're trying to quit, fake up/down/up/down.
+      This is checked before the kbd_fifo guard below on purpose: headless mode
+      never calls osd_input_initpost(), so kbd_fifo stays NULL and the guard used
+      to swallow the fake ESC -- which is the only way trying_to_quit reaches
+      handle_user_interface().  Without this, neither -frames_to_run nor SIGQUIT
+      could end a headless run. */
+   if (keycode == KEY_ESC && trying_to_quit)
+   {
+      static int dummy_state = 1;
+      return dummy_state ^= 1;
+   }
+
    /* blames to the dos-people who want to check key states before
       the display (and under X thus the keyboard) is initialised */
    if (!kbd_fifo)
@@ -213,13 +225,6 @@ int osd_is_key_pressed(int keycode)
    
    if (keycode >= KEY_MAX)
       return 0;
-
-   /* special case: if we're trying to quit, fake up/down/up/down */
-   if (keycode == KEY_ESC && trying_to_quit)
-   {
-      static int dummy_state = 1;
-      return dummy_state ^= 1;
-   }
 
    sysdep_update_keyboard();
 	

--- a/src/unix/video.c
+++ b/src/unix/video.c
@@ -773,7 +773,31 @@ void osd_update_video_and_audio(struct mame_display *display)
 #ifdef REMOTE_DEBUG
 	remote_debug_frame_update(display);
 #endif
-	if (pmoptions.headless) return;
+	/* Headless: -frames_to_run has to be honoured here.  The frame counter below
+	   lives inside the `GAME_BITMAP_CHANGED` blit block, and headless never creates
+	   a display, so that block never runs and -ftr N never terminated the run --
+	   headless runs could only be killed on a wall-clock timer.  This function is
+	   called exactly once per emulated frame (from updatescreen(), via
+	   artwork_update_video_and_audio(), whether or not the frame is skipped), so
+	   counting here is the same count the display path would have produced.
+	   Same class of gap as the headless osd_close_display() fix above.
+
+	   The termination test is deliberately spelled the same way as the display
+	   path's below (`frames_displayed + 1 == frames_to_display`) rather than as
+	   `>= frames_to_display`: the two differ by one frame, so the same -ftr N
+	   would otherwise emulate a different number of frames headless than
+	   windowed.  The `> 0` guard is kept because "run forever" is 0 here.
+	   Note the display path's counter still means something slightly different
+	   -- it starts only once start_time is set, a second into the run, and it
+	   skips frames that are not blitted -- so this aligns the comparison, not
+	   the whole meaning of the count. */
+	if (pmoptions.headless)
+	{
+		frames_displayed++;
+		if (frames_to_display > 0 && frames_displayed + 1 == frames_to_display)
+			trying_to_quit = 1;
+		return;
+	}
 	int skip_this_frame;
 	cycles_t curr;
 


### PR DESCRIPTION
Needs #PR655. Four behavioural fixes; i8051.h untouched, no API change.

Serial callbacks were cleared in i8051_reset(), so a driver that set them at init lost them on the first reset — moved to i8051_init(). Timer 1's baud-rate bit clock implemented. MOVX @Ri now consults the existing i8051_set_eram_iaddr_callback hook it previously ignored for that addressing form, so paged XRAM no longer collapses onto page 0.

Harmless for any game that doesn't set the callback; the old path is preserved when it's null.