### PR TITLE
sleic: Bike Race / Pin-Ball YM3812 phi-M is 2.5 MHz, not 4 MHz

### DIFF
--- a/src/wpc/sleic.c
+++ b/src/wpc/sleic.c
@@ -943,7 +943,7 @@ static void ym3812_irq(int irq) {
 static struct YM3812interface SLEIC_ym3812_intf =
 {
 	1,					/* 1 chip */
-	4000000,			/* 4 MHz */
+	2500000,			/* phi-M = OCLK/8 = 20MHz/8 */
 	{ 100 },			/* volume */
 	{ ym3812_irq },		/* IRQ Callback */
 };


### PR DESCRIPTION
The shared SLEIC_ym3812_intf has carried a bare 4000000 with the comment "4 MHz" since the driver was written.  The board's tap is YCLK = OCLK/8 = 20 MHz / 8, and both firmwares' own note tables say the same thing.

Every F-Number either ROM writes is the rounded frequency in HERTZ of a standard equal-tempered note: Bike Race uses 247, 277, 311, 330, 349, 370, 440, 466 (= B3, C#4, D#4, E4, F4, F#4, A4, A#4) and Sleic Pin-Ball 494 and 659 (= B4, E5).  That is a usable way to write a note table only at this clock, because

    2 500 000 / (72 * 2^15)  =  1.059638  =  2^(1/12) to within +0.29 cents

so an F-Number carrying a note's Hz value sounds that note one semitone up. Traced over 249 key-ons out of Bike Race and 37 out of Sleic Pin-Ball, every note lands within 2.2 cents of A4 = 440 concert pitch at 2.5 MHz (RMS 1.1); at 4 MHz the whole scale is 14.1 cents sharp and transposed by 8.14 semitones, an interval no music is written in.

Confirmed against hardware from a recording of a real Bike Race: its sustained FM tones measure C4 261.62 Hz (-0.0 cents), D4 293.68 (+0.1), G4 391.90 (-0.4), B2 123.48 (+0.1), G5 784.05 (+0.1), A#5 932.32 (-0.0) and C6 1047.14 (+1.1) -- concert pitch, and every one of them a member of the ROM's own eight-note scale.  The 4 MHz build measures 14 to 17 cents sharp of that grid.

The octave above, 5 MHz = OCLK/4, fits the note table just as well, since it is the same pitch set read one block lower and pitch alone cannot separate a clock from its octave.  It is ruled out on the part instead: the YM3812's rated phi-M ceiling is 4 MHz.

Affects bikerace, bikerac2, bikerac3 (SLEIC3) and sleicpin (SLEIC1), which share the interface and the board.  Tempo is unchanged -- the FM sequencer is IRQ-paced, not clock-paced.  Io Moon has its own IOMOON_YM3812_CLOCK and is untouched here.