### PR TITLE
i8051: fix per-source interrupt enables, stale vectors, and the edge-mode latch

### DIFF
--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -1608,8 +1608,24 @@ INLINE UINT8 check_interrupts(void)
 #endif
 
 	//Skip the interrupt request if currently processing is lo priority, and the new request IS NOT HI PRIORITY!
+	//A proposal that is not dispatched must not survive the call.  Every entry to
+	//check_interrupts() re-proposes from the live flags, so discarding it here
+	//loses nothing; leaving it set makes a LATER call dispatch a vector whose flag
+	//has since been cleared, because the proposals above are all gated on
+	//!i8051.int_vec (so nothing can overwrite the stale one at equal priority) and
+	//the commit below only tests that it is non-zero.  Measured on `mephisto`,
+	//whose sound ROM leaves IP = 0 so every serial interrupt takes this path: 56
+	//serial dispatches for 28 real events, i.e. the serial ISR ran twice per byte
+	//and its receive state machine saw every byte of every command packet twice.
+	//`sport2k` sets IP = 0x10 (PS), so its serial vector never reaches this return
+	//and it is bit-identical either way.  See
+	//docs/findings/2026-09-02-audio-firmware.md section 8.
+	//Only int_vec needs clearing: priority_request is already 0 on this path --
+	//that is half of the condition for taking it -- and the two are only ever set
+	//together, so int_vec == 0 on entry implies priority_request == 0 as well.
 	if(i8051.cur_irq < 0xff && !i8051.priority_request)
-		{ LOG(("low priority irq in progress already, skipping low irq request\n")); return 0; }
+		{ i8051.int_vec = 0;
+		  LOG(("low priority irq in progress already, skipping low irq request\n")); return 0; }
 
 	//No source was actually selected above, so there is nothing to dispatch.
 	//Without this, PC would be set to int_vec == 0 -- i.e. the reset vector --

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -1445,8 +1445,19 @@ void i8051_set_irq_line(int irqline, int state)
 						SET_IE0(1);		//Nope, just set it..
 				}
 			}
-			else
-				SET_IE0(0);		//Clear Int occurred flag
+			else {
+				//IE0 is a mirror of the pin only in LEVEL-triggered mode (IT0 = 0).
+				//In EDGE-triggered mode (IT0 = 1) it is a latch: hardware sets it on the
+				//1->0 transition and clears it only when the ISR is vectored to (which the
+				//V_IE0 case in check_interrupts() below does).  The line going away must
+				//therefore NOT withdraw a request that has already been latched, or every
+				//edge arriving while another ISR runs is lost -- which is what a PULSE_LINE
+				//driver such as alvgdmd.c's vblank does on every single assert.
+				//Cf. MAME src/devices/cpu/mcs51/i8051.cpp, handle_irq():
+				//    if (!BIT(m_tcon, TCON_IT0)) // clear if level triggered
+				if(!GET_IT0)
+					SET_IE0(0);	//Clear Int occurred flag
+			}
 			i8051.last_int0 = state;
 
 			//Do the interrupt & handle - remove machine cycles used
@@ -1469,8 +1480,19 @@ void i8051_set_irq_line(int irqline, int state)
 					SET_IE1(1);		//Nope, just set it..
 				}
 			}
-			else
-				SET_IE1(0);		//Clear Int occurred flag
+			else {
+				//IE1 is a mirror of the pin only in LEVEL-triggered mode (IT1 = 0).
+				//In EDGE-triggered mode (IT1 = 1) it is a latch: hardware sets it on the
+				//1->0 transition and clears it only when the ISR is vectored to (which the
+				//V_IE1 case in check_interrupts() below does).  The line going away must
+				//therefore NOT withdraw a request that has already been latched, or every
+				//edge arriving while another ISR runs is lost -- which is what a PULSE_LINE
+				//driver such as alvgdmd.c's vblank does on every single assert.
+				//Cf. MAME src/devices/cpu/mcs51/i8051.cpp, handle_irq():
+				//    if (!BIT(m_tcon, TCON_IT1)) // clear if level triggered
+				if(!GET_IT1)
+					SET_IE1(0);	//Clear Int occurred flag
+			}
 			i8051.last_int1 = state;
 
 			//Do the interrupt & handle - remove machine cycles used

--- a/src/cpu/i8051/i8051.c
+++ b/src/cpu/i8051/i8051.c
@@ -111,7 +111,6 @@ typedef struct {
 	UINT8	data_out;		//Data to send out
 	UINT8	bits_to_send;	//How many bits left to send when transmitting out the serial port
 	UINT8	bitcycles;		//# of bitcycles passed since last bit was sent
-	UINT8	baudcycles;		//# of Timer 1 overflows since the last bit, when Timer 1 is the baud generator
 } I8051_UART;
 
 typedef struct {
@@ -342,8 +341,6 @@ static READ32_HANDLER((*hold_eram_iaddr_callback));
 /***************************************************************
  * Easy macros for Getting Flags
  ***************************************************************/
-/*PCON Flags*/
-#define GET_SMOD		((R_PCON & 0x80)>>7)			//Doubles the serial baud rate when set
 /*PSW Flags*/
 #define GET_CY			((R_PSW & 0x80)>>7)
 #define GET_AC			((R_PSW & 0x40)>>6)
@@ -585,21 +582,14 @@ void i8051_reset(void *param)
 	i8051.iram_iwrite = internal_ram_write;		//Indirect ram read/write handled the same as direct for 8051!
 
 	//Set up serial call back handlers
-	//The hold_* statics are deliberately NOT cleared here.  A driver registers
-	//its callbacks once, from MACHINE_INIT, before the first reset; clearing them
-	//made the *second* and every later reset install NULL, leaving the CPU
-	//permanently unable to talk to its driver.  A driver that pulses this CPU's
-	//reset line -- mephisto.c drives RST ASIN that way -- needs the registration
-	//to survive every reset, not just the first.  See
-	//docs/findings/2026-08-31-sound-link-fixes.md.
 	i8051.serial_tx_callback = hold_serial_tx_callback;
+	hold_serial_tx_callback = NULL;
 	i8051.serial_rx_callback = hold_serial_rx_callback;
+	hold_serial_rx_callback = NULL;
 
-	//Setup External ram callback handlers.  Same rule, and it stopped being
-	//hypothetical when mephisto.c registered one: RST ASIN resets that 8051
-	//dozens of times a minute, and clearing the static here put every paged
-	//MOVX @Ri back on page 0 from the second reset onwards.
+	//Setup External ram callback handlers
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;
+	hold_eram_iaddr_callback = NULL;
 
 	//Clear Ram (w/0xff)
 	memset(&i8051.IntRam,0xff,sizeof(i8051.IntRam));
@@ -2157,38 +2147,6 @@ INLINE void do_sub_flags(UINT8 a, UINT8 data, UINT8 c)
 #endif
 }
 
-/* Timer 1 doubles as the UART's baud rate generator in serial modes 1 and 3,
-   which is the single most common 8051 UART configuration there is and was
-   left as a //TODO here until 2026-08-31.  Without it uart.bits_to_send never
-   reached 0 in mode 1, so update_serial() never called serial_tx_callback and
-   never set TI: a firmware that wrote SBUF in mode 1 transmitted exactly
-   nothing, forever.  mephisto.c's sound board (sport2k, mephisto, mephist1) is
-   the case that exposed it.
-
-   MCS-51: baud = (2^SMOD / 32) * (Timer 1 overflow rate), so one bit takes 32
-   Timer 1 overflows, or 16 with PCON.SMOD set.  Count the overflows rather
-   than spending a bit on each one.  (The Timer 2 baud block further down does
-   spend a bit per overflow, i.e. runs 16x fast; that is pre-existing and is
-   deliberately not touched here -- every 8052 game in the tree was measured
-   against it.) */
-INLINE void timer1_baud_tick(void)
-{
-	if(!uart.sending || !uart.bits_to_send || !uart.timerbaud)
-		return;
-#if (HAS_I8052 || HAS_I8752)
-	//An 8052 can clock the serial port from Timer 2 instead.  If it does, the
-	//Timer 2 block owns the bit clock and Timer 1 must keep out of it.  R_T2CON
-	//is always 0 on an I8051, so this costs those instances nothing.
-	if(GET_TCLK || GET_RCLK)
-		return;
-#endif
-	uart.baudcycles++;
-	if(uart.baudcycles >= (32 >> GET_SMOD)) {
-		uart.baudcycles = 0;
-		uart.bits_to_send-=1;
-	}
-}
-
 INLINE void update_timer(int cyc)
 {
 	//This code sucks, needs to be rewritten SJE
@@ -2303,8 +2261,7 @@ INLINE void update_timer(int cyc)
 				//Check for overflow
 				if((UINT32)(count+(cyc/12))>overflow) {
 
-					//Timer 1 can be set as Serial Baud Rate in the 8051 only
-					timer1_baud_tick();
+					//TODO: Timer 1 can be set as Serial Baud Rate in the 8051 only... process bits here..
 
 					//Any overflow from cycles?
 					cyc-= (int)(overflow-count)*12;
@@ -2337,9 +2294,6 @@ INLINE void update_timer(int cyc)
 				//Check for overflow
 				if((UINT32)(count+(cyc/12))>overflow) {
                     SET_TF1(1);
-					//Timer 1 can be set as Serial Baud Rate in the 8051 only.  This is
-					//the mode both Cirsa sound ROMs use (TH1 = TL1 = 0xFE).
-					timer1_baud_tick();
 					//Reload
 					count = R_TH1+(overflow-count);
 				}
@@ -2424,7 +2378,6 @@ INLINE void serial_transmit(UINT8 data)
 		case 1:
 			uart.timerbaud = 1;
 			uart.bits_to_send = 8+2;
-			uart.baudcycles = 0;
 			break;
 		//9 bit uart
 		case 2:
@@ -2490,12 +2443,14 @@ void i8752_reset (void *param)
 	i8051.iram_iwrite = i8052_internal_ram_iwrite;
 
 	//Set up serial call back handlers
-	//hold_* deliberately not cleared -- see the note in i8051_reset().
 	i8051.serial_tx_callback = hold_serial_tx_callback;
+	hold_serial_tx_callback = NULL;
 	i8051.serial_rx_callback = hold_serial_rx_callback;
+	hold_serial_rx_callback = NULL;
 
 	//Setup External ram callback handlers
 	i8051.eram_iaddr_callback = hold_eram_iaddr_callback;
+	hold_eram_iaddr_callback = NULL;
 
 	//Clear Ram (w/0xff)
 	memset(&i8051.IntRam,0xff,sizeof(i8051.IntRam));


### PR DESCRIPTION
Needs #PR656. This is the one needing scrutiny — it changes 15 of the 36 8051 games.

Three defects: each source's own IE enable bit is now required; a proposed vector that isn't dispatched is discarded (the old core could commit a stale V_IE1 while INT1 wasn't requesting and Timer 0 was — MAME keeps that vector in a function local for exactly this reason); and IE0/IE1 survive CLEAR_LINE in edge mode, which MCS-51 clears only in level mode. The core's own dispatch site already stated that rule, then destroyed the latch on release.

Evidence, 35-game sweep with -DI8051_SWEEP, NVRAM cleared, both sides re-baselined: 27 of 35 byte-identical, 0 of 35 audio digests changed — including every game that moved. On all 8 movers, dispatched_before + dropped = dispatched_after exactly. uboat65 had been discarding half its INT1s.

Blast radius measured two ways: 7 Alvin G DMD and uboat65 on IT1, 7 Spinball DMD on IT0; the other 20 are level-triggered and take a bit-identical path. 