### PR TITLE
recel: add Mr. Evil (1978) and Mr. Doom (1979)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ and listen to/record the pinball game sounds with the pure PinMAME package itsel
 - *Juegos Populares* - Petaco (1984), Faeton (1985), America 1492, Aqualand (both 1987)
 - *LTD* - Atlantis, Black Hole, Zephy, Cowboy Eight Ball, Mr. & Mrs. Pec-Men, Al Capone (1980-1983)
 - *Peyper* - Odisea Paris-Dakar (1987)
-- *Recel* - Fair Fight (1978)
+- *Recel* - Fair Fight, Mr. Evil (both 1978), Mr. Doom (1979)
 - *Recreativos Franco* - Super Star (1986)
 - *Sonic* - Odin DeLuxe (1985), Pole Position (1987), Star Wars (1987)
 - *Allied Leisure* - All games from Super Picker (1977) to Star Shooter (1979)

--- a/release/whatsnew.txt
+++ b/release/whatsnew.txt
@@ -32,7 +32,7 @@ Get rid of BASS external dependency (used for internal AltSound mode 1 support) 
 *** CORE/CPU ***
 Added Pinball 2000 emulation. It works in principle, but the CPU is clocked way too low (0.33x) for performance reasons (for now)! Still, it seems to work reasonably well, most likely as the graphics/video part is not emulated cycle-accurate and thus much faster than the clock rate implies.
 Added Recreativos Franco emulation (Super Star), including improved i8085 emulation
-Added Recel System III emulation (Fair Fight)
+Added Recel System III emulation (Fair Fight, Mr. Evil, Mr. Doom)
 Fixed and extended Sleic emulation (Bike Race, Io Moon, Pin-Ball), including some i86 fixes
 Fixed and extended Cirsa Sport 2000, including more i86 fixes and i8256 emulation
 Fixed and extended Stargame Mephisto, dto.

--- a/src/wpc/driver.c
+++ b/src/wpc/driver.c
@@ -1014,6 +1014,8 @@ DRIVERNV(metalman)      //Metal Man (1992)
 // ----------------
 DRIVERNV(recel)         //System III (not a game)
 DRIVERNV(r_fairfght)    //Fair Fight (1978)
+DRIVERNV(r_mrevil)      //Mr. Evil (1978)
+DRIVERNV(r_mrdoom)      //Mr. Doom (1979)
                         //Hot & Cold (1978)
                         //Screech (1978)
 

--- a/src/wpc/recelgames.c
+++ b/src/wpc/recelgames.c
@@ -58,3 +58,20 @@ INIT_RECEL(r_fairfght, recel_disp, 1)
 RECEL_ROMSTART(r_fairfght, "fa.c5", 0x0100, CRC(5d3694da) SHA1(4d0a8033acb6ef2e2af107f76540fd19b4a39b12))
 RECEL_ROMEND
 CORE_CLONEDEFNV(r_fairfght,recel,"Fair Fight",1978,"Recel",gl_mRECEL,0)
+
+/*-------------------------------------------------------------------
+/ Mr. Evil (1978) - model 1.055, doc 035-626
+/-------------------------------------------------------------------*/
+INIT_RECEL(r_mrevil, recel_disp, 1)
+RECEL_ROMSTART(r_mrevil, "me.c5", 0x0100, CRC(53ce24a0) SHA1(42d376e3e7a4e94a09db2f974af8d4869579d0f5))
+RECEL_ROMEND
+CORE_CLONEDEFNV(r_mrevil,recel,"Mr. Evil",1978,"Recel",gl_mRECEL,0)
+
+/*-------------------------------------------------------------------
+/ Mr. Doom (1979) - model 1.060, doc 035-635. Mr. Evil re-themed: same
+/ switch matrix and driver table, different ROM and rules.
+/-------------------------------------------------------------------*/
+INIT_RECEL(r_mrdoom, recel_disp, 1)
+RECEL_ROMSTART(r_mrdoom, "md.c5", 0x0100, CRC(ca679a69) SHA1(f08f0cfe646f08882473dcd5d23889fffe4a03c8))
+RECEL_ROMEND
+CORE_CLONEDEFNV(r_mrdoom,recel,"Mr. Doom",1979,"Recel",gl_mRECEL,0)


### PR DESCRIPTION
Both run on the same System III board as Fair Fight and share a playfield: Mr. Doom is a 1979 re-theme of Mr. Evil with the same 29-switch matrix and the same nine driver outputs, so they need no code beyond a ROM and a table entry. Verified against service docs 035-626 and 035-634/635: self-check, coining, a full game, the printed point values, and the drop-target bank rules (bank reset lights the 50,000/extra-ball award, second reset doubles bonus) all match.

The display layout is Fair Fight's -- four six-digit player counters plus the credit/ball/match digits -- because the 10788 GPKD wiring is a System III board feature, not a per-game one.